### PR TITLE
Safer Gemini fallback, item/NPC matching refactor, and debug gating

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -20,7 +20,7 @@
         "takeable": true, "readable": true,
         "use_effect_player": "read_newspaper_for_news_or_thoughts"
     },
-    "Fresh Newspaper": {
+    "fresh newspaper": {
         "description": "A recently printed newspaper, still smelling faintly of ink. The headlines might offer insights into current events or the city's mood.",
         "takeable": true, "readable": true, "value": 2,
         "use_effect_player": "read_evolving_news_article"

--- a/game_engine/character_module.py
+++ b/game_engine/character_module.py
@@ -3,6 +3,7 @@ import random
 import copy
 import logging
 import json
+from .game_config import DEBUG_LOGS
 
 def load_characters_data(data_path='data/characters.json'):
     """Loads character data from a JSON file."""
@@ -519,7 +520,8 @@ class Character:
                 else:
                     # Player memories are simple strings
                     self.memory_about_player.append(f"Objective '{obj_desc}' concluded with stage '{stage_desc_for_memory}'.")
-                print(f"[DEBUG] Player {self.name} completed objective: {obj_desc} (Stage: {stage_desc_for_memory if by_stage else 'N/A'})")
+                    if DEBUG_LOGS:
+                        print(f"[DEBUG] Player {self.name} completed objective: {obj_desc} (Stage: {stage_desc_for_memory if by_stage else 'N/A'})")
 
             link_info = None
             current_stage = self.get_current_stage_for_objective(objective_id)
@@ -543,41 +545,49 @@ class Character:
                     if target_objective:
                         target_obj_desc = target_objective.get('description', 'Unnamed Linked Objective')
                         if not target_objective.get("active", False) and not target_objective.get("completed", False) :
-                            print(f"[DEBUG] Linking: Activating objective '{target_obj_desc}' due to completion of '{obj_desc}'.")
+                            if DEBUG_LOGS:
+                                print(f"[DEBUG] Linking: Activating objective '{target_obj_desc}' due to completion of '{obj_desc}'.")
                             self.activate_objective(target_objective_id) 
                             if specific_next_stage_id and target_objective.get("current_stage_id") != specific_next_stage_id :
-                                print(f"[DEBUG] Linking: Advancing newly activated objective '{target_obj_desc}' to specific stage '{specific_next_stage_id}'.")
+                                if DEBUG_LOGS:
+                                    print(f"[DEBUG] Linking: Advancing newly activated objective '{target_obj_desc}' to specific stage '{specific_next_stage_id}'.")
                                 self.advance_objective_stage(target_objective_id, specific_next_stage_id)
                             if self.is_player: # Player memories are simple strings
                                 self.memory_about_player.append(f"Completing '{obj_desc}' has opened up new paths regarding '{target_obj_desc}'.")
                         
                         elif target_objective.get("active", False) and not target_objective.get("completed", False):
                             if specific_next_stage_id:
-                                print(f"[DEBUG] Linking: Advancing active objective '{target_obj_desc}' to specific stage '{specific_next_stage_id}' due to '{obj_desc}'.")
+                                if DEBUG_LOGS:
+                                    print(f"[DEBUG] Linking: Advancing active objective '{target_obj_desc}' to specific stage '{specific_next_stage_id}' due to '{obj_desc}'.")
                                 if self.advance_objective_stage(target_objective_id, specific_next_stage_id):
                                      if self.is_player: # Player memories are simple strings
                                         self.memory_about_player.append(f"Progress on '{obj_desc}' has further developed your understanding of '{target_obj_desc}'.")
-                                else: print(f"[DEBUG] Linking: Failed to advance '{target_obj_desc}' to stage '{specific_next_stage_id}'.")
+                                elif DEBUG_LOGS:
+                                    print(f"[DEBUG] Linking: Failed to advance '{target_obj_desc}' to stage '{specific_next_stage_id}'.")
                             else:
                                 current_target_stage = self.get_current_stage_for_objective(target_objective_id)
                                 if current_target_stage and current_target_stage.get("next_stages"):
                                     potential_next_ids = current_target_stage["next_stages"]
                                     if isinstance(potential_next_ids, dict) and potential_next_ids:
                                         auto_next_stage_id = next(iter(potential_next_ids.values()))
-                                        print(f"[DEBUG] Linking: Attempting generic advance for active objective '{target_obj_desc}' to its next stage '{auto_next_stage_id}' due to '{obj_desc}'.")
+                                        if DEBUG_LOGS:
+                                            print(f"[DEBUG] Linking: Attempting generic advance for active objective '{target_obj_desc}' to its next stage '{auto_next_stage_id}' due to '{obj_desc}'.")
                                         if self.advance_objective_stage(target_objective_id, auto_next_stage_id):
                                             if self.is_player: # Player memories are simple strings
                                                 self.memory_about_player.append(f"Progress on '{obj_desc}' has influenced your approach to '{target_obj_desc}'.")
                                     elif isinstance(potential_next_ids, list) and potential_next_ids:
                                          auto_next_stage_id = potential_next_ids[0]
-                                         print(f"[DEBUG] Linking: Attempting generic advance for active objective '{target_obj_desc}' to its next stage '{auto_next_stage_id}' due to '{obj_desc}'.")
+                                         if DEBUG_LOGS:
+                                             print(f"[DEBUG] Linking: Attempting generic advance for active objective '{target_obj_desc}' to its next stage '{auto_next_stage_id}' due to '{obj_desc}'.")
                                          if self.advance_objective_stage(target_objective_id, auto_next_stage_id):
                                             if self.is_player: # Player memories are simple strings
                                                 self.memory_about_player.append(f"Progress on '{obj_desc}' has influenced your approach to '{target_obj_desc}'.")
                                     else:
-                                        print(f"[DEBUG] Linking: Objective '{target_obj_desc}' is active, but current stage has no defined 'next_stages' for generic advance.")
+                                        if DEBUG_LOGS:
+                                            print(f"[DEBUG] Linking: Objective '{target_obj_desc}' is active, but current stage has no defined 'next_stages' for generic advance.")
                                 else:
-                                    print(f"[DEBUG] Linking: Objective '{target_obj_desc}' is active, but current stage or its 'next_stages' are not clearly defined for generic advance.")
+                                    if DEBUG_LOGS:
+                                        print(f"[DEBUG] Linking: Objective '{target_obj_desc}' is active, but current stage or its 'next_stages' are not clearly defined for generic advance.")
             return True
         return False
 
@@ -592,7 +602,8 @@ class Character:
                 if any(s.get("stage_id") == set_stage_id for s in obj.get("stages", [])):
                     initial_stage_id_to_set = set_stage_id
                 else:
-                    print(f"[DEBUG] Warning: Requested stage_id '{set_stage_id}' for activating objective '{objective_id}' not found. Defaulting to first stage.")
+                    if DEBUG_LOGS:
+                        print(f"[DEBUG] Warning: Requested stage_id '{set_stage_id}' for activating objective '{objective_id}' not found. Defaulting to first stage.")
 
             if not initial_stage_id_to_set: 
                 if obj.get("stages") and obj["stages"][0].get("stage_id"):
@@ -608,7 +619,8 @@ class Character:
             current_stage_desc = self.get_current_stage_for_objective(objective_id).get('description', 'initial stage')
             if self.is_player: # Player memories are simple strings
                 self.memory_about_player.append(f"New objective active or re-activated: '{obj.get('description', 'Unnamed Objective')}' (Current stage: '{current_stage_desc}').")
-            print(f"[DEBUG] Player {self.name} activated objective: {obj.get('description')} - now at stage '{current_stage_desc}'")
+            if DEBUG_LOGS:
+                print(f"[DEBUG] Player {self.name} activated objective: {obj.get('description')} - now at stage '{current_stage_desc}'")
             return True
         return False
 

--- a/game_engine/event_manager.py
+++ b/game_engine/event_manager.py
@@ -1,6 +1,6 @@
 # event_manager.py
 import random
-from .game_config import (Colors, DEFAULT_ITEMS,
+from .game_config import (Colors, DEFAULT_ITEMS, DEBUG_LOGS,
                          STATIC_PLAYER_REFLECTIONS, STATIC_ANONYMOUS_NOTE_CONTENT,
                          STATIC_STREET_LIFE_EVENTS, STATIC_NPC_NPC_INTERACTIONS)
 
@@ -250,7 +250,8 @@ class EventManager:
 
     def check_and_trigger_events(self):
         if self.game.game_time % 50 == 0: # Cooldown reset periodically
-            print(f"[DEBUG] EventManager: Checking event cooldowns at game time {self.game.game_time}")
+            if DEBUG_LOGS:
+                print(f"[DEBUG] EventManager: Checking event cooldowns at game time {self.game.game_time}")
             events_to_remove = {ev for ev in self.triggered_events if ev.endswith("_recent")}
             for ev_rem in events_to_remove: self.triggered_events.remove(ev_rem)
 

--- a/game_engine/game_config.py
+++ b/game_engine/game_config.py
@@ -25,6 +25,7 @@ DREAM_CHANCE_TROUBLED_STATE = 0.35 # Chance if feverish, agitated etc. on new da
 RUMOR_CHANCE_PER_NPC_INTERACTION = 0.15 # Chance an NPC shares a rumor during dialogue
 AMBIENT_RUMOR_CHANCE_PUBLIC_PLACE = 0.05 # Chance to overhear ambient rumor in public
 NPC_SHARE_RUMOR_MIN_RELATIONSHIP = -2 # NPC won't share rumors if relationship is too low
+DEBUG_LOGS = False
 
 # --- Phrases that might indicate a natural end to a conversation ---
 CONCLUDING_PHRASES = [

--- a/game_engine/game_state.py
+++ b/game_engine/game_state.py
@@ -19,6 +19,7 @@ from .game_config import (Colors, SAVE_GAME_FILE, # API_CONFIG_FILE, GEMINI_MODE
                          STATIC_PLAYER_REFLECTIONS, STATIC_ENHANCED_OBSERVATIONS,      # Added
                          STATIC_NEWSPAPER_SNIPPETS, STATIC_DREAM_SEQUENCES,            # Added
                          generate_static_item_interaction_description, STATIC_RUMORS)  # Added
+from .game_config import DEBUG_LOGS
 from .character_module import Character, CHARACTERS_DATA
 from .location_module import LOCATIONS_DATA
 from .gemini_interactions import GeminiAPI
@@ -94,6 +95,134 @@ class Game:
 
     def _input_color(self, prompt_text, color_code):
         return input(f"{color_code}{prompt_text}{Colors.RESET}")
+
+    def _resolve_prefix_match(self, target, options, label):
+        target = target.lower()
+        matches = [option for option in options if option.lower().startswith(target)]
+        if not matches:
+            return None, False
+        if len(matches) > 1:
+            self._print_color(f"Which {label} did you mean? {', '.join(matches)}", Colors.YELLOW)
+            return None, True
+        return matches[0], False
+
+    def _get_matching_location_item(self, target):
+        location_items = self.dynamic_location_items.get(self.current_location_name, [])
+        options = [item_info["name"] for item_info in location_items]
+        match, ambiguous = self._resolve_prefix_match(target, options, "item")
+        if ambiguous or not match:
+            return None, ambiguous
+        return next((item_info for item_info in location_items if item_info["name"] == match), None), False
+
+    def _get_matching_inventory_item(self, target):
+        if not self.player_character:
+            return None, False
+        options = [item_info["name"] for item_info in self.player_character.inventory]
+        match, ambiguous = self._resolve_prefix_match(target, options, "item")
+        if ambiguous or not match:
+            return None, ambiguous
+        return next((item_info for item_info in self.player_character.inventory if item_info["name"] == match), None), False
+
+    def _get_matching_npc(self, target):
+        options = [npc.name for npc in self.npcs_in_current_location]
+        match, ambiguous = self._resolve_prefix_match(target, options, "person")
+        if ambiguous or not match:
+            return None, ambiguous
+        return next((npc for npc in self.npcs_in_current_location if npc.name == match), None), False
+
+    def _display_item_properties(self, item_default):
+        properties_to_display = []
+        if item_default.get('readable', False): properties_to_display.append(f"Type: Readable")
+        if item_default.get('consumable', False): properties_to_display.append(f"Type: Consumable")
+        if item_default.get('value') is not None: properties_to_display.append(f"Value: {item_default['value']} kopeks")
+        if item_default.get('is_notable', False): properties_to_display.append(f"Trait: Notable")
+        if item_default.get('stackable', False): properties_to_display.append(f"Trait: Stackable")
+        if item_default.get('owner'): properties_to_display.append(f"Belongs to: {item_default['owner']}")
+        if item_default.get('use_effect_player'): properties_to_display.append(f"Action: Can be 'used'")
+        if properties_to_display:
+            self._print_color("--- Properties ---", Colors.BLUE + Colors.BOLD)
+            for prop_str in properties_to_display: self._print_color(f"- {prop_str}", Colors.BLUE)
+            self._print_color("", Colors.RESET)
+
+    def _inspect_item(self, item_name, item_default, action_context, observation_context, allow_npc_memory):
+        self._print_color(f"You examine the {item_name}:", Colors.GREEN)
+        gen_desc = None
+        base_desc_for_skill_check = item_default.get('description', "An ordinary item.")
+
+        if not self.low_ai_data_mode and self.gemini_api.model:
+            gen_desc = self.gemini_api.get_item_interaction_description(
+                self.player_character, item_name, item_default, action_context,
+                self.current_location_name, self.get_current_time_period()
+            )
+
+        if gen_desc is not None and not (isinstance(gen_desc, str) and gen_desc.startswith("(OOC:")) and not self.low_ai_data_mode:
+            self._print_color(f"\"{gen_desc}\"", Colors.GREEN)
+            base_desc_for_skill_check = gen_desc
+        else:
+            if self.low_ai_data_mode or gen_desc is None or (isinstance(gen_desc, str) and gen_desc.startswith("(OOC:")):
+                gen_desc = generate_static_item_interaction_description(item_name, "examine")
+                self._print_color(f"\"{gen_desc}\"", Colors.CYAN)
+            else:
+                self._print_color(f"({base_desc_for_skill_check})", Colors.DIM)
+
+        self._display_item_properties(item_default)
+
+        if self.player_character.check_skill("Observation", 1):
+            self._print_color("(Your keen eye picks up on finer details...)", Colors.CYAN + Colors.DIM)
+            detailed_observation = None
+            if not self.low_ai_data_mode and self.gemini_api.model:
+                detailed_observation = self.gemini_api.get_enhanced_observation(
+                    self.player_character,
+                    target_name=item_name,
+                    target_category="item",
+                    base_description=base_desc_for_skill_check,
+                    skill_check_context=observation_context
+                )
+
+            if detailed_observation is None or (isinstance(detailed_observation, str) and detailed_observation.startswith("(OOC:")) or self.low_ai_data_mode:
+                if STATIC_ENHANCED_OBSERVATIONS:
+                    detailed_observation = random.choice(STATIC_ENHANCED_OBSERVATIONS)
+                else:
+                    detailed_observation = "You notice a few more mundane details, but nothing striking."
+                if detailed_observation:
+                    self._print_color(f"Detail: \"{detailed_observation}\"", Colors.CYAN)
+            elif detailed_observation:
+                self._print_color(f"Detail: \"{detailed_observation}\"", Colors.GREEN)
+
+        if allow_npc_memory and item_name in HIGHLY_NOTABLE_ITEMS_FOR_MEMORY:
+            for npc_observer in self.npcs_in_current_location:
+                if npc_observer.name != self.player_character.name:
+                    sentiment_impact = -2 if item_name in ["Raskolnikov's axe", "bloodied rag"] else -1
+                    npc_observer.add_player_memory(
+                        memory_type="player_action_observed",
+                        turn=self.game_time,
+                        content={"action": "examined_item", "item_name": item_name, "location": self.current_location_name},
+                        sentiment_impact=sentiment_impact
+                    )
+
+    def _validate_item_data(self):
+        missing_items = set()
+        for location_name, location_data in LOCATIONS_DATA.items():
+            for item_info in location_data.get("items_present", []):
+                item_name = item_info.get("name")
+                if item_name and item_name not in DEFAULT_ITEMS:
+                    missing_items.add(f"Location '{location_name}' references unknown item '{item_name}'.")
+
+        for character_name, character_data in CHARACTERS_DATA.items():
+            for item_info in character_data.get("inventory_items", []):
+                item_name = item_info.get("name")
+                if item_name and item_name not in DEFAULT_ITEMS:
+                    missing_items.add(f"Character '{character_name}' references unknown item '{item_name}'.")
+
+        for item_name in HIGHLY_NOTABLE_ITEMS_FOR_MEMORY:
+            if item_name not in DEFAULT_ITEMS:
+                missing_items.add(f"Notable items list references unknown item '{item_name}'.")
+
+        if missing_items:
+            self._print_color("Warning: Item data inconsistencies detected:", Colors.YELLOW)
+            for message in sorted(missing_items):
+                self._print_color(f"- {message}", Colors.YELLOW)
+            self._print_color("", Colors.RESET)
 
     def get_current_time_period(self):
         time_in_day = self.game_time % MAX_TIME_UNITS_PER_DAY
@@ -425,8 +554,11 @@ class Game:
         if not self.player_character: self._print_color("Cannot use items: Player character not set.", Colors.RED); return False
         item_to_use_name = None
         if item_name_input:
-            for inv_item_obj in self.player_character.inventory:
-                if inv_item_obj["name"].lower().startswith(item_name_input.lower()): item_to_use_name = inv_item_obj["name"]; break
+            item_in_inventory, ambiguous = self._get_matching_inventory_item(item_name_input.lower())
+            if ambiguous:
+                return False
+            if item_in_inventory:
+                item_to_use_name = item_in_inventory["name"]
             if not item_to_use_name:
                 if self.player_character.has_item(item_name_input): item_to_use_name = item_name_input
                 else: self._print_color(f"You don't have '{item_name_input}' to {interaction_type.replace('_', ' ')}.", Colors.RED); return False
@@ -470,6 +602,7 @@ class Game:
         # No need for an additional print here unless desired for game-level confirmation.
 
         self._print_color("\n--- Crime and Punishment: A Text Adventure ---", Colors.CYAN + Colors.BOLD)
+        self._validate_item_data()
 
         game_loaded_successfully = False
         # Non-interactive mode: Automatically start a new game if GEMINI_API_KEY is set
@@ -718,174 +851,101 @@ class Game:
             if self._check_game_ending_conditions(): break
 
     def _handle_look_at_location_item(self, target_to_look_at):
-        for item_info in self.dynamic_location_items.get(self.current_location_name, []):
-            if item_info["name"].lower().startswith(target_to_look_at):
-                item_default = DEFAULT_ITEMS.get(item_info["name"]); base_desc_for_skill_check = "An ordinary item."
-                if item_default:
-                    self._print_color(f"You examine the {item_info['name']}:", Colors.GREEN)
-                    gen_desc = None
-                    base_desc_for_skill_check = item_default.get('description', "An ordinary item.") # Initialize base_desc
-
-                    if not self.low_ai_data_mode and self.gemini_api.model:
-                        gen_desc = self.gemini_api.get_item_interaction_description(self.player_character, item_info['name'], item_default, "examine closely in environment", self.current_location_name, self.get_current_time_period())
-
-                    if gen_desc is not None and not (isinstance(gen_desc, str) and gen_desc.startswith("(OOC:")) and not self.low_ai_data_mode:
-                        # AI success
-                        self._print_color(f"\"{gen_desc}\"", Colors.GREEN)
-                        base_desc_for_skill_check = gen_desc # Use AI desc for skill check base
-                    else:
-                        # Fallback or AI failed/OOC or low_ai_mode
-                        if self.low_ai_data_mode or gen_desc is None or (isinstance(gen_desc, str) and gen_desc.startswith("(OOC:")) :
-                            gen_desc = generate_static_item_interaction_description(item_info['name'], "examine")
-                            # base_desc_for_skill_check remains item_default.get('description', ...) from initialization
-                            self._print_color(f"\"{gen_desc}\"", Colors.CYAN)
-                        else: # Should not be reached if logic is correct, but as a safeguard
-                            self._print_color(f"({base_desc_for_skill_check})", Colors.DIM)
-
-                    properties_to_display = []
-                    if item_default.get('readable', False): properties_to_display.append(f"Type: Readable")
-                    if item_default.get('consumable', False): properties_to_display.append(f"Type: Consumable")
-                    if item_default.get('value') is not None: properties_to_display.append(f"Value: {item_default['value']} kopeks")
-                    if item_default.get('is_notable', False): properties_to_display.append(f"Trait: Notable")
-                    if item_default.get('stackable', False): properties_to_display.append(f"Trait: Stackable")
-                    if item_default.get('owner'): properties_to_display.append(f"Belongs to: {item_default['owner']}")
-                    if item_default.get('use_effect_player'): properties_to_display.append(f"Action: Can be 'used'")
-                    if properties_to_display:
-                        self._print_color("--- Properties ---", Colors.BLUE + Colors.BOLD)
-                        for prop_str in properties_to_display: self._print_color(f"- {prop_str}", Colors.BLUE)
-                        self._print_color("", Colors.RESET)
-                    if self.player_character.check_skill("Observation", 1):
-                        self._print_color("(Your keen eye picks up on finer details...)", Colors.CYAN + Colors.DIM)
-                        observation_context = f"Player ({self.player_character.name}) succeeded an Observation skill check examining the {item_info['name']} in {self.current_location_name}. What subtle detail, past use, hidden inscription, or unusual characteristic do they notice that isn't immediately obvious?"
-                        detailed_observation = None
-                        if not self.low_ai_data_mode and self.gemini_api.model:
-                            detailed_observation = self.gemini_api.get_enhanced_observation(self.player_character, target_name=item_info['name'], target_category="item", base_description=base_desc_for_skill_check, skill_check_context=observation_context)
-
-                        if detailed_observation is None or (isinstance(detailed_observation, str) and detailed_observation.startswith("(OOC:")) or self.low_ai_data_mode:
-                            if STATIC_ENHANCED_OBSERVATIONS:
-                                detailed_observation = random.choice(STATIC_ENHANCED_OBSERVATIONS)
-                            else:
-                                detailed_observation = "You notice a few more mundane details, but nothing striking."
-                            if detailed_observation:
-                                 self._print_color(f"Detail: \"{detailed_observation}\"", Colors.CYAN)
-                        elif detailed_observation:
-                            self._print_color(f"Detail: \"{detailed_observation}\"", Colors.GREEN)
-
-                        if item_info["name"] in HIGHLY_NOTABLE_ITEMS_FOR_MEMORY:
-                            for npc_observer in self.npcs_in_current_location:
-                                if npc_observer.name != self.player_character.name:
-                                    sentiment_impact = -2 if item_info["name"] in ["Raskolnikov's axe", "bloodied rag"] else -1
-                                    npc_observer.add_player_memory(memory_type="player_action_observed", turn=self.game_time, content={"action": f"examined_item_in_location", "item_name": item_info["name"], "location": self.current_location_name}, sentiment_impact=sentiment_impact)
-                    return True
+        item_info, ambiguous = self._get_matching_location_item(target_to_look_at)
+        if ambiguous:
+            return True
+        if item_info:
+            item_default = DEFAULT_ITEMS.get(item_info["name"])
+            if item_default:
+                observation_context = (
+                    f"Player ({self.player_character.name}) succeeded an Observation skill check examining the "
+                    f"{item_info['name']} in {self.current_location_name}. What subtle detail, past use, hidden "
+                    f"inscription, or unusual characteristic do they notice that isn't immediately obvious?"
+                )
+                self._inspect_item(
+                    item_info["name"],
+                    item_default,
+                    "examine closely in environment",
+                    observation_context,
+                    allow_npc_memory=True
+                )
+                return True
         return False
 
     def _handle_look_at_inventory_item(self, target_to_look_at):
         if self.player_character:
-            for inv_item_info in self.player_character.inventory:
-                if inv_item_info["name"].lower().startswith(target_to_look_at):
-                    item_default = DEFAULT_ITEMS.get(inv_item_info["name"]); base_desc_for_skill_check = "An ordinary item."
-                    if item_default:
-                        self._print_color(f"You examine your {inv_item_info['name']}:", Colors.GREEN)
-                        gen_desc = None
-                        base_desc_for_skill_check = item_default.get('description', "An ordinary item.") # Initialize base_desc
-
-                        if not self.low_ai_data_mode and self.gemini_api.model:
-                            gen_desc = self.gemini_api.get_item_interaction_description(self.player_character, inv_item_info['name'], item_default, "examine closely from inventory", self.current_location_name, self.get_current_time_period())
-
-                        if gen_desc is not None and not (isinstance(gen_desc, str) and gen_desc.startswith("(OOC:")) and not self.low_ai_data_mode:
-                            # AI success
-                            self._print_color(f"\"{gen_desc}\"", Colors.GREEN)
-                            base_desc_for_skill_check = gen_desc # Use AI desc for skill check base
-                        else:
-                            # Fallback or AI failed/OOC or low_ai_mode
-                            if self.low_ai_data_mode or gen_desc is None or (isinstance(gen_desc, str) and gen_desc.startswith("(OOC:")) :
-                                gen_desc = generate_static_item_interaction_description(inv_item_info['name'], "examine")
-                                self._print_color(f"\"{gen_desc}\"", Colors.CYAN)
-                            else: # Should not be reached
-                                self._print_color(f"({base_desc_for_skill_check})", Colors.DIM)
-                        properties_to_display = []
-                        if item_default.get('readable', False): properties_to_display.append(f"Type: Readable")
-                        if item_default.get('consumable', False): properties_to_display.append(f"Type: Consumable")
-                        if item_default.get('value') is not None: properties_to_display.append(f"Value: {item_default['value']} kopeks")
-                        if item_default.get('is_notable', False): properties_to_display.append(f"Trait: Notable")
-                        if item_default.get('stackable', False): properties_to_display.append(f"Trait: Stackable")
-                        if item_default.get('owner'): properties_to_display.append(f"Belongs to: {item_default['owner']}")
-                        if item_default.get('use_effect_player'): properties_to_display.append(f"Action: Can be 'used'")
-                        if properties_to_display:
-                            self._print_color("--- Properties ---", Colors.BLUE + Colors.BOLD)
-                            for prop_str in properties_to_display: self._print_color(f"- {prop_str}", Colors.BLUE)
-                            self._print_color("", Colors.RESET)
-                            if self.player_character.check_skill("Observation", 1):
-                                self._print_color("(Your keen eye picks up on finer details...)", Colors.CYAN + Colors.DIM)
-                                observation_context = f"Player ({self.player_character.name}) succeeded an Observation skill check examining their {inv_item_info['name']}. What subtle detail, past use, hidden inscription, or unusual characteristic do they notice that isn't immediately obvious?"
-                                detailed_observation = None
-                                if not self.low_ai_data_mode and self.gemini_api.model:
-                                    detailed_observation = self.gemini_api.get_enhanced_observation(self.player_character, target_name=inv_item_info['name'], target_category="item", base_description=base_desc_for_skill_check, skill_check_context=observation_context)
-
-                                if detailed_observation is None or (isinstance(detailed_observation, str) and detailed_observation.startswith("(OOC:")) or self.low_ai_data_mode:
-                                    if STATIC_ENHANCED_OBSERVATIONS:
-                                        detailed_observation = random.choice(STATIC_ENHANCED_OBSERVATIONS)
-                                    else:
-                                        detailed_observation = "You notice a few more mundane details, but nothing striking."
-                                    if detailed_observation: # Check if not None from random.choice
-                                        self._print_color(f"Detail: \"{detailed_observation}\"", Colors.CYAN)
-                                elif detailed_observation: # AI success and not OOC
-                                    self._print_color(f"Detail: \"{detailed_observation}\"", Colors.GREEN)
-                                # If detailed_observation is still None, nothing specific is printed.
-
-                            if inv_item_info["name"] in HIGHLY_NOTABLE_ITEMS_FOR_MEMORY:
-                                for npc_observer in self.npcs_in_current_location:
-                                    if npc_observer.name != self.player_character.name:
-                                        sentiment_impact = -2 if inv_item_info["name"] in ["Raskolnikov's axe", "bloodied rag"] else -1
-                                        npc_observer.add_player_memory(memory_type="player_action_observed", turn=self.game_time, content={"action": f"examined_item_from_inventory", "item_name": inv_item_info["name"], "location": self.current_location_name}, sentiment_impact=sentiment_impact)
-                        return True
+            inv_item_info, ambiguous = self._get_matching_inventory_item(target_to_look_at)
+            if ambiguous:
+                return True
+            if inv_item_info:
+                item_default = DEFAULT_ITEMS.get(inv_item_info["name"])
+                if item_default:
+                    observation_context = (
+                        f"Player ({self.player_character.name}) succeeded an Observation skill check examining their "
+                        f"{inv_item_info['name']}. What subtle detail, past use, hidden inscription, or unusual "
+                        f"characteristic do they notice that isn't immediately obvious?"
+                    )
+                    self._inspect_item(
+                        inv_item_info["name"],
+                        item_default,
+                        "examine closely from inventory",
+                        observation_context,
+                        allow_npc_memory=True
+                    )
+                    return True
         return False
 
     def _handle_look_at_npc(self, target_to_look_at):
-        for npc in self.npcs_in_current_location:
-            if npc.name.lower().startswith(target_to_look_at):
-                self._print_color(f"You look closely at {Colors.YELLOW}{npc.name}{Colors.RESET} (appears {npc.apparent_state}):", Colors.WHITE)
-                base_desc_for_skill_check = npc.persona[:100] if npc.persona else f"{npc.name} is present." # Initialize base_desc
-                observation = None
+        npc, ambiguous = self._get_matching_npc(target_to_look_at)
+        if ambiguous:
+            return True
+        if npc:
+            self._print_color(f"You look closely at {Colors.YELLOW}{npc.name}{Colors.RESET} (appears {npc.apparent_state}):", Colors.WHITE)
+            base_desc_for_skill_check = npc.persona[:100] if npc.persona else f"{npc.name} is present." # Initialize base_desc
+            observation = None
 
-                if not self.low_ai_data_mode and self.gemini_api.model:
-                    observation_prompt = f"observing {npc.name} in {self.current_location_name}. They appear to be '{npc.apparent_state}'. You recall: {npc.get_player_memory_summary(self.game_time)}"
-                    observation = self.gemini_api.get_player_reflection(self.player_character, self.current_location_name, self.get_current_time_period(), observation_prompt, self.player_character.get_inventory_description(), self._get_objectives_summary(self.player_character))
+            if not self.low_ai_data_mode and self.gemini_api.model:
+                observation_prompt = f"observing {npc.name} in {self.current_location_name}. They appear to be '{npc.apparent_state}'. You recall: {npc.get_player_memory_summary(self.game_time)}"
+                observation = self.gemini_api.get_player_reflection(self.player_character, self.current_location_name, self.get_current_time_period(), observation_prompt, self.player_character.get_inventory_description(), self._get_objectives_summary(self.player_character))
 
-                if observation is not None and not (isinstance(observation, str) and observation.startswith("(OOC:")) and not self.low_ai_data_mode:
-                    # AI success
-                    self._print_color(f"\"{observation}\"", Colors.GREEN)
-                    base_desc_for_skill_check = observation # Use AI desc for skill check base
+            if observation is not None and not (isinstance(observation, str) and observation.startswith("(OOC:")) and not self.low_ai_data_mode:
+                self._print_color(f"\"{observation}\"", Colors.GREEN)
+                base_desc_for_skill_check = observation
+            else:
+                if self.low_ai_data_mode or observation is None or (isinstance(observation, str) and observation.startswith("(OOC:")) :
+                    if STATIC_PLAYER_REFLECTIONS:
+                        observation = f"{npc.name} is here. {random.choice(STATIC_PLAYER_REFLECTIONS)}"
+                    else:
+                        observation = f"You observe {npc.name}. They seem to be going about their business."
+                    self._print_color(f"\"{observation}\"", Colors.CYAN)
                 else:
-                    # Fallback or AI failed/OOC or low_ai_mode
-                    if self.low_ai_data_mode or observation is None or (isinstance(observation, str) and observation.startswith("(OOC:")) :
-                        if STATIC_PLAYER_REFLECTIONS: # Using general player reflections as a fallback for observing an NPC
-                            observation = f"{npc.name} is here. {random.choice(STATIC_PLAYER_REFLECTIONS)}"
-                        else:
-                            observation = f"You observe {npc.name}. They seem to be going about their business."
-                        self._print_color(f"\"{observation}\"", Colors.CYAN)
-                        # base_desc_for_skill_check remains npc.persona[:100]
-                    else: # Should not be reached
-                        self._print_color(f"({base_desc_for_skill_check})", Colors.DIM)
+                    self._print_color(f"({base_desc_for_skill_check})", Colors.DIM)
 
-                if self.player_character.check_skill("Observation", 1):
-                    self._print_color("(Your keen observation notices something more...)", Colors.CYAN + Colors.DIM)
-                    observation_context = f"Player ({self.player_character.name}) succeeded an Observation skill check while looking at {npc.name} (appears {npc.apparent_state}). What subtle, non-obvious detail does {self.player_character.name} notice about {npc.name}'s demeanor, clothing, a hidden object, or a subtle emotional cue? This should be something beyond the obvious, a deeper insight."
-                    detailed_observation = None
-                    if not self.low_ai_data_mode and self.gemini_api.model:
-                        detailed_observation = self.gemini_api.get_enhanced_observation(self.player_character, target_name=npc.name, target_category="person", base_description=base_desc_for_skill_check, skill_check_context=observation_context)
+            if self.player_character.check_skill("Observation", 1):
+                self._print_color("(Your keen observation notices something more...)", Colors.CYAN + Colors.DIM)
+                observation_context = (
+                    f"Player ({self.player_character.name}) succeeded an Observation skill check while looking at "
+                    f"{npc.name} (appears {npc.apparent_state}). What subtle, non-obvious detail does "
+                    f"{self.player_character.name} notice about {npc.name}'s demeanor, clothing, a hidden object, "
+                    f"or a subtle emotional cue? This should be something beyond the obvious, a deeper insight."
+                )
+                detailed_observation = None
+                if not self.low_ai_data_mode and self.gemini_api.model:
+                    detailed_observation = self.gemini_api.get_enhanced_observation(
+                        self.player_character, target_name=npc.name, target_category="person",
+                        base_description=base_desc_for_skill_check, skill_check_context=observation_context
+                    )
 
-                    if detailed_observation is None or (isinstance(detailed_observation, str) and detailed_observation.startswith("(OOC:")) or self.low_ai_data_mode:
-                        if STATIC_ENHANCED_OBSERVATIONS:
-                            detailed_observation = random.choice(STATIC_ENHANCED_OBSERVATIONS)
-                        else:
-                            detailed_observation = "You notice some subtle cues, but their full meaning eludes you." # Ultimate fallback
-                        if detailed_observation: # Check if not None
-                            self._print_color(f"Insight: \"{detailed_observation}\"", Colors.CYAN)
-                    elif detailed_observation: # AI success
-                        self._print_color(f"Insight: \"{detailed_observation}\"", Colors.GREEN)
-                    # If still None, nothing specific printed beyond skill check success.
-                return True
+                if detailed_observation is None or (isinstance(detailed_observation, str) and detailed_observation.startswith("(OOC:")) or self.low_ai_data_mode:
+                    if STATIC_ENHANCED_OBSERVATIONS:
+                        detailed_observation = random.choice(STATIC_ENHANCED_OBSERVATIONS)
+                    else:
+                        detailed_observation = "You notice some subtle cues, but their full meaning eludes you."
+                    if detailed_observation:
+                        self._print_color(f"Insight: \"{detailed_observation}\"", Colors.CYAN)
+                elif detailed_observation:
+                    self._print_color(f"Insight: \"{detailed_observation}\"", Colors.GREEN)
+            return True
         return False
 
     def _handle_look_at_scenery(self, target_to_look_at):
@@ -1061,9 +1121,13 @@ class Game:
         if not argument: self._print_color("What do you want to take?", Colors.RED); return False, False
         if not self.player_character: self._print_color("Cannot take items: Player character not available.", Colors.RED); return False, False
         item_to_take_name = argument.lower()
-        location_items = self.dynamic_location_items.get(self.current_location_name, []); item_found_in_loc = None; item_idx_in_loc = -1
-        for idx, item_info in enumerate(location_items):
-            if item_info["name"].lower().startswith(item_to_take_name): item_found_in_loc = item_info; item_idx_in_loc = idx; break
+        location_items = self.dynamic_location_items.get(self.current_location_name, [])
+        item_found_in_loc, ambiguous = self._get_matching_location_item(item_to_take_name)
+        item_idx_in_loc = -1
+        if item_found_in_loc:
+            item_idx_in_loc = location_items.index(item_found_in_loc)
+        elif ambiguous:
+            return False, False
         if item_found_in_loc:
             item_default_props = DEFAULT_ITEMS.get(item_found_in_loc["name"], {})
             if item_default_props.get("takeable", False):
@@ -1104,9 +1168,10 @@ class Game:
     def _handle_drop_command(self, argument):
         if not argument: self._print_color("What do you want to drop?", Colors.RED); return False, False
         if not self.player_character: self._print_color("Cannot drop items: Player character not available.", Colors.RED); return False, False
-        item_to_drop_name_input = argument.lower(); item_in_inventory_obj = None
-        for inv_item in self.player_character.inventory:
-            if inv_item["name"].lower().startswith(item_to_drop_name_input): item_in_inventory_obj = inv_item; break
+        item_to_drop_name_input = argument.lower()
+        item_in_inventory_obj, ambiguous = self._get_matching_inventory_item(item_to_drop_name_input)
+        if ambiguous:
+            return False, False
         if item_in_inventory_obj:
             item_name_to_drop = item_in_inventory_obj["name"]; item_default_props = DEFAULT_ITEMS.get(item_name_to_drop, {}); drop_quantity = 1
             if self.player_character.remove_from_inventory(item_name_to_drop, drop_quantity):
@@ -1165,8 +1230,10 @@ class Game:
         if not argument: self._print_color("Who do you want to talk to?", Colors.RED); return False, False
         if not self.npcs_in_current_location: print("There's no one here to talk to."); return False, False
         if not self.player_character: self._print_color("Cannot talk: Player character not available.", Colors.RED); return False, False
-        target_name_input = argument
-        target_npc = next((npc for npc in self.npcs_in_current_location if npc.name.lower().startswith(target_name_input.lower())), None)
+        target_name_input = argument.lower()
+        target_npc, ambiguous = self._get_matching_npc(target_name_input)
+        if ambiguous:
+            return False, False
         if target_npc:
             if target_npc.name == "Porfiry Petrovich":
                 solve_murders_obj = target_npc.get_objective_by_id("solve_murders")
@@ -1244,7 +1311,9 @@ class Game:
             self.player_character.current_location = potential_target_loc_name; self.current_location_description_shown_this_visit = False
             self.last_significant_event_summary = f"moved from {old_location} to {self.current_location_name}."
             if self.player_character.name == "Rodion Raskolnikov" and potential_target_loc_name in ["Pawnbroker's Apartment", "Pawnbroker's Apartment Building"]:
-                self.player_notoriety_level = min(3, max(0, self.player_notoriety_level + 0.25)); self._print_color("(Your presence in this place feels heavy with unseen eyes...)", Colors.YELLOW + Colors.DIM); print(f"[DEBUG] Notoriety changed to: {self.player_notoriety_level}")
+                self.player_notoriety_level = min(3, max(0, self.player_notoriety_level + 0.25)); self._print_color("(Your presence in this place feels heavy with unseen eyes...)", Colors.YELLOW + Colors.DIM)
+                if DEBUG_LOGS:
+                    print(f"[DEBUG] Notoriety changed to: {self.player_notoriety_level}")
             self.update_current_location_details(from_explicit_look_cmd=False); moved = True
             return True, True
         else: self._print_color(f"You can't find a way to '{target_exit_input}' from here.", Colors.RED); return False, False
@@ -1252,7 +1321,7 @@ class Game:
     def _handle_read_item(self, item_to_use_name, item_props, item_obj_in_inventory):
         if not item_props.get("readable"): self._print_color(f"You can't read the {item_to_use_name}.", Colors.YELLOW); return False
         effect_key = item_props.get("use_effect_player")
-        if item_to_use_name == "old newspaper" or item_to_use_name == "Fresh Newspaper":
+        if item_to_use_name == "old newspaper" or item_to_use_name == "fresh newspaper":
             self._print_color(f"You smooth out the creases of the {item_to_use_name} and scan the faded print.", Colors.WHITE)
             article_snippet = None
             if not self.low_ai_data_mode and self.gemini_api.model:

--- a/game_engine/gemini_interactions.py
+++ b/game_engine/gemini_interactions.py
@@ -1,7 +1,8 @@
 # gemini_interactions.py
-import google.generativeai as genai
 import os
 import json
+import importlib
+import importlib.util
 
 # --- Self-contained API Configuration Constants ---
 API_CONFIG_FILE = "gemini_config.json"
@@ -13,9 +14,20 @@ from .game_config import Colors
 class GeminiAPI:
     def __init__(self):
         self.model = None
+        self.genai = None
         self.chosen_model_name = DEFAULT_GEMINI_MODEL_NAME # Initialize with default
         self._print_color_func = lambda text, color, end="\n": print(f"{color}{text}{Colors.RESET}", end=end)
         self._input_color_func = lambda prompt, color: input(f"{color}{prompt}{Colors.RESET}")
+
+    def _load_genai(self):
+        if self.genai:
+            return True
+        spec = importlib.util.find_spec("google.generativeai")
+        if spec is None:
+            self._log_message("Gemini API library not installed. Running with placeholder responses.", Colors.YELLOW)
+            return False
+        self.genai = importlib.import_module("google.generativeai")
+        return True
 
     def _log_message(self, text, color, end="\n"):
         if hasattr(self, '_print_color_func') and callable(self._print_color_func):
@@ -57,16 +69,19 @@ class GeminiAPI:
             self._log_message(f"Internal: _attempt_api_setup called with no API key from {source}.", Colors.RED)
             self.model = None
             return False
+        if not self._load_genai():
+            self.model = None
+            return False
             
         try:
-            genai.configure(api_key=api_key)
+            self.genai.configure(api_key=api_key)
         except Exception as e_config:
             self._print_color_func(f"Error configuring Gemini API (genai.configure using key from {source}): {e_config}", Colors.RED)
             self.model = None
             return False
 
         try:
-            model_instance = genai.GenerativeModel(model_to_use) # Use the passed model_to_use
+            model_instance = self.genai.GenerativeModel(model_to_use) # Use the passed model_to_use
         except Exception as model_e:
             self._print_color_func(f"Error instantiating Gemini model '{model_to_use}' (key from {source}): {model_e}", Colors.RED)
             self._print_color_func(f"The API key might be valid, but there's an issue with model '{model_to_use}' (e.g., name, access permissions).", Colors.YELLOW)
@@ -83,7 +98,7 @@ class GeminiAPI:
             ]
             test_response = model_instance.generate_content(
                 "This is a test of the API. Please respond with the word 'test' to confirm.",
-                generation_config=genai.types.GenerationConfig(candidate_count=1, max_output_tokens=5),
+                generation_config=self.genai.types.GenerationConfig(candidate_count=1, max_output_tokens=5),
                 safety_settings=safety_settings
             )
 
@@ -210,7 +225,9 @@ class GeminiAPI:
                 if preferred_model_from_config != DEFAULT_GEMINI_MODEL_NAME:
                     self._log_message(f"Loaded preferred model '{preferred_model_from_config}' from config.", Colors.YELLOW)
 
-                genai.configure(api_key=key_to_try)
+                if not self._load_genai():
+                    return {"api_configured": False, "low_ai_preference": False}
+                self.genai.configure(api_key=key_to_try)
                 self._log_message(f"genai.configure() successful with key from {key_source}.", Colors.GREEN)
 
                 if self._attempt_api_setup(key_to_try, key_source, preferred_model_from_config):
@@ -245,7 +262,9 @@ class GeminiAPI:
                 return {"api_configured": False, "low_ai_preference": False}
             
             try:
-                genai.configure(api_key=manual_api_key_input)
+                if not self._load_genai():
+                    return {"api_configured": False, "low_ai_preference": False}
+                self.genai.configure(api_key=manual_api_key_input)
                 self._log_message(f"genai.configure() successful with manually entered key.", Colors.GREEN)
             except Exception as e_manual_initial_config:
                  self._print_color_func(f"Error initially configuring Gemini API with manually entered key: {e_manual_initial_config}", Colors.RED)
@@ -281,6 +300,9 @@ class GeminiAPI:
         self._print_color_func = print_func
         self._input_color_func = input_func
         self._print_color_func("\n--- Gemini API Key Configuration ---", Colors.MAGENTA)
+
+        if not self._load_genai():
+            return {"api_configured": False, "low_ai_preference": False}
 
         env_result = self._handle_env_key()
         if env_result is not None:

--- a/tests/test_game_logic.py
+++ b/tests/test_game_logic.py
@@ -37,7 +37,7 @@ TEST_GAME_ITEMS = { # For TestItemEffects
     "tattered handkerchief": {"description": "A worn piece of cloth.", "use_effect_player": "comfort_self_if_ill"},
     "Raskolnikov's axe": {"description": "A weighty axe.", "use_effect_player": "grip_axe_and_reminisce_horror"},
     "cheap vodka": {"description": "A bottle of cheap spirits.", "use_effect_player": "drink_vodka_for_oblivion", "consumable": True, "stackable": True},
-    "Fresh Newspaper": {"description": "Today's news.", "readable": True, "use_effect_player": "read_evolving_news_article"},
+    "fresh newspaper": {"description": "Today's news.", "readable": True, "use_effect_player": "read_evolving_news_article"},
     "mother's letter": {"description": "A letter from Pulcheria.", "readable": True, "use_effect_player": "reread_letter_and_feel_familial_pressure"},
 }
 
@@ -702,10 +702,10 @@ class TestItemEffects(unittest.TestCase):
         self.game._print_color.assert_any_call("The vodka clashes terribly with your fever, making you feel worse.", Colors.RED)
 
     def test_read_newspaper(self):
-        self.player.inventory.append({"name": "Fresh Newspaper", "quantity": 1})
+        self.player.inventory.append({"name": "fresh newspaper", "quantity": 1})
         self.player.add_journal_entry = MagicMock()
         self.game.gemini_api.get_newspaper_article_snippet = MagicMock(return_value="A terrible crime was reported...")
-        self.game.handle_use_item("Fresh Newspaper", None, "read")
+        self.game.handle_use_item("fresh newspaper", None, "read")
         self.game.gemini_api.get_newspaper_article_snippet.assert_called_once()
         self.player.add_journal_entry.assert_called_once_with("News (AI)", "A terrible crime was reported...", "Day 1, Morning") # Updated "News" to "News (AI)"
         self.assertEqual(self.player.apparent_state, "thoughtful")
@@ -1026,11 +1026,11 @@ class TestLowAIMode(unittest.TestCase):
         # For now, we just ensure the primary AI call is skipped. A more robust test would check base_desc.
 
     @patch('game_engine.game_state.DEFAULT_ITEMS', {
-        "Fresh Newspaper": {"description": "Today's news.", "readable": True}
+        "fresh newspaper": {"description": "Today's news.", "readable": True}
     })
     def test_read_newspaper_low_ai_mode(self):
         self.game.low_ai_data_mode = True
-        self.game.player_character.inventory = [{"name": "Fresh Newspaper", "quantity": 1}]
+        self.game.player_character.inventory = [{"name": "fresh newspaper", "quantity": 1}]
         self.game.gemini_api.get_newspaper_article_snippet = MagicMock()
 
         expected_snippet = "The headlines are dull today."
@@ -1039,7 +1039,7 @@ class TestLowAIMode(unittest.TestCase):
         # Ensure the item exists in player's inventory for _handle_read_item
         # The _handle_read_item is called from handle_use_item
         with patch('game_engine.game_state.STATIC_NEWSPAPER_SNIPPETS', [expected_snippet, "Other news."]):
-             self.game.handle_use_item("Fresh Newspaper", None, "read") # Correct way to trigger _handle_read_item
+             self.game.handle_use_item("fresh newspaper", None, "read") # Correct way to trigger _handle_read_item
 
         # Static newspaper snippets are printed with YELLOW in the current implementation if AI was not attempted
         # but if low_ai_data_mode is true, it's CYAN.


### PR DESCRIPTION
### Motivation
- Make Gemini integration robust when the optional `google.generativeai` package is not present and avoid noisy debug prints in normal runs.
- Consolidate duplicate look/examine logic to provide consistent item and NPC inspection behavior and clearer ambiguity handling.
- Normalize item naming and add a startup validation pass to surface inconsistent item references early.

### Description
- Add guarded, lazy loading of the Gemini client (`_load_genai`) and update API setup paths to gracefully fall back to placeholder responses when the library/key/model are unavailable (changes in `game_engine/gemini_interactions.py`).
- Introduce a shared `DEBUG_LOGS` flag in `game_engine/game_config.py` and gate existing debug prints across `event_manager`, `character_module`, and `game_state` so debug output is opt-in.
- Refactor prefix matching and ambiguity resolution into helpers (`_resolve_prefix_match`, `_get_matching_location_item`, `_get_matching_inventory_item`, `_get_matching_npc`) and centralize item inspection into `_inspect_item` with `_display_item_properties` to remove duplicated logic and unify AI/static fallbacks (`game_engine/game_state.py`).
- Add `_validate_item_data` called at game initialization to warn about missing `DEFAULT_ITEMS` references and reduce silent data errors (`game_engine/game_state.py`).
- Normalize the newspaper item key from `"Fresh Newspaper"` to `"fresh newspaper"`, update handling in `_handle_read_item`, and align tests (`data/items.json`, `tests/test_game_logic.py`).

### Testing
- Ran the full unit test suite with `pytest -q`; all tests passed: `87 passed, 2 warnings`.
- Warnings observed relate to Google client/deprecation notices from the environment and do not affect test outcomes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988fc4d7050832582e3c2035f716cae)