### PR TITLE
Normalize item naming, improve command matching, and soften Gemini fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Step into the tormented mind of Rodion Raskolnikov, the saintly Sonya Marmeladov
 ## Features
 
 * **Rich Narrative Core:** Follow branching objectives mirroring the novel's complexity, such as Raskolnikov's "Grapple with Crime" or Sonya's "Guide Raskolnikov".
-* **Interactive Item System:** Find, use, and give items like "Raskolnikov's axe," "Sonya's New Testament," or AI-generated "Anonymous Notes" that can drive the plot or reveal character insights.
+* **Interactive Item System:** Find, use, and give items like "raskolnikov's axe," "sonya's new testament," or AI-generated "anonymous notes" that can drive the plot or reveal character insights.
 * **Dynamic Events:** Encounter scripted and emergent events, from Marmeladov's tragic tavern confessions to Katerina Ivanovna's public laments, or even find mysterious notes reacting to your deeds.
 * **Psychological Depth:** Explore your character's inner world through AI-generated reflections, dreams, and observations.
 * **Persistent World:** Save and load your progress at any time.

--- a/data/characters.json
+++ b/data/characters.json
@@ -4,64 +4,182 @@
         "greeting": "Hmph. What do you want?",
         "default_location": "Raskolnikov's Garret",
         "accessible_locations": [
-            "Raskolnikov's Garret", "Stairwell (Outside Raskolnikov's Garret)", "Haymarket Square", "Tavern",
-            "Sonya's Room", "Police Station (General Area)", "Porfiry's Office",
-            "Pawnbroker's Apartment Building", "Pawnbroker's Apartment", "Voznesensky Bridge", "Pulcheria's Lodgings",
-            "Katerina Ivanovna's Apartment", "Quiet Courtyard"
+            "Raskolnikov's Garret",
+            "Stairwell (Outside Raskolnikov's Garret)",
+            "Haymarket Square",
+            "Tavern",
+            "Sonya's Room",
+            "Police Station (General Area)",
+            "Porfiry's Office",
+            "Pawnbroker's Apartment Building",
+            "Pawnbroker's Apartment",
+            "Voznesensky Bridge",
+            "Pulcheria's Lodgings",
+            "Katerina Ivanovna's Apartment",
+            "Quiet Courtyard"
         ],
         "objectives": [
             {
                 "id": "grapple_with_crime",
                 "description": "Come to terms with the murder of Alyona Ivanovna and Lizaveta.",
-                "completed": false, "active": true, "current_stage_id": "initial_turmoil",
+                "completed": false,
+                "active": true,
+                "current_stage_id": "initial_turmoil",
                 "stages": [
-                    {"stage_id": "initial_turmoil", "description": "Reel from the act, battling fever and paranoia. Avoid immediate suspicion.", "is_current_stage": true,
-                     "success_criteria": "Survive initial days without capture, manage fever.",
-                     "next_stages": {"confession_path": "seek_sonya", "justification_path": "engage_porfiry_intellectually", "despair_path": "isolate_further"}},
-                    {"stage_id": "seek_sonya", "description": "Drawn to Sonya's suffering and purity, consider confession as a path to redemption.", "is_current_stage": false},
-                    {"stage_id": "engage_porfiry_intellectually", "description": "Test your theories and will against Porfiry Petrovich, attempting to outwit him.", "is_current_stage": false},
-                    {"stage_id": "isolate_further", "description": "Succumb to nihilistic despair, pushing everyone away.", "is_current_stage": false},
-                    {"stage_id": "received_cross_from_sonya", "description": "Sonya has given you her cypress cross, a symbol of shared suffering and potential redemption.", "is_current_stage": false},
-                    {"stage_id": "confessed_to_sonya", "description": "Having confessed to Sonya, grapple with her reaction and the path she proposes.", "is_current_stage": false},
-                    {"stage_id": "public_confession", "description": "Confess publicly at the Haymarket or police station.", "is_current_stage": false, "is_ending_stage": true},
-                    {"stage_id": "siberia", "description": "Face the consequences in Siberia, seeking spiritual rebirth.", "is_current_stage": false, "is_ending_stage": true},
-                    {"stage_id": "unrepentant_end", "description": "Remain unrepentant, your theory leading to a bleak end (capture or suicide).", "is_current_stage": false, "is_ending_stage": true}
+                    {
+                        "stage_id": "initial_turmoil",
+                        "description": "Reel from the act, battling fever and paranoia. Avoid immediate suspicion.",
+                        "is_current_stage": true,
+                        "success_criteria": "Survive initial days without capture, manage fever.",
+                        "next_stages": {
+                            "confession_path": "seek_sonya",
+                            "justification_path": "engage_porfiry_intellectually",
+                            "despair_path": "isolate_further"
+                        }
+                    },
+                    {
+                        "stage_id": "seek_sonya",
+                        "description": "Drawn to Sonya's suffering and purity, consider confession as a path to redemption.",
+                        "is_current_stage": false
+                    },
+                    {
+                        "stage_id": "engage_porfiry_intellectually",
+                        "description": "Test your theories and will against Porfiry Petrovich, attempting to outwit him.",
+                        "is_current_stage": false
+                    },
+                    {
+                        "stage_id": "isolate_further",
+                        "description": "Succumb to nihilistic despair, pushing everyone away.",
+                        "is_current_stage": false
+                    },
+                    {
+                        "stage_id": "received_cross_from_sonya",
+                        "description": "Sonya has given you her cypress cross, a symbol of shared suffering and potential redemption.",
+                        "is_current_stage": false
+                    },
+                    {
+                        "stage_id": "confessed_to_sonya",
+                        "description": "Having confessed to Sonya, grapple with her reaction and the path she proposes.",
+                        "is_current_stage": false
+                    },
+                    {
+                        "stage_id": "public_confession",
+                        "description": "Confess publicly at the Haymarket or police station.",
+                        "is_current_stage": false,
+                        "is_ending_stage": true
+                    },
+                    {
+                        "stage_id": "siberia",
+                        "description": "Face the consequences in Siberia, seeking spiritual rebirth.",
+                        "is_current_stage": false,
+                        "is_ending_stage": true
+                    },
+                    {
+                        "stage_id": "unrepentant_end",
+                        "description": "Remain unrepentant, your theory leading to a bleak end (capture or suicide).",
+                        "is_current_stage": false,
+                        "is_ending_stage": true
+                    }
                 ]
             },
             {
                 "id": "understand_theory",
                 "description": "Grapple with the validity and consequences of your 'extraordinary man' theory.",
-                "completed": false, "active": true, "current_stage_id": "initial_validation",
+                "completed": false,
+                "active": true,
+                "current_stage_id": "initial_validation",
                 "stages": [
-                     {"stage_id": "initial_validation", "description": "Internally justify your actions based on your theory.", "is_current_stage": true},
-                     {"stage_id": "challenged_by_reality", "description": "Confront the human cost and psychological toll, questioning the theory's basis.", "is_current_stage": false},
-                     {"stage_id": "theory_shattered", "description": "Recognize the flaws and inhumanity of the theory.", "is_current_stage": false, "linked_to_objective_completion": {"id": "grapple_with_crime", "stage_to_advance_to": "seek_sonya"}},
-                     {"stage_id": "theory_reinforced_darkly", "description": "Twist the theory further to rationalize ongoing defiance or despair.", "is_current_stage": false}
+                    {
+                        "stage_id": "initial_validation",
+                        "description": "Internally justify your actions based on your theory.",
+                        "is_current_stage": true
+                    },
+                    {
+                        "stage_id": "challenged_by_reality",
+                        "description": "Confront the human cost and psychological toll, questioning the theory's basis.",
+                        "is_current_stage": false
+                    },
+                    {
+                        "stage_id": "theory_shattered",
+                        "description": "Recognize the flaws and inhumanity of the theory.",
+                        "is_current_stage": false,
+                        "linked_to_objective_completion": {
+                            "id": "grapple_with_crime",
+                            "stage_to_advance_to": "seek_sonya"
+                        }
+                    },
+                    {
+                        "stage_id": "theory_reinforced_darkly",
+                        "description": "Twist the theory further to rationalize ongoing defiance or despair.",
+                        "is_current_stage": false
+                    }
                 ]
             },
             {
                 "id": "help_family",
                 "description": "Alleviate your mother and sister's financial burdens and protect Dunya from Luzhin and Svidrigailov.",
-                "completed": false, "active": true, "current_stage_id": "learn_of_arrival",
-                 "stages": [
-                    {"stage_id": "learn_of_arrival", "description": "React to the news of your mother and sister's arrival and Dunya's engagement.", "is_current_stage": true},
-                    {"stage_id": "confront_luzhin", "description": "Confront Pyotr Petrovich Luzhin over his intentions towards Dunya.", "is_current_stage": false},
-                    {"stage_id": "warn_dunya_svidrigailov", "description": "Warn Dunya about the true nature of Arkady Svidrigailov.", "is_current_stage": false},
-                    {"stage_id": "family_secure", "description": "Ensure Dunya is safe and your mother is somewhat at peace.", "is_current_stage": false, "is_ending_stage": true}
-                 ]
+                "completed": false,
+                "active": true,
+                "current_stage_id": "learn_of_arrival",
+                "stages": [
+                    {
+                        "stage_id": "learn_of_arrival",
+                        "description": "React to the news of your mother and sister's arrival and Dunya's engagement.",
+                        "is_current_stage": true
+                    },
+                    {
+                        "stage_id": "confront_luzhin",
+                        "description": "Confront Pyotr Petrovich Luzhin over his intentions towards Dunya.",
+                        "is_current_stage": false
+                    },
+                    {
+                        "stage_id": "warn_dunya_svidrigailov",
+                        "description": "Warn Dunya about the true nature of Arkady Svidrigailov.",
+                        "is_current_stage": false
+                    },
+                    {
+                        "stage_id": "family_secure",
+                        "description": "Ensure Dunya is safe and your mother is somewhat at peace.",
+                        "is_current_stage": false,
+                        "is_ending_stage": true
+                    }
+                ]
             },
             {
                 "id": "ponder_redemption",
                 "description": "Reflect on the meaning of Sonya's cross and the possibility of redemption.",
-                "completed": false, "active": false, "current_stage_id": "initial_reflection",
+                "completed": false,
+                "active": false,
+                "current_stage_id": "initial_reflection",
                 "stages": [
-                    {"stage_id": "initial_reflection", "description": "The weight of the cross prompts unsettling thoughts of guilt and sacrifice.", "is_current_stage": true},
-                    {"stage_id": "glimmer_of_hope", "description": "A fleeting sense that suffering might lead to something beyond despair.", "is_current_stage": false},
-                    {"stage_id": "path_to_confession_clearer", "description": "The cross becomes a concrete symbol of the path Sonya represents.", "is_current_stage": false}
+                    {
+                        "stage_id": "initial_reflection",
+                        "description": "The weight of the cross prompts unsettling thoughts of guilt and sacrifice.",
+                        "is_current_stage": true
+                    },
+                    {
+                        "stage_id": "glimmer_of_hope",
+                        "description": "A fleeting sense that suffering might lead to something beyond despair.",
+                        "is_current_stage": false
+                    },
+                    {
+                        "stage_id": "path_to_confession_clearer",
+                        "description": "The cross becomes a concrete symbol of the path Sonya represents.",
+                        "is_current_stage": false
+                    }
                 ]
             }
         ],
-        "inventory_items": [{"name": "mother's letter", "quantity": 1}, {"name": "worn coin", "quantity": 5}],
+        "inventory_items": [
+            {
+                "name": "mother's letter",
+                "quantity": 1
+            },
+            {
+                "name": "worn coin",
+                "quantity": 5
+            }
+        ],
         "schedule": {
             "Morning": "Raskolnikov's Garret",
             "Afternoon": "Haymarket Square",
@@ -81,30 +199,69 @@
         "greeting": "Oh... hello. May God be with you.",
         "default_location": "Sonya's Room",
         "accessible_locations": [
-            "Sonya's Room", "Haymarket Square", "Raskolnikov's Garret", "Pulcheria's Lodgings",
-            "Police Station (General Area)", "Tavern", "Katerina Ivanovna's Apartment", "Quiet Courtyard"
+            "Sonya's Room",
+            "Haymarket Square",
+            "Raskolnikov's Garret",
+            "Pulcheria's Lodgings",
+            "Police Station (General Area)",
+            "Tavern",
+            "Katerina Ivanovna's Apartment",
+            "Quiet Courtyard"
         ],
         "objectives": [
             {
-                "id": "support_family", "description": "Continue to support the Marmeladov children and Katerina Ivanovna.",
-                "completed": false, "active": true, "current_stage_id": "default",
-                "stages" : [{"stage_id": "default", "description": "Provide for the family amidst hardship."}]
+                "id": "support_family",
+                "description": "Continue to support the Marmeladov children and Katerina Ivanovna.",
+                "completed": false,
+                "active": true,
+                "current_stage_id": "default",
+                "stages": [
+                    {
+                        "stage_id": "default",
+                        "description": "Provide for the family amidst hardship."
+                    }
+                ]
             },
             {
-                "id": "guide_raskolnikov", "description": "Offer spiritual guidance and hope to Rodion Raskolnikov, urging him towards confession.",
-                "completed": false, "active": true, "current_stage_id": "initial_encounter",
+                "id": "guide_raskolnikov",
+                "description": "Offer spiritual guidance and hope to Rodion Raskolnikov, urging him towards confession.",
+                "completed": false,
+                "active": true,
+                "current_stage_id": "initial_encounter",
                 "stages": [
-                    {"stage_id": "initial_encounter", "description": "Recognize a shared suffering in Raskolnikov."},
-                    {"stage_id": "lazarus_reading", "description": "Read the story of Lazarus to Raskolnikov, offering a path to spiritual rebirth."},
-                    {"stage_id": "offer_cross", "description": "Offer Raskolnikov her cypress cross as a symbol of shared suffering and redemption."},
-                    {"stage_id": "receive_confession", "description": "Hear Raskolnikov's confession and urge him to accept his suffering."},
-                    {"stage_id": "follow_to_siberia", "description": "Decide to follow Raskolnikov to Siberia.", "is_ending_stage": true}
+                    {
+                        "stage_id": "initial_encounter",
+                        "description": "Recognize a shared suffering in Raskolnikov."
+                    },
+                    {
+                        "stage_id": "lazarus_reading",
+                        "description": "Read the story of Lazarus to Raskolnikov, offering a path to spiritual rebirth."
+                    },
+                    {
+                        "stage_id": "offer_cross",
+                        "description": "Offer Raskolnikov her cypress cross as a symbol of shared suffering and redemption."
+                    },
+                    {
+                        "stage_id": "receive_confession",
+                        "description": "Hear Raskolnikov's confession and urge him to accept his suffering."
+                    },
+                    {
+                        "stage_id": "follow_to_siberia",
+                        "description": "Decide to follow Raskolnikov to Siberia.",
+                        "is_ending_stage": true
+                    }
                 ]
             }
         ],
         "inventory_items": [
-            {"name": "Sonya's New Testament", "quantity": 1},
-            {"name": "Sonya's Cypress Cross", "quantity": 1}
+            {
+                "name": "sonya's new testament",
+                "quantity": 1
+            },
+            {
+                "name": "sonya's cypress cross",
+                "quantity": 1
+            }
         ],
         "npc_relationships": {
             "Katerina Ivanovna Marmeladova": -1,
@@ -128,24 +285,54 @@
         "greeting": "Well, well, look who it is. Come in, come in. Care for a little chat... or perhaps you have something on your mind?",
         "default_location": "Porfiry's Office",
         "accessible_locations": [
-            "Porfiry's Office", "Police Station (General Area)", "Haymarket Square", "Raskolnikov's Garret"
+            "Porfiry's Office",
+            "Police Station (General Area)",
+            "Haymarket Square",
+            "Raskolnikov's Garret"
         ],
         "objectives": [
             {
-                "id": "solve_murders", "description": "Uncover the truth behind the murders of Alyona Ivanovna and Lizaveta, focusing on Raskolnikov.",
-                "completed": false, "active": true, "current_stage_id": "initial_suspicion",
+                "id": "solve_murders",
+                "description": "Uncover the truth behind the murders of Alyona Ivanovna and Lizaveta, focusing on Raskolnikov.",
+                "completed": false,
+                "active": true,
+                "current_stage_id": "initial_suspicion",
                 "stages": [
-                    {"stage_id": "initial_suspicion", "description": "Observe Raskolnikov and gather preliminary impressions."},
-                    {"stage_id": "psychological_probes", "description": "Engage Raskolnikov in conversations designed to test his guilt and theories."},
-                    {"stage_id": "closing_the_net", "description": "Subtly reveal the strength of the evidence or understanding of Raskolnikov's mind."},
-                    {"stage_id": "encourage_confession", "description": "Offer Raskolnikov a chance to confess for a potentially lighter sentence."},
-                    {"stage_id": "case_solved", "description": "Raskolnikov confesses or is irrefutably proven guilty.", "is_ending_stage": true}
+                    {
+                        "stage_id": "initial_suspicion",
+                        "description": "Observe Raskolnikov and gather preliminary impressions."
+                    },
+                    {
+                        "stage_id": "psychological_probes",
+                        "description": "Engage Raskolnikov in conversations designed to test his guilt and theories."
+                    },
+                    {
+                        "stage_id": "closing_the_net",
+                        "description": "Subtly reveal the strength of the evidence or understanding of Raskolnikov's mind."
+                    },
+                    {
+                        "stage_id": "encourage_confession",
+                        "description": "Offer Raskolnikov a chance to confess for a potentially lighter sentence."
+                    },
+                    {
+                        "stage_id": "case_solved",
+                        "description": "Raskolnikov confesses or is irrefutably proven guilty.",
+                        "is_ending_stage": true
+                    }
                 ]
             },
             {
-                "id": "understand_criminal_mind", "description": "Explore the psychology of the criminal, particularly Raskolnikov's 'extraordinary man' theory.",
-                "completed": false, "active": true, "current_stage_id": "default",
-                 "stages" : [{"stage_id": "default", "description": "Observe and analyze criminal behavior."}]
+                "id": "understand_criminal_mind",
+                "description": "Explore the psychology of the criminal, particularly Raskolnikov's 'extraordinary man' theory.",
+                "completed": false,
+                "active": true,
+                "current_stage_id": "default",
+                "stages": [
+                    {
+                        "stage_id": "default",
+                        "description": "Observe and analyze criminal behavior."
+                    }
+                ]
             }
         ],
         "inventory_items": [],
@@ -171,24 +358,52 @@
         "greeting": "Greetings. I hope you are well. Rodya has been so... unlike himself.",
         "default_location": "Pulcheria's Lodgings",
         "accessible_locations": [
-            "Pulcheria's Lodgings", "Haymarket Square", "Raskolnikov's Garret", "Sonya's Room", "Tavern",
+            "Pulcheria's Lodgings",
+            "Haymarket Square",
+            "Raskolnikov's Garret",
+            "Sonya's Room",
+            "Tavern",
             "Katerina Ivanovna's Apartment"
         ],
         "objectives": [
             {
-                "id": "protect_rodion", "description": "Understand what is troubling Rodion and protect him from harm or folly.",
-                "completed": false, "active": true, "current_stage_id": "default",
-                 "stages" : [{"stage_id": "default", "description": "Seek to understand and aid Rodion."}]
+                "id": "protect_rodion",
+                "description": "Understand what is troubling Rodion and protect him from harm or folly.",
+                "completed": false,
+                "active": true,
+                "current_stage_id": "default",
+                "stages": [
+                    {
+                        "stage_id": "default",
+                        "description": "Seek to understand and aid Rodion."
+                    }
+                ]
             },
             {
-                "id": "resolve_luzhin", "description": "Deal with the unwelcome attentions and proposal of Pyotr Petrovich Luzhin.",
-                "completed": false, "active": true, "current_stage_id": "default",
-                "stages" : [{"stage_id": "default", "description": "Address the situation with Luzhin."}]
+                "id": "resolve_luzhin",
+                "description": "Deal with the unwelcome attentions and proposal of Pyotr Petrovich Luzhin.",
+                "completed": false,
+                "active": true,
+                "current_stage_id": "default",
+                "stages": [
+                    {
+                        "stage_id": "default",
+                        "description": "Address the situation with Luzhin."
+                    }
+                ]
             },
             {
-                "id": "assess_svidrigailov", "description": "Determine the true intentions of Arkady Svidrigailov and protect herself.",
-                "completed": false, "active": true, "current_stage_id": "default",
-                "stages" : [{"stage_id": "default", "description": "Be wary of Svidrigailov."}]
+                "id": "assess_svidrigailov",
+                "description": "Determine the true intentions of Arkady Svidrigailov and protect herself.",
+                "completed": false,
+                "active": true,
+                "current_stage_id": "default",
+                "stages": [
+                    {
+                        "stage_id": "default",
+                        "description": "Be wary of Svidrigailov."
+                    }
+                ]
             }
         ],
         "inventory_items": [],
@@ -208,28 +423,61 @@
         "greeting": "Ah, a new face. Or an old one? St. Petersburg is so full of... possibilities. And ghosts. Don't you find?",
         "default_location": "Tavern",
         "accessible_locations": [
-            "Tavern", "Haymarket Square", "Sonya's Room", "Pulcheria's Lodgings", "Voznesensky Bridge",
-            "Raskolnikov's Garret", "Katerina Ivanovna's Apartment"
+            "Tavern",
+            "Haymarket Square",
+            "Sonya's Room",
+            "Pulcheria's Lodgings",
+            "Voznesensky Bridge",
+            "Raskolnikov's Garret",
+            "Katerina Ivanovna's Apartment"
         ],
         "objectives": [
             {
-                "id": "pursue_dunya", "description": "Attempt to win over Dunya Raskolnikova, employing various means.",
-                "completed": false, "active": true, "current_stage_id": "default",
-                "stages" : [{"stage_id": "default", "description": "Consider your approach towards Dunya."}]
+                "id": "pursue_dunya",
+                "description": "Attempt to win over Dunya Raskolnikova, employing various means.",
+                "completed": false,
+                "active": true,
+                "current_stage_id": "default",
+                "stages": [
+                    {
+                        "stage_id": "default",
+                        "description": "Consider your approach towards Dunya."
+                    }
+                ]
             },
             {
-                "id": "escape_ennui", "description": "Find some amusement or meaning to escape your profound boredom and past ghosts, perhaps through Raskolnikov or Dunya.",
-                "completed": false, "active": true, "current_stage_id": "default",
-                "stages" : [{"stage_id": "default", "description": "Seek distraction from your ennui."}]
-
+                "id": "escape_ennui",
+                "description": "Find some amusement or meaning to escape your profound boredom and past ghosts, perhaps through Raskolnikov or Dunya.",
+                "completed": false,
+                "active": true,
+                "current_stage_id": "default",
+                "stages": [
+                    {
+                        "stage_id": "default",
+                        "description": "Seek distraction from your ennui."
+                    }
+                ]
             },
             {
-                "id": "final_reckoning", "description": "Confront the emptiness of his existence.",
-                "completed": false, "active": false, "current_stage_id": "default",
-                "stages" : [{"stage_id": "default", "description": "The end approaches."}]
+                "id": "final_reckoning",
+                "description": "Confront the emptiness of his existence.",
+                "completed": false,
+                "active": false,
+                "current_stage_id": "default",
+                "stages": [
+                    {
+                        "stage_id": "default",
+                        "description": "The end approaches."
+                    }
+                ]
             }
         ],
-        "inventory_items": [{"name": "worn coin", "quantity": 100}],
+        "inventory_items": [
+            {
+                "name": "worn coin",
+                "quantity": 100
+            }
+        ],
         "skills": {
             "Observation": 2,
             "Persuasion": 2
@@ -241,27 +489,54 @@
             "Night": "Voznesensky Bridge"
         }
     },
-     "Dmitri Razumikhin": {
+    "Dmitri Razumikhin": {
         "persona": "You are Dmitri Razumikhin from Dostoevsky's 'Crime and Punishment'. You are Raskolnikov's loyal friend, energetic, talkative, somewhat poor but resourceful and generally good-natured. You are practical and often try to help Raskolnikov, though sometimes bewildered by his behavior. Your speech is enthusiastic, direct, and sometimes a bit boisterous.",
         "greeting": "Rodya! There you are! I was just thinking about you. You've been looking stranger than a three-legged dog lately. What's on your mind?",
         "default_location": "Tavern",
         "accessible_locations": [
-            "Tavern", "Haymarket Square", "Raskolnikov's Garret", "Stairwell (Outside Raskolnikov's Garret)",
-            "Pulcheria's Lodgings", "Police Station (General Area)", "Sonya's Room", "Katerina Ivanovna's Apartment"
+            "Tavern",
+            "Haymarket Square",
+            "Raskolnikov's Garret",
+            "Stairwell (Outside Raskolnikov's Garret)",
+            "Pulcheria's Lodgings",
+            "Police Station (General Area)",
+            "Sonya's Room",
+            "Katerina Ivanovna's Apartment"
         ],
         "objectives": [
             {
-                "id": "help_raskolnikov", "description": "Figure out what's wrong with Raskolnikov and help him get back on his feet.",
-                "completed": false, "active": true, "current_stage_id": "default",
-                "stages" : [{"stage_id": "default", "description": "Worry about Rodya and try to assist him."}]
+                "id": "help_raskolnikov",
+                "description": "Figure out what's wrong with Raskolnikov and help him get back on his feet.",
+                "completed": false,
+                "active": true,
+                "current_stage_id": "default",
+                "stages": [
+                    {
+                        "stage_id": "default",
+                        "description": "Worry about Rodya and try to assist him."
+                    }
+                ]
             },
             {
-                "id": "support_dunya_pulcheria", "description": "Offer assistance and protection to Dunya and Pulcheria Alexandrovna.",
-                "completed": false, "active": true, "current_stage_id": "default",
-                "stages" : [{"stage_id": "default", "description": "Look out for Rodya's family."}]
+                "id": "support_dunya_pulcheria",
+                "description": "Offer assistance and protection to Dunya and Pulcheria Alexandrovna.",
+                "completed": false,
+                "active": true,
+                "current_stage_id": "default",
+                "stages": [
+                    {
+                        "stage_id": "default",
+                        "description": "Look out for Rodya's family."
+                    }
+                ]
             }
         ],
-        "inventory_items": [{"name": "worn coin", "quantity": 15}],
+        "inventory_items": [
+            {
+                "name": "worn coin",
+                "quantity": 15
+            }
+        ],
         "npc_relationships": {
             "Rodion Raskolnikov": 5,
             "Dunya Raskolnikova": 2,
@@ -283,19 +558,38 @@
         "greeting": "Rodya, my dear boy! Or... oh, excuse me. Hello. Have you seen my Rodya? I worry so.",
         "default_location": "Pulcheria's Lodgings",
         "accessible_locations": [
-            "Pulcheria's Lodgings", "Raskolnikov's Garret", "Haymarket Square", "Sonya's Room",
+            "Pulcheria's Lodgings",
+            "Raskolnikov's Garret",
+            "Haymarket Square",
+            "Sonya's Room",
             "Katerina Ivanovna's Apartment"
         ],
         "objectives": [
             {
-                "id": "ensure_rodyas_wellbeing", "description": "Understand why Rodya is so troubled and ensure he is safe and well.",
-                "completed": false, "active": true, "current_stage_id": "default",
-                "stages" : [{"stage_id": "default", "description": "Be deeply concerned for Rodion's state."}]
+                "id": "ensure_rodyas_wellbeing",
+                "description": "Understand why Rodya is so troubled and ensure he is safe and well.",
+                "completed": false,
+                "active": true,
+                "current_stage_id": "default",
+                "stages": [
+                    {
+                        "stage_id": "default",
+                        "description": "Be deeply concerned for Rodion's state."
+                    }
+                ]
             },
             {
-                "id": "see_dunya_settled", "description": "Hope for Dunya to find a secure and happy future.",
-                "completed": false, "active": true, "current_stage_id": "default",
-                "stages" : [{"stage_id": "default", "description": "Wish for Dunya's happiness and security."}]
+                "id": "see_dunya_settled",
+                "description": "Hope for Dunya to find a secure and happy future.",
+                "completed": false,
+                "active": true,
+                "current_stage_id": "default",
+                "stages": [
+                    {
+                        "stage_id": "default",
+                        "description": "Wish for Dunya's happiness and security."
+                    }
+                ]
             }
         ],
         "inventory_items": [],
@@ -311,29 +605,63 @@
         "greeting": "Who are you to disturb a respectable, albeit unfortunate, family? Can't you see we are suffering? Oh, the indignity! The children are starving!",
         "default_location": "Katerina Ivanovna's Apartment",
         "accessible_locations": [
-            "Katerina Ivanovna's Apartment", "Haymarket Square", "Sonya's Room", "Tavern"
+            "Katerina Ivanovna's Apartment",
+            "Haymarket Square",
+            "Sonya's Room",
+            "Tavern"
         ],
         "objectives": [
             {
-                "id": "lament_fate", "description": "Express outrage and despair at her family's poverty and the injustices of the world.",
-                "completed": false, "active": true, "current_stage_id": "default",
-                "stages" : [{"stage_id": "default", "description": "Voice her grievances loudly and often."}]
-            },
-            {
-                "id": "care_for_children", "description": "Attempt to care for her young children (Polenka, Kolya, Lida) amidst growing illness and poverty.",
-                "completed": false, "active": true, "current_stage_id": "default",
-                "stages" : [{"stage_id": "default", "description": "Struggle to provide for her children."}]
-            },
-            {
-                "id": "memorial_dinner_for_marmeladov", "description": "Obsessively plan a grand (and financially ruinous) memorial dinner for Marmeladov.",
-                "completed": false, "active": false, "current_stage_id": "planning",
+                "id": "lament_fate",
+                "description": "Express outrage and despair at her family's poverty and the injustices of the world.",
+                "completed": false,
+                "active": true,
+                "current_stage_id": "default",
                 "stages": [
-                    {"stage_id": "planning", "description": "Frantically try to arrange a memorial dinner beyond her means."},
-                    {"stage_id": "dinner_chaos", "description": "The memorial dinner descends into chaos and further humiliation.", "is_ending_stage": true}
+                    {
+                        "stage_id": "default",
+                        "description": "Voice her grievances loudly and often."
+                    }
+                ]
+            },
+            {
+                "id": "care_for_children",
+                "description": "Attempt to care for her young children (Polenka, Kolya, Lida) amidst growing illness and poverty.",
+                "completed": false,
+                "active": true,
+                "current_stage_id": "default",
+                "stages": [
+                    {
+                        "stage_id": "default",
+                        "description": "Struggle to provide for her children."
+                    }
+                ]
+            },
+            {
+                "id": "memorial_dinner_for_marmeladov",
+                "description": "Obsessively plan a grand (and financially ruinous) memorial dinner for Marmeladov.",
+                "completed": false,
+                "active": false,
+                "current_stage_id": "planning",
+                "stages": [
+                    {
+                        "stage_id": "planning",
+                        "description": "Frantically try to arrange a memorial dinner beyond her means."
+                    },
+                    {
+                        "stage_id": "dinner_chaos",
+                        "description": "The memorial dinner descends into chaos and further humiliation.",
+                        "is_ending_stage": true
+                    }
                 ]
             }
         ],
-        "inventory_items": [{"name": "tattered handkerchief", "quantity": 1}],
+        "inventory_items": [
+            {
+                "name": "tattered handkerchief",
+                "quantity": 1
+            }
+        ],
         "schedule": {
             "Morning": "Katerina Ivanovna's Apartment",
             "Afternoon": "Katerina Ivanovna's Apartment",
@@ -346,12 +674,23 @@
         "persona": "You are Ilya, a junior police clerk. You are overworked, somewhat officious, and keen to follow procedure. You mostly deal with paperwork and minor complaints, often sighing about the chaos of the station. You address people formally.",
         "greeting": "Yes? State your business, please. Quickly, I have much to attend to.",
         "default_location": "Police Station (General Area)",
-        "accessible_locations": ["Police Station (General Area)", "Porfiry's Office"],
+        "accessible_locations": [
+            "Police Station (General Area)",
+            "Porfiry's Office"
+        ],
         "objectives": [
             {
-                "id": "maintain_order", "description": "Try to keep the station's administrative tasks in order.",
-                "completed": false, "active": true, "current_stage_id": "default",
-                 "stages" : [{"stage_id": "default", "description": "Process paperwork and direct petitioners."}]
+                "id": "maintain_order",
+                "description": "Try to keep the station's administrative tasks in order.",
+                "completed": false,
+                "active": true,
+                "current_stage_id": "default",
+                "stages": [
+                    {
+                        "stage_id": "default",
+                        "description": "Process paperwork and direct petitioners."
+                    }
+                ]
             }
         ],
         "inventory_items": [],
@@ -367,12 +706,23 @@
         "persona": "You are Officer Volkov, a seasoned but weary police officer. You've seen much in your time on the St. Petersburg streets and are generally cynical and taciturn. You might offer a gruff comment or a suspicious glance. You don't waste words.",
         "greeting": "Hmph. What is it now?",
         "default_location": "Police Station (General Area)",
-        "accessible_locations": ["Police Station (General Area)", "Haymarket Square"],
+        "accessible_locations": [
+            "Police Station (General Area)",
+            "Haymarket Square"
+        ],
         "objectives": [
             {
-                "id": "keep_peace", "description": "Maintain a semblance of order on the streets and in the station.",
-                "completed": false, "active": true, "current_stage_id": "default",
-                "stages" : [{"stage_id": "default", "description": "Observe and intervene if necessary."}]
+                "id": "keep_peace",
+                "description": "Maintain a semblance of order on the streets and in the station.",
+                "completed": false,
+                "active": true,
+                "current_stage_id": "default",
+                "stages": [
+                    {
+                        "stage_id": "default",
+                        "description": "Observe and intervene if necessary."
+                    }
+                ]
             }
         ],
         "inventory_items": [],

--- a/data/items.json
+++ b/data/items.json
@@ -1,7 +1,9 @@
 {
     "worn coin": {
         "description": "A grimy, well-worn kopek. It's seen better days, but still holds some small value. Could be offered as meagre charity or perhaps to buy a moment's peace or a cheap drink.",
-        "takeable": true, "value": 1, "stackable": true,
+        "takeable": true,
+        "value": 1,
+        "stackable": true,
         "notable_threshold": 20,
         "use_effect_player": "offer_charity_or_payment"
     },
@@ -17,35 +19,41 @@
     },
     "old newspaper": {
         "description": "A yellowed page from a St. Petersburg newspaper, dated some weeks ago. The print is faded. Reading it might offer a glimpse into the city's recent events or spark a troubling thought.",
-        "takeable": true, "readable": true,
+        "takeable": true,
+        "readable": true,
         "use_effect_player": "read_newspaper_for_news_or_thoughts"
     },
-    "Fresh Newspaper": {
+    "fresh newspaper": {
         "description": "A recently printed newspaper, still smelling faintly of ink. The headlines might offer insights into current events or the city's mood.",
-        "takeable": true, "readable": true, "value": 2,
+        "takeable": true,
+        "readable": true,
+        "value": 2,
         "use_effect_player": "read_evolving_news_article"
     },
-    "Anonymous Note": {
+    "anonymous note": {
         "description": "A hastily scribbled note, contents unknown until read. It feels ominous.",
-        "takeable": true, "readable": true, "is_notable": true,
+        "takeable": true,
+        "readable": true,
+        "is_notable": true,
         "use_effect_player": "read_generated_document",
         "generated_content": ""
     },
-    "Raskolnikov's axe": {
+    "raskolnikov's axe": {
         "description": "A heavy, sharp axe, the blade still bearing almost imperceptible dark stains. It feels cold and menacing to the touch, a weight not just in hand but on the soul. Holding it brings back vivid, horrifying memories and a surge of conflicting emotions.",
         "takeable": true,
         "hidden_in_location": "Raskolnikov's Garret",
         "is_notable": true,
         "use_effect_player": "grip_axe_and_reminisce_horror"
     },
-    "Sonya's New Testament": {
+    "sonya's new testament": {
         "description": "A small, well-thumbed copy of the New Testament. Its pages are marked and worn, a testament to Sonya's unwavering faith. Reading it might offer solace, or a stark confrontation with one's own sins.",
-        "takeable": true, "readable": true,
+        "takeable": true,
+        "readable": true,
         "owner": "Sonya Marmeladova",
         "is_notable": true,
         "use_effect_player": "read_testament_for_solace_or_guilt"
     },
-    "Sonya's Cypress Cross": {
+    "sonya's cypress cross": {
         "description": "A small, plain cypress wood cross, given by Sonya. It feels strangely warm to the touch, imbued with a sense of simple, profound faith and shared suffering. Holding it might bring a moment of clarity, remorse, or a fragile hope for redemption.",
         "takeable": true,
         "owner": "Sonya Marmeladova",
@@ -60,18 +68,21 @@
     },
     "mother's letter": {
         "description": "A letter from Pulcheria Alexandrovna, filled with anxious love and troubling news of Dunya. Re-reading it might stir deep feelings of guilt, responsibility, or a desperate urge to protect one's family.",
-        "takeable": true, "readable": true,
+        "takeable": true,
+        "readable": true,
         "is_notable": true,
         "owner": "Rodion Raskolnikov",
         "use_effect_player": "reread_letter_and_feel_familial_pressure"
     },
     "cheap vodka": {
         "description": "A half-empty bottle of harsh, cheap vodka. It promises temporary oblivion from the crushing weight of thoughts and reality. Drinking it will likely lead to a muddled state.",
-        "takeable": true, "consumable": true, "value": 5,
+        "takeable": true,
+        "consumable": true,
+        "value": 5,
         "use_effect_player": "drink_vodka_for_oblivion"
     },
-    "Lizaveta's bundle": {
-        "description": "A small, poorly wrapped bundle tied with string, containing a few meager possessions. It was dropped by Lizaveta. Examining its contents – perhaps a worn shawl, a child's toy, a copper coin – serves as a brutal reminder of the innocent life taken, deepening the sense of guilt.",
+    "lizaveta's bundle": {
+        "description": "A small, poorly wrapped bundle tied with string, containing a few meager possessions. It was dropped by Lizaveta. Examining its contents \u2013 perhaps a worn shawl, a child's toy, a copper coin \u2013 serves as a brutal reminder of the innocent life taken, deepening the sense of guilt.",
         "takeable": true,
         "is_notable": true,
         "hidden_in_location": "Pawnbroker's Apartment",

--- a/data/locations.json
+++ b/data/locations.json
@@ -1,22 +1,44 @@
 {
     "Tavern": {
-        "description": "The air in this St. Petersburg tavern is thick with the acrid smell of cheap makhorka tobacco, stale beer, the greasy steam of cheap food, and unwashed bodies. Grimy wooden tables are scarred with countless rings from wet glasses and spilled drink. A cacophony of the city's underbelly fills the space: low, guttural laughter from one corner, hushed, desperate whispers from another, sharp arguments flaring up and dying down, and the occasional burst of drunken song. Shadows cling to the corners, and the flickering gaslight casts a jaundiced glow on the faces of the varied patrons – students, minor officials, workmen, and more shadowy figures – each seemingly lost in their own private miseries, fleeting revelries, or intense, low-voiced conversations that might concern anything from petty gossip to life-altering decisions. It's a place where crucial information might be overheard by chance, or a fateful encounter could occur.",
-        "exits": {"Haymarket Square": "Push through the heavy, creaking door back into the sensory assault of Haymarket Square."},
-        "items_present": [{"name": "dusty bottle", "quantity": 2}, {"name": "worn coin", "quantity": 1}, {"name": "cheap vodka", "quantity": 1}],
+        "description": "The air in this St. Petersburg tavern is thick with the acrid smell of cheap makhorka tobacco, stale beer, the greasy steam of cheap food, and unwashed bodies. Grimy wooden tables are scarred with countless rings from wet glasses and spilled drink. A cacophony of the city's underbelly fills the space: low, guttural laughter from one corner, hushed, desperate whispers from another, sharp arguments flaring up and dying down, and the occasional burst of drunken song. Shadows cling to the corners, and the flickering gaslight casts a jaundiced glow on the faces of the varied patrons \u2013 students, minor officials, workmen, and more shadowy figures \u2013 each seemingly lost in their own private miseries, fleeting revelries, or intense, low-voiced conversations that might concern anything from petty gossip to life-altering decisions. It's a place where crucial information might be overheard by chance, or a fateful encounter could occur.",
+        "exits": {
+            "Haymarket Square": "Push through the heavy, creaking door back into the sensory assault of Haymarket Square."
+        },
+        "items_present": [
+            {
+                "name": "dusty bottle",
+                "quantity": 2
+            },
+            {
+                "name": "worn coin",
+                "quantity": 1
+            },
+            {
+                "name": "cheap vodka",
+                "quantity": 1
+            }
+        ],
         "time_effects": {
             "Night": " The tavern is rowdier now, filled with more drunken shouts and the desperate gaiety of those trying to forget the coming dawn."
         }
     },
     "Raskolnikov's Garret": {
         "description": "This tiny garret, more like a cupboard or a 'coffin' of a room, is tucked away oppressively under the very eaves of a towering, five-storied house. The ceiling presses down, so low you feel you could touch it without standing. Dusty, yellowed, and peeling wallpaper, adorned with a barely discernible floral pattern, seems to absorb what little light filters through the grimy window, contributing to the room's sense of psychological confinement. The air is perpetually stuffy, heavy with the scent of dust, abject poverty, and unspoken, feverish thoughts. A rickety table, a chair, and a wretched sofa covered in tattered chintz are the sole, miserable furnishings.",
-        "exits": {"Stairwell (Outside Raskolnikov's Garret)": "Open the flimsy door and step out into the dim, echoing stairwell."},
-        "items_present": [{"name": "old newspaper", "quantity": 1}],
+        "exits": {
+            "Stairwell (Outside Raskolnikov's Garret)": "Open the flimsy door and step out into the dim, echoing stairwell."
+        },
+        "items_present": [
+            {
+                "name": "old newspaper",
+                "quantity": 1
+            }
+        ],
         "time_effects": {
             "Night": " The room is even more oppressive in the darkness, shadows deepening the sense of confinement. The city's distant noises seem louder here."
         }
     },
     "Stairwell (Outside Raskolnikov's Garret)": {
-        "description": "The stairwell is a dark, narrow passage, spiraling down into the building's depths. The air is cool and damp, carrying a mélange of odors: stale cooking smells from other apartments, the faint scent of lye from a recent, perfunctory cleaning, and an underlying mustiness. Each creak of the wooden steps underfoot echoes ominously. Faint sounds of life – a distant argument, a child's cry, a snatch of a song – drift from behind closed doors.",
+        "description": "The stairwell is a dark, narrow passage, spiraling down into the building's depths. The air is cool and damp, carrying a m\u00e9lange of odors: stale cooking smells from other apartments, the faint scent of lye from a recent, perfunctory cleaning, and an underlying mustiness. Each creak of the wooden steps underfoot echoes ominously. Faint sounds of life \u2013 a distant argument, a child's cry, a snatch of a song \u2013 drift from behind closed doors.",
         "exits": {
             "Raskolnikov's Garret": "Climb the last few steps back to the garret door.",
             "Haymarket Square": "Descend the seemingly endless flights of stairs, emerging into the clamor of Haymarket Square.",
@@ -29,9 +51,9 @@
         "exits": {
             "Haymarket Square": "Leave the quiet sorrow of the room and return to the jarring noise of Haymarket Square.",
             "Katerina Ivanovna's Apartment": "A short, grim walk takes you to the even more chaotic dwelling of Katerina Ivanovna."
-            },
+        },
         "items_present": [],
-         "time_effects": {
+        "time_effects": {
             "Evening": " A single candle often burns, casting long, flickering shadows that dance with Sonya's quiet movements."
         }
     },
@@ -41,15 +63,22 @@
             "Haymarket Square": "Escape the oppressive atmosphere of the station and find yourself back near Haymarket Square.",
             "Porfiry's Office": "Navigate through a corridor to the examining magistrate's office."
         },
-        "items_present": [{"name": "old newspaper", "quantity": 3}]
+        "items_present": [
+            {
+                "name": "old newspaper",
+                "quantity": 3
+            }
+        ]
     },
     "Porfiry's Office": {
         "description": "Porfiry Petrovich's office is somewhat more orderly than the general area, though still utilitarian. A large, cluttered desk dominates the room, piled with case files and legal documents. Bookshelves laden with dusty tomes line one wall. The room is typically hazy with tobacco smoke, as Porfiry is a frequent smoker. A couple of worn armchairs for visitors are placed before the desk, inviting an interrogation that feels more like a casual, albeit unsettling, conversation.",
-        "exits": {"Police Station (General Area)": "Step out of the intense scrutiny of the office and back into the general area of the police station."},
+        "exits": {
+            "Police Station (General Area)": "Step out of the intense scrutiny of the office and back into the general area of the police station."
+        },
         "items_present": []
     },
     "Haymarket Square": {
-        "description": "Haymarket Square is an oppressive sensory explosion, the beating, often diseased heart of this part of St. Petersburg, especially under the stifling summer heat. The air is a thick, choking soup of smells: rotting vegetables, fresh hay, horse manure, cheap vodka, unwashed bodies, and the greasy aroma of street food from countless stalls, all mingling with fine, pervasive dust. A relentless cacophony of sounds assaults the ears – the shouts of vendors hawking their wares, the rumbling of cartwheels on cobblestones, the whinnying of horses, the cries of beggars, and the drunken, desperate singing from nearby taverns. The crowd is a dense, ever-shifting mass of humanity – a cross-section of the city's poor, drunk, and desperate – navigating the chaotic, filthy space, contributing to an atmosphere that feels both overwhelmingly vibrant and deeply unsettling.",
+        "description": "Haymarket Square is an oppressive sensory explosion, the beating, often diseased heart of this part of St. Petersburg, especially under the stifling summer heat. The air is a thick, choking soup of smells: rotting vegetables, fresh hay, horse manure, cheap vodka, unwashed bodies, and the greasy aroma of street food from countless stalls, all mingling with fine, pervasive dust. A relentless cacophony of sounds assaults the ears \u2013 the shouts of vendors hawking their wares, the rumbling of cartwheels on cobblestones, the whinnying of horses, the cries of beggars, and the drunken, desperate singing from nearby taverns. The crowd is a dense, ever-shifting mass of humanity \u2013 a cross-section of the city's poor, drunk, and desperate \u2013 navigating the chaotic, filthy space, contributing to an atmosphere that feels both overwhelmingly vibrant and deeply unsettling.",
         "exits": {
             "Tavern": "Duck into a nearby tavern, seeking either oblivion or company.",
             "Stairwell (Outside Raskolnikov's Garret)": "Weave through the throng towards the tall tenement building where Raskolnikov lodges.",
@@ -61,7 +90,16 @@
             "Katerina Ivanovna's Apartment": "Follow a narrow, squalid alley towards the Marmeladovs' chaotic dwelling.",
             "Quiet Courtyard": "Slip through a narrow archway into a surprisingly quiet courtyard."
         },
-        "items_present": [{"name": "tattered handkerchief", "quantity": 1}, {"name": "worn coin", "quantity": 2}],
+        "items_present": [
+            {
+                "name": "tattered handkerchief",
+                "quantity": 1
+            },
+            {
+                "name": "worn coin",
+                "quantity": 2
+            }
+        ],
         "time_effects": {
             "Morning": " The market is at its busiest, with farmers and traders shouting their prices.",
             "Evening": " The crowds begin to thin, but a more desperate, shadowy element emerges."
@@ -77,29 +115,45 @@
     },
     "Pawnbroker's Apartment": {
         "description": "Alyona Ivanovna's small apartment, though rather cluttered, is surprisingly clean, a testament to Lizaveta's diligent work. The walls are covered in cheap, yellow wallpaper. Simple muslin curtains hang over the windows, which look out onto the courtyard. Pots of geraniums line the windowsills, adding a touch of incongruous life to the otherwise severe room. The main room contains a sofa with a high wooden back, a round table, a chest of drawers, and a few chairs. The air is usually thick with the smell of whatever Alyona is cooking or the general scent of old belongings. Despite the cleanliness, there's an underlying sense of tension and suspicion, largely emanating from the old pawnbroker herself.",
-        "exits": {"Pawnbroker's Apartment Building": "Turn your back on the scene and leave the apartment, returning to the stairwell."},
-        "items_present": [{"name": "Lizaveta's bundle", "quantity": 1}]
+        "exits": {
+            "Pawnbroker's Apartment Building": "Turn your back on the scene and leave the apartment, returning to the stairwell."
+        },
+        "items_present": [
+            {
+                "name": "lizaveta's bundle",
+                "quantity": 1
+            }
+        ]
     },
     "Voznesensky Bridge": {
         "description": "Standing on the Voznesensky Bridge, you feel the city's pulse around you, yet also a strange sense of detachment. The wide expanse of the murky canal flows beneath, its dark waters reflecting the grey St. Petersburg sky. Horse-drawn carts rattle across the cobblestones, and pedestrians hurry past, wrapped in their own concerns. It's a place of transit, but also one for contemplation, where the vastness of the city and the weight of one's thoughts can feel overwhelming.",
-        "exits": {"Haymarket Square": "Leave the bridge's exposed expanse and walk back towards the chaotic embrace of Haymarket Square."},
+        "exits": {
+            "Haymarket Square": "Leave the bridge's exposed expanse and walk back towards the chaotic embrace of Haymarket Square."
+        },
         "items_present": [],
-         "time_effects": {
+        "time_effects": {
             "Evening": " Gas lamps along the bridge cast long, wavering reflections on the dark water below."
         }
     },
     "Pulcheria's Lodgings": {
         "description": "The rented rooms where Pulcheria Alexandrovna and Dunya are staying are modest but kept meticulously clean, a stark contrast to Raskolnikov's garret. There's a smell of lavender and old linen. Simple furniture is arranged neatly, and a samovar might be hissing quietly in a corner. Despite the attempt at creating a homely atmosphere, an undercurrent of anxiety and hopeful, almost painful expectation for Rodya pervades the rooms.",
-        "exits": {"Haymarket Square": "Take your leave from the lodgings and head back towards the bustling activity of Haymarket Square."},
+        "exits": {
+            "Haymarket Square": "Take your leave from the lodgings and head back towards the bustling activity of Haymarket Square."
+        },
         "items_present": []
     },
     "Katerina Ivanovna's Apartment": {
-        "description": "A cramped, squalid room, overflowing with the detritus of poverty and shattered pride. Three young children – Polenka, Kolya, and Lida – often huddle in a corner, their eyes wide with fear or hunger. Katerina Ivanovna herself, flushed with fever and consumption, dominates the space with her shrill voice, lamentations, and fits of coughing. The air is stale, thick with the smell of illness, unwashed linen, and cheap tobacco (from Semyon's past presence). It's a scene of utter destitution and unbearable tension.",
+        "description": "A cramped, squalid room, overflowing with the detritus of poverty and shattered pride. Three young children \u2013 Polenka, Kolya, and Lida \u2013 often huddle in a corner, their eyes wide with fear or hunger. Katerina Ivanovna herself, flushed with fever and consumption, dominates the space with her shrill voice, lamentations, and fits of coughing. The air is stale, thick with the smell of illness, unwashed linen, and cheap tobacco (from Semyon's past presence). It's a scene of utter destitution and unbearable tension.",
         "exits": {
             "Haymarket Square": "Escape the suffocating misery and noise, returning to the relative chaos of Haymarket Square.",
             "Sonya's Room": "A short walk takes you to Sonya's slightly less chaotic, but equally sorrowful, room."
-            },
-        "items_present": [{"name": "tattered handkerchief", "quantity": 2}],
+        },
+        "items_present": [
+            {
+                "name": "tattered handkerchief",
+                "quantity": 2
+            }
+        ],
         "time_effects": {
             "Afternoon": " The children might be playing listlessly or crying, while Katerina Ivanovna is often in a state of high agitation.",
             "Evening": " Katerina might be trying to put the children to bed, her voice softer but filled with despair, or she could be loudly berating Sonya if she's present."
@@ -111,14 +165,23 @@
             "Haymarket Square": "Pass back through the archway into the noise of Haymarket Square.",
             "Stairwell (Outside Raskolnikov's Garret)": "Find the passage back to the stairwell of Raskolnikov's tenement building."
         },
-        "items_present": [{"name": "old newspaper", "quantity": 1}, {"name": "worn coin", "quantity": 1}],
+        "items_present": [
+            {
+                "name": "old newspaper",
+                "quantity": 1
+            },
+            {
+                "name": "worn coin",
+                "quantity": 1
+            }
+        ],
         "time_effects": {
             "Afternoon": " Shadows from the tall tenements stretch long across the cobblestones, deepening the sense of seclusion.",
             "Night": " The courtyard is very dark, only faint light spills from distant windows, making it feel somewhat eerie."
         }
     },
-    "Svidrigaïlov's Lodging": {
-        "description": "Svidrigaïlov has taken rooms in a quiet, somewhat secluded part of the same building as Sonya's, though his are more spacious and less overtly squalid. The main feature of note is that his rooms adjoin Sonya's through a thin wall, and it is known he can, and does, listen to conversations in her room from an empty, connecting chamber he also rents. The air here often feels heavy with his cynical amusement and unspoken intentions. The furnishings are adequate but unremarkable, betraying little of the man's true nature beyond a desire for basic comfort and privacy.",
+    "Svidriga\u00eflov's Lodging": {
+        "description": "Svidriga\u00eflov has taken rooms in a quiet, somewhat secluded part of the same building as Sonya's, though his are more spacious and less overtly squalid. The main feature of note is that his rooms adjoin Sonya's through a thin wall, and it is known he can, and does, listen to conversations in her room from an empty, connecting chamber he also rents. The air here often feels heavy with his cynical amusement and unspoken intentions. The furnishings are adequate but unremarkable, betraying little of the man's true nature beyond a desire for basic comfort and privacy.",
         "exits": {
             "Sonya's Room": "A door that presumably leads to a common hallway or area near Sonya's room.",
             "Haymarket Square": "Descend to the street and make your way back to the bustle of Haymarket Square."

--- a/game_engine/event_manager.py
+++ b/game_engine/event_manager.py
@@ -1,6 +1,6 @@
 # event_manager.py
 import random
-from .game_config import (Colors, DEFAULT_ITEMS,
+from .game_config import (Colors, DEFAULT_ITEMS, DEBUG_LOGS,
                          STATIC_PLAYER_REFLECTIONS, STATIC_ANONYMOUS_NOTE_CONTENT,
                          STATIC_STREET_LIFE_EVENTS, STATIC_NPC_NPC_INTERACTIONS)
 
@@ -191,13 +191,13 @@ class EventManager:
             event_desc = f"Tucked into your doorframe (or perhaps slipped under your door), you find a hastily folded piece of paper. It's an anonymous note."
             self._print_event(event_desc)
             
-            # Create the "Anonymous Note" item instance with this specific content
+            # Create the "anonymous note" item instance with this specific content
             # Option 1: Add to location (player must then take it)
-            note_item_instance = {"name": "Anonymous Note", "quantity": 1, "generated_content": note_text}
-            # Ensure the base "Anonymous Note" is in DEFAULT_ITEMS with readable=True
-            if "Anonymous Note" in DEFAULT_ITEMS:
+            note_item_instance = {"name": "anonymous note", "quantity": 1, "generated_content": note_text}
+            # Ensure the base "anonymous note" is in DEFAULT_ITEMS with readable=True
+            if "anonymous note" in DEFAULT_ITEMS:
                 self.game.dynamic_location_items.setdefault(self.game.current_location_name, []).append(note_item_instance)
-                self.game._print_color(f"An {Colors.GREEN}Anonymous Note{Colors.RESET} appears on the floor.", Colors.YELLOW) # Changed self to self.game
+                self.game._print_color(f"An {Colors.GREEN}anonymous note{Colors.RESET} appears on the floor.", Colors.YELLOW) # Changed self to self.game
                 self.game.player_character.add_journal_entry("Note Found", f"Found an anonymous note: {note_text[:30]}...", self.game._get_current_game_time_period_str())
 
             else: # Fallback if item not defined well
@@ -250,7 +250,8 @@ class EventManager:
 
     def check_and_trigger_events(self):
         if self.game.game_time % 50 == 0: # Cooldown reset periodically
-            print(f"[DEBUG] EventManager: Checking event cooldowns at game time {self.game.game_time}")
+            if DEBUG_LOGS:
+                print(f"[DEBUG] EventManager: Checking event cooldowns at game time {self.game.game_time}")
             events_to_remove = {ev for ev in self.triggered_events if ev.endswith("_recent")}
             for ev_rem in events_to_remove: self.triggered_events.remove(ev_rem)
 

--- a/game_engine/game_config.py
+++ b/game_engine/game_config.py
@@ -25,6 +25,7 @@ DREAM_CHANCE_TROUBLED_STATE = 0.35 # Chance if feverish, agitated etc. on new da
 RUMOR_CHANCE_PER_NPC_INTERACTION = 0.15 # Chance an NPC shares a rumor during dialogue
 AMBIENT_RUMOR_CHANCE_PUBLIC_PLACE = 0.05 # Chance to overhear ambient rumor in public
 NPC_SHARE_RUMOR_MIN_RELATIONSHIP = -2 # NPC won't share rumors if relationship is too low
+DEBUG_LOGS = False
 
 # --- Phrases that might indicate a natural end to a conversation ---
 CONCLUDING_PHRASES = [
@@ -104,8 +105,8 @@ SEPARATOR_LINE = Colors.DIM + ("-" * 60) + Colors.RESET
 
 # --- NPC Memory Configuration ---
 HIGHLY_NOTABLE_ITEMS_FOR_MEMORY = [
-    "Raskolnikov's axe", "bloodied rag", "Lizaveta's bundle",
-    "Sonya's Cypress Cross", "Sonya's New Testament", "mother's letter"
+    "raskolnikov's axe", "bloodied rag", "lizaveta's bundle",
+    "sonya's cypress cross", "sonya's new testament", "mother's letter"
 ]
 
 # --- Generic Scenery Keywords (for "look at scenery") ---

--- a/tests/test_game_logic.py
+++ b/tests/test_game_logic.py
@@ -35,9 +35,9 @@ TEST_ITEMS_FOR_LOOK = {
 
 TEST_GAME_ITEMS = { # For TestItemEffects
     "tattered handkerchief": {"description": "A worn piece of cloth.", "use_effect_player": "comfort_self_if_ill"},
-    "Raskolnikov's axe": {"description": "A weighty axe.", "use_effect_player": "grip_axe_and_reminisce_horror"},
+    "raskolnikov's axe": {"description": "A weighty axe.", "use_effect_player": "grip_axe_and_reminisce_horror"},
     "cheap vodka": {"description": "A bottle of cheap spirits.", "use_effect_player": "drink_vodka_for_oblivion", "consumable": True, "stackable": True},
-    "Fresh Newspaper": {"description": "Today's news.", "readable": True, "use_effect_player": "read_evolving_news_article"},
+    "fresh newspaper": {"description": "Today's news.", "readable": True, "use_effect_player": "read_evolving_news_article"},
     "mother's letter": {"description": "A letter from Pulcheria.", "readable": True, "use_effect_player": "reread_letter_and_feel_familial_pressure"},
 }
 
@@ -683,8 +683,8 @@ class TestItemEffects(unittest.TestCase):
 
     def test_use_raskolnikovs_axe_as_raskolnikov(self):
         self.player.name = "Rodion Raskolnikov"
-        self.player.inventory.append({"name": "Raskolnikov's axe", "quantity": 1})
-        self.game.handle_use_item("Raskolnikov's axe", None, "use_self_implicit")
+        self.player.inventory.append({"name": "raskolnikov's axe", "quantity": 1})
+        self.game.handle_use_item("raskolnikov's axe", None, "use_self_implicit")
         self.assertIn(self.player.apparent_state, ["dangerously agitated", "remorseful", "paranoid"])
 
     def test_use_cheap_vodka(self):
@@ -702,10 +702,10 @@ class TestItemEffects(unittest.TestCase):
         self.game._print_color.assert_any_call("The vodka clashes terribly with your fever, making you feel worse.", Colors.RED)
 
     def test_read_newspaper(self):
-        self.player.inventory.append({"name": "Fresh Newspaper", "quantity": 1})
+        self.player.inventory.append({"name": "fresh newspaper", "quantity": 1})
         self.player.add_journal_entry = MagicMock()
         self.game.gemini_api.get_newspaper_article_snippet = MagicMock(return_value="A terrible crime was reported...")
-        self.game.handle_use_item("Fresh Newspaper", None, "read")
+        self.game.handle_use_item("fresh newspaper", None, "read")
         self.game.gemini_api.get_newspaper_article_snippet.assert_called_once()
         self.player.add_journal_entry.assert_called_once_with("News (AI)", "A terrible crime was reported...", "Day 1, Morning") # Updated "News" to "News (AI)"
         self.assertEqual(self.player.apparent_state, "thoughtful")
@@ -901,7 +901,7 @@ TEST_LOC_DATA_FOR_LOW_AI = {
 }
 # Mock DEFAULT_ITEMS for TestLowAIMode (especially for anonymous note)
 TEST_DEFAULT_ITEMS_LOW_AI = {
-    "Anonymous Note": {"description": "A mysterious note.", "readable": True, "takeable": True}
+    "anonymous note": {"description": "A mysterious note.", "readable": True, "takeable": True}
 }
 
 
@@ -1026,11 +1026,11 @@ class TestLowAIMode(unittest.TestCase):
         # For now, we just ensure the primary AI call is skipped. A more robust test would check base_desc.
 
     @patch('game_engine.game_state.DEFAULT_ITEMS', {
-        "Fresh Newspaper": {"description": "Today's news.", "readable": True}
+        "fresh newspaper": {"description": "Today's news.", "readable": True}
     })
     def test_read_newspaper_low_ai_mode(self):
         self.game.low_ai_data_mode = True
-        self.game.player_character.inventory = [{"name": "Fresh Newspaper", "quantity": 1}]
+        self.game.player_character.inventory = [{"name": "fresh newspaper", "quantity": 1}]
         self.game.gemini_api.get_newspaper_article_snippet = MagicMock()
 
         expected_snippet = "The headlines are dull today."
@@ -1039,7 +1039,7 @@ class TestLowAIMode(unittest.TestCase):
         # Ensure the item exists in player's inventory for _handle_read_item
         # The _handle_read_item is called from handle_use_item
         with patch('game_engine.game_state.STATIC_NEWSPAPER_SNIPPETS', [expected_snippet, "Other news."]):
-             self.game.handle_use_item("Fresh Newspaper", None, "read") # Correct way to trigger _handle_read_item
+             self.game.handle_use_item("fresh newspaper", None, "read") # Correct way to trigger _handle_read_item
 
         # Static newspaper snippets are printed with YELLOW in the current implementation if AI was not attempted
         # but if low_ai_data_mode is true, it's CYAN.
@@ -1076,11 +1076,11 @@ class TestLowAIMode(unittest.TestCase):
         # Check that the static content was used to create the note
         found_note = False
         for item_data in self.game.dynamic_location_items.get(self.game.current_location_name, []):
-            if item_data["name"] == "Anonymous Note":
+            if item_data["name"] == "anonymous note":
                 self.assertEqual(item_data.get("generated_content"), STATIC_ANONYMOUS_NOTE_CONTENT)
                 found_note = True
                 break
-        self.assertTrue(found_note, "Anonymous Note with static content should be created.")
+        self.assertTrue(found_note, "anonymous note with static content should be created.")
         self.game.gemini_api.get_generated_text_document.assert_not_called()
 
     def test_event_attempt_npc_npc_interaction_low_ai_mode(self):


### PR DESCRIPTION
### Motivation
- Prevent mismatches between data and code by normalizing item keys to lowercase across `data/` and code paths. 
- Reduce noisy developer output and make debug logs opt-in so normal runs are cleaner. 
- Make user commands and movement more forgiving by improving prefix matching, exit ambiguity handling and offering suggestions for unknown commands. 
- Make the Gemini integration robust when the optional client library or key/model setup is unavailable and surface data inconsistencies early. 

### Description
- Normalized item keys to lowercase in `data/items.json` and updated all references in `data/locations.json`, `data/characters.json`, tests and code, and updated `HIGHLY_NOTABLE_ITEMS_FOR_MEMORY` accordingly. 
- Consolidated item/NPC/exit matching and ambiguity resolution by adding helper methods: `_resolve_prefix_match`, `_get_matching_location_item`, `_get_matching_inventory_item`, `_get_matching_npc`, and `_get_matching_exit` in `game_engine/game_state.py`. 
- Centralized item inspection into `_inspect_item` and `_display_item_properties`, added `_get_command_suggestions` to suggest close command matches, and added `_validate_item_data` to check for missing `DEFAULT_ITEMS` and invalid `hidden_in_location` references. 
- Made debug prints conditional on the shared `DEBUG_LOGS` flag and gated noisy messages in `game_engine/character_module.py` and `game_engine/event_manager.py`. 
- Improved movement and talk flows to use the new matching helpers and display clear ambiguity prompts for exits and NPCs in `game_engine/game_state.py`. 
- Softened Gemini dependency handling by lazily loading `google.generativeai` in `game_engine/gemini_interactions.py`, showing the missing-library warning only once, and gracefully falling back to static placeholders when the library/key/model are unavailable. 
- Updated `game_engine/event_manager.py` to create and reference the lowercase `anonymous note` item and adjusted test fixtures in `tests/test_game_logic.py` to match the new keys. 

### Testing
- Ran the full unit test suite with `pytest -q`; all tests passed: `87 passed, 2 warnings`. 
- The warnings are environment/client related deprecation notices for the Google client and do not affect test outcomes. 
- Manual sanity checks included running the game initialization path to ensure `._validate_item_data()` prints no fatal errors with the updated data.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988fc4d7050832582e3c2035f716cae)