### PR TITLE
Migrate Gemini integration to google.genai client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-google-generativeai
+google-genai
 blessed

--- a/tests/test_game_logic.py
+++ b/tests/test_game_logic.py
@@ -138,8 +138,8 @@ class TestInventoryDescription(unittest.TestCase):
 
 class TestGeminiDialogueQuotes(unittest.TestCase):
     def setUp(self):
-        self.mock_genai_configure = patch('google.generativeai.configure').start()
-        self.mock_generative_model_cls = patch('google.generativeai.GenerativeModel').start()
+        self.mock_genai_configure = MagicMock()
+        self.mock_generative_model_cls = MagicMock()
 
         self.api = GeminiAPI()
         self.api.model = MagicMock()
@@ -1218,6 +1218,9 @@ class TestGeminiAPIConfiguration(unittest.TestCase):
         # Patch methods within the GeminiAPI instance or its module
         self.patch_attempt_api_setup = patch.object(self.api, '_attempt_api_setup')
         self.mock_attempt_api_setup = self.patch_attempt_api_setup.start()
+
+        self.patch_load_genai = patch.object(self.api, '_load_genai', return_value=True)
+        self.mock_load_genai = self.patch_load_genai.start()
 
         self.patch_os_path_exists = patch('game_engine.gemini_interactions.os.path.exists')
         self.mock_os_path_exists = self.patch_os_path_exists.start()


### PR DESCRIPTION
### Motivation
- The prior `google.generativeai` package is deprecated and the codebase must use the new `google.genai` client so runtime calls and installs are up-to-date.
- Keep existing `generate_content(...)` callsites working with minimal changes while switching to the new client interface.

### Description
- Replaced runtime imports and detection from `google.generativeai` to `google.genai` and added a `client` attribute to `GeminiAPI` to hold `genai.Client` instances.
- Introduced a small `_GeminiModelAdapter` wrapper that exposes `generate_content(prompt, ...)` and forwards calls to `client.models.generate_content(...)` so existing callsites remain unchanged.
- Updated `_attempt_api_setup` to initialize `genai.Client(api_key=...)` instead of calling `genai.configure(...)`, and adjusted verification to use the adapter and dict-based generation config.
- Updated intent-model selection and generation calls to pass simple dict configs and to use the adapter when a `client` is available; updated `requirements.txt` to `google-genai` and tweaked tests to stop patching removed `google.generativeai` symbols and to mock `_load_genai` where needed.

### Testing
- Ran targeted test commands `pytest -q tests/test_gemini_interactions.py tests/test_game_logic.py` which initially surfaced failures during migration and were resolved by adapting the test patches and config flow, and re-running fixed remaining issues.
- Ran full suite with `pytest -q` and observed all tests passing: `98 passed` (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997067a683483259851da65832d9e12)