### PR TITLE
Include `psychology` in Character serialization tests and align Gemini model tests

### DIFF
--- a/tests/test_character_module.py
+++ b/tests/test_character_module.py
@@ -38,8 +38,19 @@ class TestCharacterModule(unittest.TestCase):
             "objectives": [],
             "inventory": [],
             "apparent_state": "normal",
+            "psychology": {"suspicion": 0, "fear": 0, "respect": 50},
         }
         self.assertEqual(char_dict, expected_dict)
+
+    def test_to_dict_includes_custom_psychology(self):
+        self.character.psychology = {"suspicion": 35, "fear": 10, "respect": 65}
+
+        char_dict = self.character.to_dict()
+
+        self.assertEqual(
+            char_dict["psychology"],
+            {"suspicion": 35, "fear": 10, "respect": 65}
+        )
 
     def test_from_dict(self):
         char_data = {

--- a/tests/test_game_logic.py
+++ b/tests/test_game_logic.py
@@ -11,7 +11,7 @@ if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
 from game_engine.character_module import Character
-from game_engine.gemini_interactions import GeminiAPI
+from game_engine.gemini_interactions import GeminiAPI, DEFAULT_GEMINI_MODEL_NAME
 from game_engine.game_state import Game
 from game_engine.event_manager import EventManager
 from game_engine.game_config import Colors, TIME_UNITS_PER_PLAYER_ACTION, TIME_UNITS_FOR_NPC_SCHEDULE_UPDATE, MAX_TIME_UNITS_PER_DAY, NPC_MOVE_CHANCE, TIME_PERIODS
@@ -64,7 +64,6 @@ TEST_SCHEDULED_NPC_DATA = {
         "schedule": {}
     }
 }
-
 
 class TestInventoryDescription(unittest.TestCase):
     def setUp(self):
@@ -1258,8 +1257,8 @@ class TestGeminiAPIConfiguration(unittest.TestCase):
         # Check that the correct model options were printed
         model_prompt_calls = [args[0] for args, _ in self.mock_print_func.call_args_list if args and isinstance(args[0], str)]
 
-        self.assertTrue(any("Gemini 2.5 Pro (Default) (ID: gemini-2.5-pro)" in call for call in model_prompt_calls))
-        self.assertTrue(any("Gemini Flash Latest (ID: gemini-flash-latest)" in call for call in model_prompt_calls))
+        self.assertTrue(any("Gemini 3 Pro Preview (Default) (ID: gemini-3-pro-preview)" in call for call in model_prompt_calls))
+        self.assertTrue(any("Gemini 3 Flash Preview (ID: gemini-3-flash-preview)" in call for call in model_prompt_calls))
 
         # Check that the input prompt was for choices 1-2
         input_prompt_found = False
@@ -1270,7 +1269,7 @@ class TestGeminiAPIConfiguration(unittest.TestCase):
                 break
         self.assertTrue(input_prompt_found, "Input prompt for 1-2 choices not found.")
 
-        self.assertEqual(self.api.chosen_model_name, 'gemini-2.5-pro')
+        self.assertEqual(self.api.chosen_model_name, DEFAULT_GEMINI_MODEL_NAME)
 
     def test_configure_select_first_model_successfully(self):
         self.mock_os_getenv.return_value = None # No ENV key
@@ -1279,8 +1278,8 @@ class TestGeminiAPIConfiguration(unittest.TestCase):
         self.mock_input_func.side_effect = ["dummy_manual_key", "1", "n", "n"]
 
         self.api.configure(self.mock_print_func, self.mock_input_func)
-        self.assertEqual(self.api.chosen_model_name, 'gemini-2.5-pro')
-        self.mock_attempt_api_setup.assert_called_with("dummy_manual_key", "user input", 'gemini-2.5-pro')
+        self.assertEqual(self.api.chosen_model_name, 'gemini-3-pro-preview')
+        self.mock_attempt_api_setup.assert_called_with("dummy_manual_key", "user input", 'gemini-3-pro-preview')
 
     def test_configure_successful_api_setup_prompts_low_ai_mode_yes(self):
         # Simulate manual API key input path


### PR DESCRIPTION
### Motivation
- Tests were failing due to a change in `Character.to_dict()` exposing the `psychology` field and due to updated Gemini model defaults/labels in the API configuration flow.
- Update the test expectations so they reflect the current runtime behavior and constants in the codebase.
- Keep model-selection tests resilient to `DEFAULT_GEMINI_MODEL_NAME` changes.

### Description
- Updated `tests/test_character_module.py` to include the `psychology` field in the expected output of `Character.to_dict()` and added `test_to_dict_includes_custom_psychology` to verify custom psychology values are preserved.
- Updated `tests/test_game_logic.py` to import `DEFAULT_GEMINI_MODEL_NAME` and to expect the current Gemini model display names/IDs (`gemini-3-pro-preview` and `gemini-3-flash-preview`) in the configuration prompts.
- Adjusted one assertion to compare `self.api.chosen_model_name` against `DEFAULT_GEMINI_MODEL_NAME` to make the test robust to future default changes.

### Testing
- Ran the full test suite with `pytest -q` and verified all tests pass.
- Result: `88 passed` (with 2 unrelated deprecation/future warnings from external Google libraries).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e3ef0b4dc83258a8d5f581334387d)