### PR TITLE
feat: Implement enhanced NPC memory and Observation/Persuasion skills

### DIFF
--- a/game_config.py
+++ b/game_config.py
@@ -154,7 +154,8 @@ COMMAND_SYNONYMS = {
     "help": ["commands", "actions"],
     "save": ["save game"],
     "load": ["load game"],
-    "quit": ["exit", "q"]
+    "quit": ["exit", "q"],
+    "persuade": ["convince", "argue with"] # New command
 }
 
 # --- Player States (for NPC reactions) ---


### PR DESCRIPTION
This commit introduces several enhancements to gameplay depth:

1.  **Enhanced NPC Memory:**
    - NPCs now store structured memories of your interactions, including items exchanged, significant actions observed (e.g., you examining a key item), and the sentiment of dialogue exchanges.
    - The summary of these memories provided to the AI for dialogue generation is richer, allowing NPCs to recall and react to past events more specifically.

2.  **Observation Skill Integration:**
    - Your characters can now utilize an "Observation" skill.
    - When using the "look at" command on NPCs, items, or scenery, a successful skill check (based on skill level + d6 roll vs. difficulty) will provide additional, more insightful descriptive details.

3.  **Persuasion Skill Integration:**
    - A new "persuade [NPC] that/to [statement]" command has been added.
    - This triggers a "Persuasion" skill check for you.
    - The NPC's response will reflect whether they are swayed or resistant based on the skill check's success or failure.
    - NPCs remember persuasion attempts, and outcomes can influence your relationships with them.

4.  **Supporting Changes:**
    - Added a `check_skill(skill_name, difficulty_threshold)` method to the Character class.
    - Updated `CHARACTERS_DATA` to include "Observation" and "Persuasion" skill values for key characters.
    - Modified relevant interaction methods and prompts to support these new features.