### PR TITLE
fix: resolve remaining lint findings and cleanup test imports

### DIFF
--- a/game_engine/character_module.py
+++ b/game_engine/character_module.py
@@ -3,42 +3,66 @@ import random
 import copy
 import logging
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 from .game_config import DEBUG_LOGS
+
 
 def load_characters_data(data_path=None):
     from .game_config import get_data_path
+
     if data_path is None:
-        data_path = get_data_path('data/characters.json')
+        data_path = get_data_path("data/characters.json")
     """Loads character data from a JSON file."""
     try:
-        with open(data_path, 'r', encoding='utf-8') as f:
+        with open(data_path, "r", encoding="utf-8") as f:
             return json.load(f)
     except FileNotFoundError:
         logging.error(f"Error: The characters data file was not found at {data_path}")
         return {}
     except json.JSONDecodeError:
-        logging.error(f"Error: The characters data file at {data_path} is not a valid JSON.")
+        logging.error(
+            f"Error: The characters data file at {data_path} is not a valid JSON."
+        )
         return {}
+
 
 CHARACTERS_DATA = load_characters_data()
 
+
 class Character:
-    def __init__(self, name, persona, greeting, default_location, accessible_locations,
-                 objectives=None, inventory_items=None, schedule=None, npc_relationships=None, skills_data=None,
-                 psychology=None, is_player=False):
+    def __init__(
+        self,
+        name,
+        persona,
+        greeting,
+        default_location,
+        accessible_locations,
+        objectives=None,
+        inventory_items=None,
+        schedule=None,
+        npc_relationships=None,
+        skills_data=None,
+        psychology=None,
+        is_player=False,
+    ):
         self.name = name
         self.persona = persona
         self.greeting = greeting
         self.default_location = default_location
         self.current_location = default_location
-        self.accessible_locations = accessible_locations if accessible_locations is not None else [default_location]
+        self.accessible_locations = (
+            accessible_locations
+            if accessible_locations is not None
+            else [default_location]
+        )
         self.is_player = is_player
         self.conversation_histories = {}
         self.memory_about_player = []  # List of dictionaries
-        self.journal_entries = [] 
+        self.journal_entries = []
         self.relationship_with_player = 0
-        self.npc_relationships = copy.deepcopy(npc_relationships) if npc_relationships is not None else {}
+        self.npc_relationships = (
+            copy.deepcopy(npc_relationships) if npc_relationships is not None else {}
+        )
         self.skills = copy.deepcopy(skills_data) if skills_data is not None else {}
         default_psychology = {"suspicion": 0, "fear": 0, "respect": 50}
         if psychology is None:
@@ -47,16 +71,22 @@ class Character:
             merged_psychology = copy.deepcopy(default_psychology)
             merged_psychology.update(psychology)
             self.psychology = merged_psychology
-        
+
         self.objectives = []
         if objectives:
             for obj_template in objectives:
                 obj = copy.deepcopy(obj_template)
                 obj["completed"] = obj.get("completed", False)
-                obj["active"] = obj.get("active", True) 
+                obj["active"] = obj.get("active", True)
                 if "stages" not in obj or not obj["stages"]:
-                    obj["stages"] = [{"stage_id": "default", "description": "Initial state of objective.", "is_current_stage": True}]
-                
+                    obj["stages"] = [
+                        {
+                            "stage_id": "default",
+                            "description": "Initial state of objective.",
+                            "is_current_stage": True,
+                        }
+                    ]
+
                 current_stage_id_present = "current_stage_id" in obj
                 current_stage_is_valid = False
                 if current_stage_id_present:
@@ -66,27 +96,29 @@ class Character:
                             current_stage_is_valid = True
                         else:
                             stage["is_current_stage"] = False
-                
+
                 if not current_stage_id_present or not current_stage_is_valid:
-                    if obj["stages"]: 
+                    if obj["stages"]:
                         obj["current_stage_id"] = obj["stages"][0].get("stage_id")
                         obj["stages"][0]["is_current_stage"] = True
-                    else: 
+                    else:
                         obj["current_stage_id"] = "default"
 
                 self.objectives.append(obj)
 
-
-        self.inventory = [copy.deepcopy(item) for item in inventory_items] if inventory_items else []
+        self.inventory = (
+            [copy.deepcopy(item) for item in inventory_items] if inventory_items else []
+        )
         self.schedule = schedule if schedule else {}
-        self.apparent_state = CHARACTERS_DATA.get(name, {}).get("apparent_state", "normal")
-
+        self.apparent_state = CHARACTERS_DATA.get(name, {}).get(
+            "apparent_state", "normal"
+        )
 
     def add_journal_entry(self, entry_type, text_content, game_day_time_period_str):
-        MAX_JOURNAL_ENTRIES = 20 
+        MAX_JOURNAL_ENTRIES = 20
         if len(self.journal_entries) >= MAX_JOURNAL_ENTRIES:
-            self.journal_entries.pop(0) 
-        
+            self.journal_entries.pop(0)
+
         entry = f"({game_day_time_period_str}) [{entry_type.upper()}]: {text_content}"
         self.journal_entries.append(entry)
 
@@ -95,7 +127,6 @@ class Character:
             return "Journal is empty."
         return "\nRecent Journal Entries:\n" + "\n".join(self.journal_entries[-count:])
 
-
     def to_dict(self) -> Dict[str, Any]:
         return {
             "name": self.name,
@@ -103,7 +134,7 @@ class Character:
             "is_player": self.is_player,
             "conversation_histories": self.conversation_histories,
             "memory_about_player": self.memory_about_player,
-            "journal_entries": self.journal_entries, 
+            "journal_entries": self.journal_entries,
             "relationship_with_player": self.relationship_with_player,
             "npc_relationships": self.npc_relationships,
             "skills": self.skills,
@@ -114,30 +145,38 @@ class Character:
         }
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any], static_char_data: Optional[Dict[str, Any]]) -> 'Character':
+    def from_dict(
+        cls, data: Dict[str, Any], static_char_data: Optional[Dict[str, Any]]
+    ) -> "Character":
         static_char_data_safe = static_char_data if static_char_data is not None else {}
-        
+
         char = cls(
-            name=data["name"], 
+            name=data["name"],
             persona=static_char_data_safe.get("persona", "A mysterious figure."),
             greeting=static_char_data_safe.get("greeting", "Hello."),
-            default_location=static_char_data_safe.get("default_location", "Unknown Location"),
+            default_location=static_char_data_safe.get(
+                "default_location", "Unknown Location"
+            ),
             accessible_locations=static_char_data_safe.get("accessible_locations", []),
-            objectives=[], 
-            inventory_items=data.get("inventory", []), 
+            objectives=[],
+            inventory_items=data.get("inventory", []),
             schedule=static_char_data_safe.get("schedule", {}),
-            npc_relationships=static_char_data_safe.get("npc_relationships", {}), 
+            npc_relationships=static_char_data_safe.get("npc_relationships", {}),
             skills_data=static_char_data_safe.get("skills", {}),
             psychology=static_char_data_safe.get("psychology"),
-            is_player=data.get("is_player", False) 
+            is_player=data.get("is_player", False),
         )
-        
+
         char.current_location = data.get("current_location", char.default_location)
         char.conversation_histories = data.get("conversation_histories", {})
-        char.memory_about_player = data.get("memory_about_player", []) # Ensures backward compatibility
-        char.journal_entries = data.get("journal_entries", []) 
+        char.memory_about_player = data.get(
+            "memory_about_player", []
+        )  # Ensures backward compatibility
+        char.journal_entries = data.get("journal_entries", [])
         char.relationship_with_player = data.get("relationship_with_player", 0)
-        char.apparent_state = data.get("apparent_state", static_char_data_safe.get("apparent_state", "normal"))
+        char.apparent_state = data.get(
+            "apparent_state", static_char_data_safe.get("apparent_state", "normal")
+        )
         saved_psychology = data.get("psychology")
         if saved_psychology is not None:
             merged_psychology = copy.deepcopy(char.psychology)
@@ -147,62 +186,98 @@ class Character:
         saved_npc_relationships = data.get("npc_relationships")
         if saved_npc_relationships is not None:
             char.npc_relationships = saved_npc_relationships
-        
+
         saved_skills = data.get("skills")
         if saved_skills is not None:
             char.skills = saved_skills
 
-        loaded_objectives_map = {obj['id']: obj for obj in data.get("objectives", []) if 'id' in obj}
+        loaded_objectives_map = {
+            obj["id"]: obj for obj in data.get("objectives", []) if "id" in obj
+        }
         static_objectives_template = static_char_data_safe.get("objectives", [])
-        
+
         final_objectives_list = []
         if static_objectives_template:
             for static_obj_template_item in static_objectives_template:
                 obj_id = static_obj_template_item.get("id")
-                if not obj_id: continue
+                if not obj_id:
+                    continue
 
-                final_obj = copy.deepcopy(static_obj_template_item) 
+                final_obj = copy.deepcopy(static_obj_template_item)
 
-                if obj_id in loaded_objectives_map: 
+                if obj_id in loaded_objectives_map:
                     loaded_obj_data = loaded_objectives_map[obj_id]
-                    final_obj["completed"] = loaded_obj_data.get("completed", final_obj.get("completed", False))
-                    final_obj["active"] = loaded_obj_data.get("active", final_obj.get("active", True))
-                    final_obj["current_stage_id"] = loaded_obj_data.get("current_stage_id", final_obj.get("current_stage_id"))
+                    final_obj["completed"] = loaded_obj_data.get(
+                        "completed", final_obj.get("completed", False)
+                    )
+                    final_obj["active"] = loaded_obj_data.get(
+                        "active", final_obj.get("active", True)
+                    )
+                    final_obj["current_stage_id"] = loaded_obj_data.get(
+                        "current_stage_id", final_obj.get("current_stage_id")
+                    )
 
                 if "stages" in final_obj and final_obj["stages"]:
                     current_stage_id_found_in_stages = False
                     for stage_in_final_obj in final_obj["stages"]:
-                        is_current = (stage_in_final_obj.get("stage_id") == final_obj.get("current_stage_id"))
+                        is_current = stage_in_final_obj.get(
+                            "stage_id"
+                        ) == final_obj.get("current_stage_id")
                         stage_in_final_obj["is_current_stage"] = is_current
                         if is_current:
                             current_stage_id_found_in_stages = True
                     if not current_stage_id_found_in_stages and final_obj["stages"]:
-                        saved_stage_id = final_obj.get("current_stage_id") # Get the saved stage ID before defaulting
+                        saved_stage_id = final_obj.get(
+                            "current_stage_id"
+                        )  # Get the saved stage ID before defaulting
                         objective_id = final_obj.get("id", "Unknown Objective")
                         logging.warning(
                             f"Warning: Saved objective stage ID '{saved_stage_id}' for objective '{objective_id}' "
                             f"not found in current game data. Defaulting to first stage."
                         )
-                        final_obj["current_stage_id"] = final_obj["stages"][0].get("stage_id")
+                        final_obj["current_stage_id"] = final_obj["stages"][0].get(
+                            "stage_id"
+                        )
                         final_obj["stages"][0]["is_current_stage"] = True
                 elif "stages" not in final_obj or not final_obj.get("stages"):
-                     final_obj["stages"] = [{"stage_id": "default", "description": "Objective state.", "is_current_stage": True}]
-                     final_obj["current_stage_id"] = "default"
+                    final_obj["stages"] = [
+                        {
+                            "stage_id": "default",
+                            "description": "Objective state.",
+                            "is_current_stage": True,
+                        }
+                    ]
+                    final_obj["current_stage_id"] = "default"
 
                 final_objectives_list.append(final_obj)
-        
+
         for loaded_id, loaded_obj_val in loaded_objectives_map.items():
-            if not any(fo.get('id') == loaded_id for fo in final_objectives_list):
-                loaded_obj_val["stages"] = loaded_obj_val.get("stages", [{"stage_id": "default", "description": "Legacy objective state.", "is_current_stage": True}])
-                if "current_stage_id" not in loaded_obj_val and loaded_obj_val.get("stages"):
-                    loaded_obj_val["current_stage_id"] = loaded_obj_val["stages"][0].get("stage_id")
-                if loaded_obj_val.get("stages"): 
+            if not any(fo.get("id") == loaded_id for fo in final_objectives_list):
+                loaded_obj_val["stages"] = loaded_obj_val.get(
+                    "stages",
+                    [
+                        {
+                            "stage_id": "default",
+                            "description": "Legacy objective state.",
+                            "is_current_stage": True,
+                        }
+                    ],
+                )
+                if "current_stage_id" not in loaded_obj_val and loaded_obj_val.get(
+                    "stages"
+                ):
+                    loaded_obj_val["current_stage_id"] = loaded_obj_val["stages"][
+                        0
+                    ].get("stage_id")
+                if loaded_obj_val.get("stages"):
                     for stage in loaded_obj_val["stages"]:
-                        stage["is_current_stage"] = (stage.get("stage_id") == loaded_obj_val.get("current_stage_id"))
+                        stage["is_current_stage"] = stage.get(
+                            "stage_id"
+                        ) == loaded_obj_val.get("current_stage_id")
                 loaded_obj_val["active"] = loaded_obj_val.get("active", True)
                 loaded_obj_val["completed"] = loaded_obj_val.get("completed", False)
                 final_objectives_list.append(loaded_obj_val)
-        
+
         char.objectives = final_objectives_list
         return char
 
@@ -220,38 +295,45 @@ class Character:
             updated_value = max(0, min(100, current_value + delta_value))
             self.psychology[stat_name] = updated_value
             if DEBUG_LOGS:
-                print(f"[DEBUG] {self.name} psychology '{stat_name}' changed by {delta_value} -> {updated_value}")
+                print(
+                    f"[DEBUG] {self.name} psychology '{stat_name}' changed by {delta_value} -> {updated_value}"
+                )
 
     def add_to_inventory(self, item_name, quantity=1):
         from .game_config import DEFAULT_ITEMS
+
         if item_name not in DEFAULT_ITEMS:
             return False
 
         item_props = DEFAULT_ITEMS[item_name]
-        is_stackable = item_props.get("stackable", False) or item_props.get("value") is not None
+        is_stackable = (
+            item_props.get("stackable", False) or item_props.get("value") is not None
+        )
 
         for item in self.inventory:
             if item["name"] == item_name:
                 if is_stackable:
                     item["quantity"] = item.get("quantity", 1) + quantity
                     return True
-                else: 
-                    return False 
+                else:
+                    return False
 
         new_item_entry = {"name": item_name}
         if is_stackable:
             new_item_entry["quantity"] = quantity
-        elif quantity > 1: 
-            pass 
+        elif quantity > 1:
+            pass
 
-        self.inventory.append(new_item_entry) 
+        self.inventory.append(new_item_entry)
         return True
-
 
     def remove_from_inventory(self, item_name, quantity=1):
         from .game_config import DEFAULT_ITEMS
+
         item_props = DEFAULT_ITEMS.get(item_name, {})
-        is_stackable = item_props.get("stackable", False) or item_props.get("value") is not None
+        is_stackable = (
+            item_props.get("stackable", False) or item_props.get("value") is not None
+        )
 
         for i, item in enumerate(self.inventory):
             if item["name"] == item_name:
@@ -263,53 +345,65 @@ class Character:
                     elif current_quantity == quantity:
                         self.inventory.pop(i)
                         return True
-                    else: 
+                    else:
                         return False
-                else: 
-                    if quantity == 1: 
+                else:
+                    if quantity == 1:
                         self.inventory.pop(i)
                         return True
-                    else: 
+                    else:
                         return False
-        return False 
+        return False
 
     def has_item(self, item_name, quantity=1):
         from .game_config import DEFAULT_ITEMS
+
         item_props = DEFAULT_ITEMS.get(item_name, {})
-        is_stackable = item_props.get("stackable", False) or item_props.get("value") is not None
+        is_stackable = (
+            item_props.get("stackable", False) or item_props.get("value") is not None
+        )
 
         for item in self.inventory:
             if item["name"] == item_name:
                 if is_stackable:
                     return item.get("quantity", 1) >= quantity
-                else: 
-                    return quantity == 1 
+                else:
+                    return quantity == 1
         return False
 
     def get_notable_carried_items_summary(self):
         from .game_config import DEFAULT_ITEMS
+
         if not self.inventory:
             return "is not carrying anything of note."
         notable_items_list = []
         for item_data in self.inventory:
             item_name = item_data["name"]
             item_props = DEFAULT_ITEMS.get(item_name, {})
-            qty = item_data.get("quantity", 1) if item_props.get("stackable") or item_props.get("value") is not None else 1
+            qty = (
+                item_data.get("quantity", 1)
+                if item_props.get("stackable") or item_props.get("value") is not None
+                else 1
+            )
 
             if item_props.get("is_notable", False):
                 item_str = item_name
-                if (item_props.get("stackable") or item_props.get("value") is not None) and qty > 1:
+                if (
+                    item_props.get("stackable") or item_props.get("value") is not None
+                ) and qty > 1:
                     item_str += f" (x{qty})"
                 notable_items_list.append(item_str)
-            elif item_name == "worn coin" and qty >= item_props.get("notable_threshold", 20): 
-                 notable_items_list.append(f"a sum of money ({qty} coins)")
+            elif item_name == "worn coin" and qty >= item_props.get(
+                "notable_threshold", 20
+            ):
+                notable_items_list.append(f"a sum of money ({qty} coins)")
         if not notable_items_list:
-            return "is not carrying anything of note." # Made consistent
+            return "is not carrying anything of note."  # Made consistent
         if len(notable_items_list) == 1:
             return f"is carrying {notable_items_list[0]}."
         elif len(notable_items_list) == 2:
             return f"is carrying {notable_items_list[0]} and {notable_items_list[1]}."
-        else: 
+        else:
             return f"is carrying {', '.join(notable_items_list[:-1])}, and {notable_items_list[-1]}."
 
     def get_inventory_description(self):
@@ -317,6 +411,7 @@ class Character:
             return "You are carrying nothing."
         descriptions = []
         from .game_config import DEFAULT_ITEMS
+
         for item_data in self.inventory:
             original_item_name = item_data["name"]
             clean_item_name = original_item_name
@@ -330,7 +425,10 @@ class Character:
                     clean_item_name = potential_clean_name
 
             item_props = DEFAULT_ITEMS.get(clean_item_name, {})
-            is_stackable = item_props.get("stackable", False) or item_props.get("value") is not None
+            is_stackable = (
+                item_props.get("stackable", False)
+                or item_props.get("value") is not None
+            )
 
             quantity = 1
             if is_stackable:
@@ -345,16 +443,18 @@ class Character:
     def add_to_history(self, other_char_name, speaker_name, text):
         if other_char_name not in self.conversation_histories:
             self.conversation_histories[other_char_name] = []
-        max_history = 10 
+        max_history = 10
         self.conversation_histories[other_char_name].append(f"{speaker_name}: {text}")
         if len(self.conversation_histories[other_char_name]) > max_history:
-            self.conversation_histories[other_char_name].pop(0) 
+            self.conversation_histories[other_char_name].pop(0)
 
     def get_formatted_history(self, other_char_name, limit=6):
         history = self.conversation_histories.get(other_char_name, [])
         return "\n".join(history[-limit:])
 
-    def add_player_memory(self, memory_type: str, turn: int, content: dict, sentiment_impact: int = 0):
+    def add_player_memory(
+        self, memory_type: str, turn: int, content: dict, sentiment_impact: int = 0
+    ):
         """
         Adds a structured memory about the player.
         memory_type: e.g., "received_item", "dialogue_exchange", "player_action_observed"
@@ -364,7 +464,9 @@ class Character:
         """
         # Basic validation to ensure content is a dictionary
         if not isinstance(content, dict):
-            print(f"Error: Memory content for type '{memory_type}' must be a dictionary. Received: {content}")
+            print(
+                f"Error: Memory content for type '{memory_type}' must be a dictionary. Received: {content}"
+            )
             # Potentially add a default error memory or skip adding this memory
             return
 
@@ -372,13 +474,13 @@ class Character:
             "type": memory_type,
             "turn": turn,
             "content": content,
-            "sentiment_impact": sentiment_impact
+            "sentiment_impact": sentiment_impact,
         }
-        
+
         # Avoid duplicate exact memories if necessary, though turn makes most unique
         # For now, allow all memories to be added.
         self.memory_about_player.append(memory_entry)
-        
+
         MAX_MEMORIES = 30  # Increased slightly
         if len(self.memory_about_player) > MAX_MEMORIES:
             self.memory_about_player.pop(0)
@@ -393,7 +495,7 @@ class Character:
         sorted_memories = sorted(
             self.memory_about_player,
             key=lambda m: (m.get("turn", 0), abs(m.get("sentiment_impact", 0))),
-            reverse=True
+            reverse=True,
         )
 
         summary_parts = []
@@ -416,11 +518,15 @@ class Character:
             if mem_type == "received_item":
                 item_name = content.get("item_name", "an item")
                 qty = content.get("quantity", 1)
-                content_str = f"player gave me {item_name}{f' (x{qty})' if qty > 1 else ''}"
+                content_str = (
+                    f"player gave me {item_name}{f' (x{qty})' if qty > 1 else ''}"
+                )
             elif mem_type == "gave_item_to_player":
                 item_name = content.get("item_name", "an item")
                 qty = content.get("quantity", 1)
-                content_str = f"I gave {item_name}{f' (x{qty})' if qty > 1 else ''} to the player"
+                content_str = (
+                    f"I gave {item_name}{f' (x{qty})' if qty > 1 else ''} to the player"
+                )
             elif mem_type == "dialogue_exchange":
                 player_stmt = content.get("player_statement", "something")
                 topic = content.get("topic_hint", "")
@@ -428,7 +534,7 @@ class Character:
                 if topic:
                     content_str = f"we talked about {topic}"
                     if player_stmt and player_stmt != "...":
-                         content_str += f", and they said '{player_stmt[:50]}...'"
+                        content_str += f", and they said '{player_stmt[:50]}...'"
                 else:
                     content_str = f"player said '{player_stmt[:50]}...'"
                 if sentiment > 0:
@@ -447,26 +553,38 @@ class Character:
                     content_str = f"{action_desc} in {location}"
                 else:
                     content_str = action_desc
-            elif mem_type == "relationship_change": # For direct relationship updates
-                direction = "positively" if content.get("change", 0) > 0 else "negatively"
+            elif mem_type == "relationship_change":  # For direct relationship updates
+                direction = (
+                    "positively" if content.get("change", 0) > 0 else "negatively"
+                )
                 reason = content.get("reason", "something they did or said")
                 content_str = f"my view of them changed {direction} because of {reason}"
-            else: # Fallback for old string memories or unknown types
-                if isinstance(mem, str): # Handle old format
-                    content_str = mem 
-                elif isinstance(content, dict) and "summary" in content: # If new type has a summary
+            else:  # Fallback for old string memories or unknown types
+                if isinstance(mem, str):  # Handle old format
+                    content_str = mem
+                elif (
+                    isinstance(content, dict) and "summary" in content
+                ):  # If new type has a summary
                     content_str = content["summary"]
-                elif isinstance(content, str): # If content is just a string
+                elif isinstance(content, str):  # If content is just a string
                     content_str = content
-            
+
             summary_parts.append(recency_prefix + content_str)
 
         if not summary_parts:
-            return "You have some fleeting recollections, but nothing stands out clearly."
-        
+            return (
+                "You have some fleeting recollections, but nothing stands out clearly."
+            )
+
         return "Key things you recall about them: " + "; ".join(summary_parts) + "."
 
-    def update_relationship(self, player_dialogue: str, positive_keywords: list[str], negative_keywords: list[str], game_turn: int):
+    def update_relationship(
+        self,
+        player_dialogue: str,
+        positive_keywords: list[str],
+        negative_keywords: list[str],
+        game_turn: int,
+    ):
         change = 0
         player_dialogue_lower = player_dialogue.lower()
         for keyword in positive_keywords:
@@ -475,22 +593,25 @@ class Character:
         for keyword in negative_keywords:
             if keyword in player_dialogue_lower:
                 change -= 1
-        
-        if change != 0: 
+
+        if change != 0:
             self.relationship_with_player += change
-            self.relationship_with_player = max(-10, min(10, self.relationship_with_player))
+            self.relationship_with_player = max(
+                -10, min(10, self.relationship_with_player)
+            )
             self.add_player_memory(
                 memory_type="relationship_change",
                 turn=game_turn,
                 content={
                     "reason": f"their statement ('{player_dialogue[:30]}...')",
-                    "change": change
+                    "change": change,
                 },
-                sentiment_impact=change
+                sentiment_impact=change,
             )
 
     def get_objective_by_id(self, objective_id):
-        if not objective_id: return None
+        if not objective_id:
+            return None
         for obj in self.objectives:
             if obj.get("id") == objective_id:
                 return obj
@@ -508,28 +629,39 @@ class Character:
         obj = self.get_objective_by_id(objective_id)
         if obj and obj.get("stages"):
             current_stage_found_in_obj = False
-            next_stage_obj_from_template = None 
-            
+            next_stage_obj_from_template = None
+
             for s_val_in_obj_stages in obj["stages"]:
                 if s_val_in_obj_stages.get("stage_id") == next_stage_id:
                     next_stage_obj_from_template = s_val_in_obj_stages
                     break
-            
+
             if not next_stage_obj_from_template:
                 return False
 
-            for stage_in_obj in obj["stages"]: 
-                stage_in_obj["is_current_stage"] = (stage_in_obj.get("stage_id") == next_stage_id)
-                if stage_in_obj["is_current_stage"]: 
-                    current_stage_found_in_obj = True 
+            for stage_in_obj in obj["stages"]:
+                stage_in_obj["is_current_stage"] = (
+                    stage_in_obj.get("stage_id") == next_stage_id
+                )
+                if stage_in_obj["is_current_stage"]:
+                    current_stage_found_in_obj = True
 
-            if current_stage_found_in_obj: 
+            if current_stage_found_in_obj:
                 obj["current_stage_id"] = next_stage_id
-                new_stage_desc = next_stage_obj_from_template.get('description', 'unnamed stage')
-                
+                new_stage_desc = next_stage_obj_from_template.get(
+                    "description", "unnamed stage"
+                )
+
                 if self.is_player:
-                    self.add_player_memory(memory_type="objective_progress", turn=0, content={"summary": f"Made progress on '{obj.get('description','Unnamed Objective')}': now at '{new_stage_desc}'."}, sentiment_impact=0)
-                
+                    self.add_player_memory(
+                        memory_type="objective_progress",
+                        turn=0,
+                        content={
+                            "summary": f"Made progress on '{obj.get('description','Unnamed Objective')}': now at '{new_stage_desc}'."
+                        },
+                        sentiment_impact=0,
+                    )
+
                 if next_stage_obj_from_template.get("is_ending_stage", False):
                     self.complete_objective(objective_id, by_stage=True)
                 return True
@@ -539,18 +671,38 @@ class Character:
         obj = self.get_objective_by_id(objective_id)
         if obj and not obj.get("completed", False):
             obj["completed"] = True
-            obj["active"] = False  
-            obj_desc = obj.get('description', 'Unnamed Objective')
+            obj["active"] = False
+            obj_desc = obj.get("description", "Unnamed Objective")
             if self.is_player:
-                current_stage_for_memory = self.get_current_stage_for_objective(objective_id)
-                stage_desc_for_memory = current_stage_for_memory.get('description', 'final stage') if current_stage_for_memory else 'final stage'
-                
+                current_stage_for_memory = self.get_current_stage_for_objective(
+                    objective_id
+                )
+                stage_desc_for_memory = (
+                    current_stage_for_memory.get("description", "final stage")
+                    if current_stage_for_memory
+                    else "final stage"
+                )
+
                 if not by_stage:
-                    self.add_player_memory(memory_type="objective_completed", turn=0, content={"summary": f"Objective '{obj_desc}' was completed."}, sentiment_impact=0)
+                    self.add_player_memory(
+                        memory_type="objective_completed",
+                        turn=0,
+                        content={"summary": f"Objective '{obj_desc}' was completed."},
+                        sentiment_impact=0,
+                    )
                 else:
-                    self.add_player_memory(memory_type="objective_completed", turn=0, content={"summary": f"Objective '{obj_desc}' concluded with stage '{stage_desc_for_memory}'."}, sentiment_impact=0)
+                    self.add_player_memory(
+                        memory_type="objective_completed",
+                        turn=0,
+                        content={
+                            "summary": f"Objective '{obj_desc}' concluded with stage '{stage_desc_for_memory}'."
+                        },
+                        sentiment_impact=0,
+                    )
                     if DEBUG_LOGS:
-                        print(f"[DEBUG] Player {self.name} completed objective: {obj_desc} (Stage: {stage_desc_for_memory if by_stage else 'N/A'})")
+                        print(
+                            f"[DEBUG] Player {self.name} completed objective: {obj_desc} (Stage: {stage_desc_for_memory if by_stage else 'N/A'})"
+                        )
 
             link_info = None
             current_stage = self.get_current_stage_for_objective(objective_id)
@@ -563,60 +715,138 @@ class Character:
                 target_objective_id = None
                 specific_next_stage_id = None
 
-                if isinstance(link_info, str): 
+                if isinstance(link_info, str):
                     target_objective_id = link_info
-                elif isinstance(link_info, dict): 
+                elif isinstance(link_info, dict):
                     target_objective_id = link_info.get("id")
                     specific_next_stage_id = link_info.get("stage_to_advance_to")
 
                 if target_objective_id:
                     target_objective = self.get_objective_by_id(target_objective_id)
                     if target_objective:
-                        target_obj_desc = target_objective.get('description', 'Unnamed Linked Objective')
-                        if not target_objective.get("active", False) and not target_objective.get("completed", False) :
+                        target_obj_desc = target_objective.get(
+                            "description", "Unnamed Linked Objective"
+                        )
+                        if not target_objective.get(
+                            "active", False
+                        ) and not target_objective.get("completed", False):
                             if DEBUG_LOGS:
-                                print(f"[DEBUG] Linking: Activating objective '{target_obj_desc}' due to completion of '{obj_desc}'.")
-                            self.activate_objective(target_objective_id) 
-                            if specific_next_stage_id and target_objective.get("current_stage_id") != specific_next_stage_id :
+                                print(
+                                    f"[DEBUG] Linking: Activating objective '{target_obj_desc}' due to completion of '{obj_desc}'."
+                                )
+                            self.activate_objective(target_objective_id)
+                            if (
+                                specific_next_stage_id
+                                and target_objective.get("current_stage_id")
+                                != specific_next_stage_id
+                            ):
                                 if DEBUG_LOGS:
-                                    print(f"[DEBUG] Linking: Advancing newly activated objective '{target_obj_desc}' to specific stage '{specific_next_stage_id}'.")
-                                self.advance_objective_stage(target_objective_id, specific_next_stage_id)
+                                    print(
+                                        f"[DEBUG] Linking: Advancing newly activated objective '{target_obj_desc}' to specific stage '{specific_next_stage_id}'."
+                                    )
+                                self.advance_objective_stage(
+                                    target_objective_id, specific_next_stage_id
+                                )
                             if self.is_player:
-                                self.add_player_memory(memory_type="objective_linked", turn=0, content={"summary": f"Completing '{obj_desc}' has opened up new paths regarding '{target_obj_desc}'."}, sentiment_impact=0)
-                        
-                        elif target_objective.get("active", False) and not target_objective.get("completed", False):
+                                self.add_player_memory(
+                                    memory_type="objective_linked",
+                                    turn=0,
+                                    content={
+                                        "summary": f"Completing '{obj_desc}' has opened up new paths regarding '{target_obj_desc}'."
+                                    },
+                                    sentiment_impact=0,
+                                )
+
+                        elif target_objective.get(
+                            "active", False
+                        ) and not target_objective.get("completed", False):
                             if specific_next_stage_id:
                                 if DEBUG_LOGS:
-                                    print(f"[DEBUG] Linking: Advancing active objective '{target_obj_desc}' to specific stage '{specific_next_stage_id}' due to '{obj_desc}'.")
-                                if self.advance_objective_stage(target_objective_id, specific_next_stage_id):
-                                     if self.is_player:
-                                        self.add_player_memory(memory_type="objective_linked", turn=0, content={"summary": f"Progress on '{obj_desc}' has further developed your understanding of '{target_obj_desc}'."}, sentiment_impact=0)
+                                    print(
+                                        f"[DEBUG] Linking: Advancing active objective '{target_obj_desc}' to specific stage '{specific_next_stage_id}' due to '{obj_desc}'."
+                                    )
+                                if self.advance_objective_stage(
+                                    target_objective_id, specific_next_stage_id
+                                ):
+                                    if self.is_player:
+                                        self.add_player_memory(
+                                            memory_type="objective_linked",
+                                            turn=0,
+                                            content={
+                                                "summary": f"Progress on '{obj_desc}' has further developed your understanding of '{target_obj_desc}'."
+                                            },
+                                            sentiment_impact=0,
+                                        )
                                 elif DEBUG_LOGS:
-                                    print(f"[DEBUG] Linking: Failed to advance '{target_obj_desc}' to stage '{specific_next_stage_id}'.")
+                                    print(
+                                        f"[DEBUG] Linking: Failed to advance '{target_obj_desc}' to stage '{specific_next_stage_id}'."
+                                    )
                             else:
-                                current_target_stage = self.get_current_stage_for_objective(target_objective_id)
-                                if current_target_stage and current_target_stage.get("next_stages"):
-                                    potential_next_ids = current_target_stage["next_stages"]
-                                    if isinstance(potential_next_ids, dict) and potential_next_ids:
-                                        auto_next_stage_id = next(iter(potential_next_ids.values()))
+                                current_target_stage = (
+                                    self.get_current_stage_for_objective(
+                                        target_objective_id
+                                    )
+                                )
+                                if current_target_stage and current_target_stage.get(
+                                    "next_stages"
+                                ):
+                                    potential_next_ids = current_target_stage[
+                                        "next_stages"
+                                    ]
+                                    if (
+                                        isinstance(potential_next_ids, dict)
+                                        and potential_next_ids
+                                    ):
+                                        auto_next_stage_id = next(
+                                            iter(potential_next_ids.values())
+                                        )
                                         if DEBUG_LOGS:
-                                            print(f"[DEBUG] Linking: Attempting generic advance for active objective '{target_obj_desc}' to its next stage '{auto_next_stage_id}' due to '{obj_desc}'.")
-                                        if self.advance_objective_stage(target_objective_id, auto_next_stage_id):
+                                            print(
+                                                f"[DEBUG] Linking: Attempting generic advance for active objective '{target_obj_desc}' to its next stage '{auto_next_stage_id}' due to '{obj_desc}'."
+                                            )
+                                        if self.advance_objective_stage(
+                                            target_objective_id, auto_next_stage_id
+                                        ):
                                             if self.is_player:
-                                                self.add_player_memory(memory_type="objective_linked", turn=0, content={"summary": f"Progress on '{obj_desc}' has influenced your approach to '{target_obj_desc}'."}, sentiment_impact=0)
-                                    elif isinstance(potential_next_ids, list) and potential_next_ids:
-                                         auto_next_stage_id = potential_next_ids[0]
-                                         if DEBUG_LOGS:
-                                             print(f"[DEBUG] Linking: Attempting generic advance for active objective '{target_obj_desc}' to its next stage '{auto_next_stage_id}' due to '{obj_desc}'.")
-                                         if self.advance_objective_stage(target_objective_id, auto_next_stage_id):
+                                                self.add_player_memory(
+                                                    memory_type="objective_linked",
+                                                    turn=0,
+                                                    content={
+                                                        "summary": f"Progress on '{obj_desc}' has influenced your approach to '{target_obj_desc}'."
+                                                    },
+                                                    sentiment_impact=0,
+                                                )
+                                    elif (
+                                        isinstance(potential_next_ids, list)
+                                        and potential_next_ids
+                                    ):
+                                        auto_next_stage_id = potential_next_ids[0]
+                                        if DEBUG_LOGS:
+                                            print(
+                                                f"[DEBUG] Linking: Attempting generic advance for active objective '{target_obj_desc}' to its next stage '{auto_next_stage_id}' due to '{obj_desc}'."
+                                            )
+                                        if self.advance_objective_stage(
+                                            target_objective_id, auto_next_stage_id
+                                        ):
                                             if self.is_player:
-                                                self.add_player_memory(memory_type="objective_linked", turn=0, content={"summary": f"Progress on '{obj_desc}' has influenced your approach to '{target_obj_desc}'."}, sentiment_impact=0)
+                                                self.add_player_memory(
+                                                    memory_type="objective_linked",
+                                                    turn=0,
+                                                    content={
+                                                        "summary": f"Progress on '{obj_desc}' has influenced your approach to '{target_obj_desc}'."
+                                                    },
+                                                    sentiment_impact=0,
+                                                )
                                     else:
                                         if DEBUG_LOGS:
-                                            print(f"[DEBUG] Linking: Objective '{target_obj_desc}' is active, but current stage has no defined 'next_stages' for generic advance.")
+                                            print(
+                                                f"[DEBUG] Linking: Objective '{target_obj_desc}' is active, but current stage has no defined 'next_stages' for generic advance."
+                                            )
                                 else:
                                     if DEBUG_LOGS:
-                                        print(f"[DEBUG] Linking: Objective '{target_obj_desc}' is active, but current stage or its 'next_stages' are not clearly defined for generic advance.")
+                                        print(
+                                            f"[DEBUG] Linking: Objective '{target_obj_desc}' is active, but current stage or its 'next_stages' are not clearly defined for generic advance."
+                                        )
             return True
         return False
 
@@ -624,32 +854,55 @@ class Character:
         obj = self.get_objective_by_id(objective_id)
         if obj:
             obj["active"] = True
-            obj["completed"] = False  
+            obj["completed"] = False
 
             initial_stage_id_to_set = None
-            if set_stage_id: 
-                if any(s.get("stage_id") == set_stage_id for s in obj.get("stages", [])):
+            if set_stage_id:
+                if any(
+                    s.get("stage_id") == set_stage_id for s in obj.get("stages", [])
+                ):
                     initial_stage_id_to_set = set_stage_id
                 else:
                     if DEBUG_LOGS:
-                        print(f"[DEBUG] Warning: Requested stage_id '{set_stage_id}' for activating objective '{objective_id}' not found. Defaulting to first stage.")
+                        print(
+                            f"[DEBUG] Warning: Requested stage_id '{set_stage_id}' for activating objective '{objective_id}' not found. Defaulting to first stage."
+                        )
 
-            if not initial_stage_id_to_set: 
+            if not initial_stage_id_to_set:
                 if obj.get("stages") and obj["stages"][0].get("stage_id"):
                     initial_stage_id_to_set = obj["stages"][0].get("stage_id")
-                else: 
-                    obj["stages"] = [{"stage_id": "default", "description": "Objective activated.", "is_current_stage": True}]
+                else:
+                    obj["stages"] = [
+                        {
+                            "stage_id": "default",
+                            "description": "Objective activated.",
+                            "is_current_stage": True,
+                        }
+                    ]
                     initial_stage_id_to_set = "default"
-            
+
             obj["current_stage_id"] = initial_stage_id_to_set
             for stage in obj.get("stages", []):
-                stage["is_current_stage"] = (stage.get("stage_id") == initial_stage_id_to_set)
-            
-            current_stage_desc = self.get_current_stage_for_objective(objective_id).get('description', 'initial stage')
+                stage["is_current_stage"] = (
+                    stage.get("stage_id") == initial_stage_id_to_set
+                )
+
+            current_stage_desc = self.get_current_stage_for_objective(objective_id).get(
+                "description", "initial stage"
+            )
             if self.is_player:
-                self.add_player_memory(memory_type="objective_activated", turn=0, content={"summary": f"New objective active or re-activated: '{obj.get('description', 'Unnamed Objective')}' (Current stage: '{current_stage_desc}')."}, sentiment_impact=0)
+                self.add_player_memory(
+                    memory_type="objective_activated",
+                    turn=0,
+                    content={
+                        "summary": f"New objective active or re-activated: '{obj.get('description', 'Unnamed Objective')}' (Current stage: '{current_stage_desc}')."
+                    },
+                    sentiment_impact=0,
+                )
             if DEBUG_LOGS:
-                print(f"[DEBUG] Player {self.name} activated objective: {obj.get('description')} - now at stage '{current_stage_desc}'")
+                print(
+                    f"[DEBUG] Player {self.name} activated objective: {obj.get('description')} - now at stage '{current_stage_desc}'"
+                )
             return True
         return False
 
@@ -660,12 +913,14 @@ class Character:
         """
         skill_value = self.skills.get(skill_name, 0)
         d6_roll = random.randint(1, 6)
-        
+
         # Formula from prompt: (skill + roll) >= (threshold + 3)
         target_number = difficulty_threshold + 3
         success = (skill_value + d6_roll) >= target_number
-        
+
         # Debug message as specified in prompt
         if DEBUG_LOGS:
-            print(f"[Skill Check] {self.name} attempting {skill_name} (Value: {skill_value}, Roll: {d6_roll}, Threshold: {difficulty_threshold}): {'Success' if success else 'Failure'}")
+            print(
+                f"[Skill Check] {self.name} attempting {skill_name} (Value: {skill_value}, Roll: {d6_roll}, Threshold: {difficulty_threshold}): {'Success' if success else 'Failure'}"
+            )
         return success

--- a/game_engine/command_handler.py
+++ b/game_engine/command_handler.py
@@ -5,14 +5,17 @@ Mixin for handling player commands and input interpretation.
 
 import re
 import difflib
-import random
 from .game_config import (
-    Colors, COMMAND_SYNONYMS, VERBOSITY_LEVELS, COLOR_THEME_MAP,
-    TIME_UNITS_PER_PLAYER_ACTION, DEFAULT_ITEMS, DEFAULT_COLOR_THEME,
-    TIME_UNITS_FOR_NPC_INTERACTION_CHANCE, NPC_INTERACTION_CHANCE,
-    apply_color_theme
+    Colors,
+    COMMAND_SYNONYMS,
+    VERBOSITY_LEVELS,
+    COLOR_THEME_MAP,
+    TIME_UNITS_PER_PLAYER_ACTION,
+    DEFAULT_ITEMS,
+    apply_color_theme,
 )
 from .location_module import LOCATIONS_DATA
+
 
 class CommandHandler:
     """Service for handling player commands and input interpretation."""
@@ -63,36 +66,63 @@ class CommandHandler:
                     entries.append(f"{option} ({descriptor})")
                 else:
                     entries.append(option)
-            self.game_state._print_color(f"Which {label} did you mean? {'; '.join(entries)}", Colors.YELLOW)
+            self.game_state._print_color(
+                f"Which {label} did you mean? {'; '.join(entries)}", Colors.YELLOW
+            )
             return None, True
         return matches[0], False
 
     def _get_matching_location_item(self, target):
-        location_items = self.game_state.dynamic_location_items.get(self.game_state.current_location_name, [])
+        location_items = self.game_state.dynamic_location_items.get(
+            self.game_state.current_location_name, []
+        )
         options = [item_info["name"] for item_info in location_items]
         match, ambiguous = self._resolve_prefix_match(
             target,
             options,
             "item",
-            descriptor_lookup=self.game_state._describe_item_brief
+            descriptor_lookup=self.game_state._describe_item_brief,
         )
         if ambiguous or not match:
             return None, ambiguous
-        return next((item_info for item_info in location_items if item_info["name"] == match), None), False
+        return (
+            next(
+                (
+                    item_info
+                    for item_info in location_items
+                    if item_info["name"] == match
+                ),
+                None,
+            ),
+            False,
+        )
 
     def _get_matching_inventory_item(self, target):
         if not self.game_state.player_character:
             return None, False
-        options = [item_info["name"] for item_info in self.game_state.player_character.inventory]
+        options = [
+            item_info["name"]
+            for item_info in self.game_state.player_character.inventory
+        ]
         match, ambiguous = self._resolve_prefix_match(
             target,
             options,
             "item",
-            descriptor_lookup=self.game_state._describe_item_brief
+            descriptor_lookup=self.game_state._describe_item_brief,
         )
         if ambiguous or not match:
             return None, ambiguous
-        return next((item_info for item_info in self.game_state.player_character.inventory if item_info["name"] == match), None), False
+        return (
+            next(
+                (
+                    item_info
+                    for item_info in self.game_state.player_character.inventory
+                    if item_info["name"] == match
+                ),
+                None,
+            ),
+            False,
+        )
 
     def _get_matching_npc(self, target):
         options = [npc.name for npc in self.game_state.npcs_in_current_location]
@@ -100,16 +130,30 @@ class CommandHandler:
             target,
             options,
             "person",
-            descriptor_lookup=self.game_state._describe_npc_brief
+            descriptor_lookup=self.game_state._describe_npc_brief,
         )
         if ambiguous or not match:
             return None, ambiguous
-        return next((npc for npc in self.game_state.npcs_in_current_location if npc.name == match), None), False
+        return (
+            next(
+                (
+                    npc
+                    for npc in self.game_state.npcs_in_current_location
+                    if npc.name == match
+                ),
+                None,
+            ),
+            False,
+        )
 
     def _get_matching_exit(self, target_input, location_exits):
         matches = []
         for target_loc_key, desc_text in location_exits.items():
-            if target_loc_key.lower() == target_input or desc_text.lower().startswith(target_input) or target_input in desc_text.lower():
+            if (
+                target_loc_key.lower() == target_input
+                or desc_text.lower().startswith(target_input)
+                or target_input in desc_text.lower()
+            ):
                 matches.append(target_loc_key)
         if not matches:
             return None, False
@@ -118,7 +162,9 @@ class CommandHandler:
             for match in matches[:5]:
                 desc = location_exits.get(match, "")
                 descriptions.append(f"{match} ({desc})" if desc else match)
-            self.game_state._print_color(f"Which exit did you mean? {'; '.join(descriptions)}", Colors.YELLOW)
+            self.game_state._print_color(
+                f"Which exit did you mean? {'; '.join(descriptions)}", Colors.YELLOW
+            )
             return None, True
         return matches[0], False
 
@@ -130,20 +176,38 @@ class CommandHandler:
         return command in known_commands
 
     def _build_intent_context(self):
-        current_location_data = LOCATIONS_DATA.get(self.game_state.current_location_name, {})
+        current_location_data = LOCATIONS_DATA.get(
+            self.game_state.current_location_name, {}
+        )
         exits = []
         for exit_target, exit_desc in current_location_data.get("exits", {}).items():
             exits.append({"name": exit_target, "description": exit_desc})
-        items = [item_info["name"] for item_info in self.game_state.dynamic_location_items.get(self.game_state.current_location_name, [])]
+        items = [
+            item_info["name"]
+            for item_info in self.game_state.dynamic_location_items.get(
+                self.game_state.current_location_name, []
+            )
+        ]
         npcs = [npc.name for npc in self.game_state.npcs_in_current_location]
-        inventory = [item_info["name"] for item_info in self.game_state.player_character.inventory] if self.game_state.player_character else []
+        inventory = (
+            [
+                item_info["name"]
+                for item_info in self.game_state.player_character.inventory
+            ]
+            if self.game_state.player_character
+            else []
+        )
         return {"exits": exits, "items": items, "npcs": npcs, "inventory": inventory}
 
     def _handle_unknown_intent(self):
-        self.game_state._print_color("Your mind is too clouded to focus on that.", Colors.YELLOW)
+        self.game_state._print_color(
+            "Your mind is too clouded to focus on that.", Colors.YELLOW
+        )
         context_examples = self._get_contextual_command_examples()
         if context_examples:
-            self.game_state._print_color(f"Try: {', '.join(context_examples)}", Colors.DIM)
+            self.game_state._print_color(
+                f"Try: {', '.join(context_examples)}", Colors.DIM
+            )
 
     def _get_contextual_command_examples(self):
         context = self._build_intent_context()
@@ -170,8 +234,13 @@ class CommandHandler:
 
     def _interpret_with_nlp(self, raw_input):
         context = self._build_intent_context()
-        intent_payload = self.game_state.nl_parser.parse_player_intent(raw_input, context)
-        if intent_payload.get("intent") == "unknown" or intent_payload.get("confidence", 0.0) < 0.7:
+        intent_payload = self.game_state.nl_parser.parse_player_intent(
+            raw_input, context
+        )
+        if (
+            intent_payload.get("intent") == "unknown"
+            or intent_payload.get("confidence", 0.0) < 0.7
+        ):
             self._handle_unknown_intent()
             return None, None
         intent = intent_payload.get("intent")
@@ -195,76 +264,241 @@ class CommandHandler:
         return difflib.get_close_matches(command_text, candidates, n=limit, cutoff=0.5)
 
     def parse_action(self, raw_input):
-        action = raw_input.strip().lower();
-        if not action: return None, None
+        action = raw_input.strip().lower()
+        if not action:
+            return None, None
         give_match = re.match(r"^(give|offer)\s+(.+?)\s+to\s+(.+)$", action)
-        if give_match: return "use", (give_match.group(2).strip(), give_match.group(3).strip(), "give")
+        if give_match:
+            return "use", (
+                give_match.group(2).strip(),
+                give_match.group(3).strip(),
+                "give",
+            )
         read_match = re.match(r"^(read|peruse)\s+(.+)$", action)
-        if read_match: return "use", (read_match.group(2).strip(), None, "read")
+        if read_match:
+            return "use", (read_match.group(2).strip(), None, "read")
         use_on_match = re.match(r"^(use|apply)\s+(.+?)\s+on\s+(.+)$", action)
-        if use_on_match: return "use", (use_on_match.group(2).strip(), use_on_match.group(3).strip(), "use_on")
-        matched_command = None; best_match_length = 0; parsed_arg = None
+        if use_on_match:
+            return "use", (
+                use_on_match.group(2).strip(),
+                use_on_match.group(3).strip(),
+                "use_on",
+            )
+        matched_command = None
+        best_match_length = 0
+        parsed_arg = None
         for base_cmd, synonyms in COMMAND_SYNONYMS.items():
             for cmd_to_check in [base_cmd] + synonyms:
                 if action == cmd_to_check:
-                    if len(cmd_to_check) > best_match_length: matched_command = base_cmd; best_match_length = len(cmd_to_check); parsed_arg = None
+                    if len(cmd_to_check) > best_match_length:
+                        matched_command = base_cmd
+                        best_match_length = len(cmd_to_check)
+                        parsed_arg = None
                 elif action.startswith(cmd_to_check + " "):
-                    if len(cmd_to_check) > best_match_length: matched_command = base_cmd; best_match_length = len(cmd_to_check); parsed_arg = action[len(cmd_to_check):].strip()
-        if matched_command: return matched_command, parsed_arg
+                    if len(cmd_to_check) > best_match_length:
+                        matched_command = base_cmd
+                        best_match_length = len(cmd_to_check)
+                        parsed_arg = action[len(cmd_to_check) :].strip()
+        if matched_command:
+            return matched_command, parsed_arg
         parts = action.split(" ", 1)
-        persuade_match = re.match(r"^(persuade|convince|argue with)\s+(.+?)\s+(?:that|to)\s+(.+)$", action)
-        if persuade_match: return "persuade", (persuade_match.group(2).strip(), persuade_match.group(3).strip())
+        persuade_match = re.match(
+            r"^(persuade|convince|argue with)\s+(.+?)\s+(?:that|to)\s+(.+)$", action
+        )
+        if persuade_match:
+            return "persuade", (
+                persuade_match.group(2).strip(),
+                persuade_match.group(3).strip(),
+            )
         return parts[0], parts[1] if len(parts) > 1 else None
 
     def _get_player_input(self):
-        player_state_info = f"{self.game_state.player_character.apparent_state}" if self.game_state.player_character else "Unknown state"
-        prompt_hint_objects = []; hint_types_added = set()
-        if hasattr(self, 'numbered_actions_context') and self.game_state.numbered_actions_context:
-            if 'talk' not in hint_types_added and len(prompt_hint_objects) < 2:
+        player_state_info = (
+            f"{self.game_state.player_character.apparent_state}"
+            if self.game_state.player_character
+            else "Unknown state"
+        )
+        prompt_hint_objects = []
+        hint_types_added = set()
+        if (
+            hasattr(self, "numbered_actions_context")
+            and self.game_state.numbered_actions_context
+        ):
+            if "talk" not in hint_types_added and len(prompt_hint_objects) < 2:
                 for action_info in self.game_state.numbered_actions_context:
-                    if len(prompt_hint_objects) >= 2: break
-                    if action_info['type'] == 'talk':
-                        current_action_type = 'talk'; current_target = action_info['target']; display_string = f"Talk to {current_target}"
-                        is_duplicate = any(ex_h['action_type'] == current_action_type and (ex_h['target'].startswith(current_target) or current_target.startswith(ex_h['target'])) for ex_h in prompt_hint_objects)
-                        if not is_duplicate: prompt_hint_objects.append({'action_type': current_action_type, 'target': current_target, 'display_string': display_string}); hint_types_added.add('talk'); break
-            if len(prompt_hint_objects) < 2 and 'item_take' not in hint_types_added:
+                    if len(prompt_hint_objects) >= 2:
+                        break
+                    if action_info["type"] == "talk":
+                        current_action_type = "talk"
+                        current_target = action_info["target"]
+                        display_string = f"Talk to {current_target}"
+                        is_duplicate = any(
+                            ex_h["action_type"] == current_action_type
+                            and (
+                                ex_h["target"].startswith(current_target)
+                                or current_target.startswith(ex_h["target"])
+                            )
+                            for ex_h in prompt_hint_objects
+                        )
+                        if not is_duplicate:
+                            prompt_hint_objects.append(
+                                {
+                                    "action_type": current_action_type,
+                                    "target": current_target,
+                                    "display_string": display_string,
+                                }
+                            )
+                            hint_types_added.add("talk")
+                            break
+            if len(prompt_hint_objects) < 2 and "item_take" not in hint_types_added:
                 for action_info in self.game_state.numbered_actions_context:
-                    if len(prompt_hint_objects) >= 2: break
-                    if action_info['type'] == 'take' and DEFAULT_ITEMS.get(action_info['target'], {}).get('is_notable', False):
-                        current_action_type = 'item_take'; current_target = action_info['target']; display_string = f"Take {current_target}"
-                        is_duplicate = any(ex_h['action_type'] == current_action_type and (ex_h['target'].startswith(current_target) or current_target.startswith(ex_h['target'])) for ex_h in prompt_hint_objects)
-                        if not is_duplicate: prompt_hint_objects.append({'action_type': current_action_type, 'target': current_target, 'display_string': display_string}); hint_types_added.add('item_take'); break
-            if len(prompt_hint_objects) < 2 and 'item_examine' not in hint_types_added:
+                    if len(prompt_hint_objects) >= 2:
+                        break
+                    if action_info["type"] == "take" and DEFAULT_ITEMS.get(
+                        action_info["target"], {}
+                    ).get("is_notable", False):
+                        current_action_type = "item_take"
+                        current_target = action_info["target"]
+                        display_string = f"Take {current_target}"
+                        is_duplicate = any(
+                            ex_h["action_type"] == current_action_type
+                            and (
+                                ex_h["target"].startswith(current_target)
+                                or current_target.startswith(ex_h["target"])
+                            )
+                            for ex_h in prompt_hint_objects
+                        )
+                        if not is_duplicate:
+                            prompt_hint_objects.append(
+                                {
+                                    "action_type": current_action_type,
+                                    "target": current_target,
+                                    "display_string": display_string,
+                                }
+                            )
+                            hint_types_added.add("item_take")
+                            break
+            if len(prompt_hint_objects) < 2 and "item_examine" not in hint_types_added:
                 for action_info in self.game_state.numbered_actions_context:
-                    if len(prompt_hint_objects) >= 2: break
-                    if action_info['type'] == 'look_at_item' and DEFAULT_ITEMS.get(action_info['target'], {}).get('is_notable', False):
-                        current_action_type = 'item_examine'; current_target = action_info['target']; display_string = f"Examine {current_target}"
-                        is_duplicate = any(ex_h['action_type'] == current_action_type and (ex_h['target'].startswith(current_target) or current_target.startswith(ex_h['target'])) for ex_h in prompt_hint_objects)
-                        if not is_duplicate: prompt_hint_objects.append({'action_type': current_action_type, 'target': current_target, 'display_string': display_string}); hint_types_added.add('item_examine'); break
-            if len(prompt_hint_objects) < 2 and 'item_take' not in hint_types_added :
+                    if len(prompt_hint_objects) >= 2:
+                        break
+                    if action_info["type"] == "look_at_item" and DEFAULT_ITEMS.get(
+                        action_info["target"], {}
+                    ).get("is_notable", False):
+                        current_action_type = "item_examine"
+                        current_target = action_info["target"]
+                        display_string = f"Examine {current_target}"
+                        is_duplicate = any(
+                            ex_h["action_type"] == current_action_type
+                            and (
+                                ex_h["target"].startswith(current_target)
+                                or current_target.startswith(ex_h["target"])
+                            )
+                            for ex_h in prompt_hint_objects
+                        )
+                        if not is_duplicate:
+                            prompt_hint_objects.append(
+                                {
+                                    "action_type": current_action_type,
+                                    "target": current_target,
+                                    "display_string": display_string,
+                                }
+                            )
+                            hint_types_added.add("item_examine")
+                            break
+            if len(prompt_hint_objects) < 2 and "item_take" not in hint_types_added:
                 for action_info in self.game_state.numbered_actions_context:
-                    if len(prompt_hint_objects) >= 2: break
-                    if action_info['type'] == 'take':
-                        current_action_type = 'item_take'; current_target = action_info['target']; display_string = f"Take {current_target}"
-                        is_duplicate = any(ex_h['action_type'] == current_action_type and (ex_h['target'].startswith(current_target) or current_target.startswith(ex_h['target'])) for ex_h in prompt_hint_objects)
-                        if not is_duplicate: prompt_hint_objects.append({'action_type': current_action_type, 'target': current_target, 'display_string': display_string}); hint_types_added.add('item_take'); break
-            if len(prompt_hint_objects) < 2 and 'item_examine' not in hint_types_added:
+                    if len(prompt_hint_objects) >= 2:
+                        break
+                    if action_info["type"] == "take":
+                        current_action_type = "item_take"
+                        current_target = action_info["target"]
+                        display_string = f"Take {current_target}"
+                        is_duplicate = any(
+                            ex_h["action_type"] == current_action_type
+                            and (
+                                ex_h["target"].startswith(current_target)
+                                or current_target.startswith(ex_h["target"])
+                            )
+                            for ex_h in prompt_hint_objects
+                        )
+                        if not is_duplicate:
+                            prompt_hint_objects.append(
+                                {
+                                    "action_type": current_action_type,
+                                    "target": current_target,
+                                    "display_string": display_string,
+                                }
+                            )
+                            hint_types_added.add("item_take")
+                            break
+            if len(prompt_hint_objects) < 2 and "item_examine" not in hint_types_added:
                 for action_info in self.game_state.numbered_actions_context:
-                    if len(prompt_hint_objects) >= 2: break
-                    if action_info['type'] == 'look_at_item':
-                        current_action_type = 'item_examine'; current_target = action_info['target']; display_string = f"Examine {current_target}"
-                        is_duplicate = any(ex_h['action_type'] == current_action_type and (ex_h['target'].startswith(current_target) or current_target.startswith(ex_h['target'])) for ex_h in prompt_hint_objects)
-                        if not is_duplicate: prompt_hint_objects.append({'action_type': current_action_type, 'target': current_target, 'display_string': display_string}); hint_types_added.add('item_examine'); break
-            if 'move' not in hint_types_added and len(prompt_hint_objects) < 2:
+                    if len(prompt_hint_objects) >= 2:
+                        break
+                    if action_info["type"] == "look_at_item":
+                        current_action_type = "item_examine"
+                        current_target = action_info["target"]
+                        display_string = f"Examine {current_target}"
+                        is_duplicate = any(
+                            ex_h["action_type"] == current_action_type
+                            and (
+                                ex_h["target"].startswith(current_target)
+                                or current_target.startswith(ex_h["target"])
+                            )
+                            for ex_h in prompt_hint_objects
+                        )
+                        if not is_duplicate:
+                            prompt_hint_objects.append(
+                                {
+                                    "action_type": current_action_type,
+                                    "target": current_target,
+                                    "display_string": display_string,
+                                }
+                            )
+                            hint_types_added.add("item_examine")
+                            break
+            if "move" not in hint_types_added and len(prompt_hint_objects) < 2:
                 for action_info in self.game_state.numbered_actions_context:
-                    if len(prompt_hint_objects) >= 2: break
-                    if action_info['type'] == 'move':
-                        current_action_type = 'move'; current_target = action_info['target']; display_string = f"Go to {current_target}"
-                        is_duplicate = any(ex_h['action_type'] == current_action_type and (ex_h['target'].startswith(current_target) or current_target.startswith(ex_h['target'])) for ex_h in prompt_hint_objects)
-                        if not is_duplicate: prompt_hint_objects.append({'action_type': current_action_type, 'target': current_target, 'display_string': display_string}); hint_types_added.add('move'); break
-        active_hint_display_strings = [h['display_string'] for h in prompt_hint_objects[:2]]
-        hint_string = f" (Hint: {Colors.DIM}{' | '.join(active_hint_display_strings)}{Colors.RESET})" if active_hint_display_strings else \
-                      (f" (Hint: {Colors.DIM}type 'look' or 'help'{Colors.RESET})" if not (hasattr(self, 'numbered_actions_context') and self.game_state.numbered_actions_context) else "")
+                    if len(prompt_hint_objects) >= 2:
+                        break
+                    if action_info["type"] == "move":
+                        current_action_type = "move"
+                        current_target = action_info["target"]
+                        display_string = f"Go to {current_target}"
+                        is_duplicate = any(
+                            ex_h["action_type"] == current_action_type
+                            and (
+                                ex_h["target"].startswith(current_target)
+                                or current_target.startswith(ex_h["target"])
+                            )
+                            for ex_h in prompt_hint_objects
+                        )
+                        if not is_duplicate:
+                            prompt_hint_objects.append(
+                                {
+                                    "action_type": current_action_type,
+                                    "target": current_target,
+                                    "display_string": display_string,
+                                }
+                            )
+                            hint_types_added.add("move")
+                            break
+        active_hint_display_strings = [
+            h["display_string"] for h in prompt_hint_objects[:2]
+        ]
+        hint_string = (
+            f" (Hint: {Colors.DIM}{' | '.join(active_hint_display_strings)}{Colors.RESET})"
+            if active_hint_display_strings
+            else (
+                f" (Hint: {Colors.DIM}type 'look' or 'help'{Colors.RESET})"
+                if not (
+                    hasattr(self, "numbered_actions_context")
+                    and self.game_state.numbered_actions_context
+                )
+                else ""
+            )
+        )
         time_info = self.game_state._get_current_game_time_period_str()
         mode_label = self.game_state._get_mode_label()
         prompt_text = (
@@ -276,7 +510,9 @@ class CommandHandler:
         fast_input = raw_action_input.strip().lower()
         if fast_input == "!!":
             if not self.game_state.command_history:
-                self.game_state._print_color("No previous command to repeat yet.", Colors.YELLOW)
+                self.game_state._print_color(
+                    "No previous command to repeat yet.", Colors.YELLOW
+                )
                 return None, None
             repeated_command = self.game_state.command_history[-1]
             self.game_state._print_color(f"Repeating: {repeated_command}", Colors.DIM)
@@ -297,14 +533,23 @@ class CommandHandler:
         try:
             action_number = int(raw_action_input)
             if 1 <= action_number <= len(self.game_state.numbered_actions_context):
-                action_info = self.game_state.numbered_actions_context[action_number - 1]
-                action_type = action_info['type']; target = action_info['target']
-                if action_type == 'move': return 'move to', target
-                elif action_type == 'talk': return 'talk to', target
-                elif action_type == 'take': return 'take', target
-                elif action_type == 'look_at_item': return 'look', target
-                elif action_type == 'look_at_npc': return 'look', target
-                elif action_info['type'] == 'select_item': return ('select_item', action_info['target'])
+                action_info = self.game_state.numbered_actions_context[
+                    action_number - 1
+                ]
+                action_type = action_info["type"]
+                target = action_info["target"]
+                if action_type == "move":
+                    return "move to", target
+                elif action_type == "talk":
+                    return "talk to", target
+                elif action_type == "take":
+                    return "take", target
+                elif action_type == "look_at_item":
+                    return "look", target
+                elif action_type == "look_at_npc":
+                    return "look", target
+                elif action_info["type"] == "select_item":
+                    return ("select_item", action_info["target"])
             else:
                 parsed_command, parsed_argument = self.parse_action(raw_action_input)
                 if self._is_known_command(parsed_command):
@@ -326,40 +571,50 @@ class CommandHandler:
     def _handle_theme_command(self, argument):
         if not argument:
             available = ", ".join(COLOR_THEME_MAP.keys())
-            self.game_state._print_color(f"Current theme: {self.game_state.color_theme}. Available: {available}.", Colors.CYAN)
+            self.game_state._print_color(
+                f"Current theme: {self.game_state.color_theme}. Available: {available}.",
+                Colors.CYAN,
+            )
             return
         requested_theme = str(argument).strip().lower()
         applied_theme = apply_color_theme(requested_theme)
         if not applied_theme:
             self.game_state._print_color(
                 f"Unknown theme '{requested_theme}'. Use: {', '.join(COLOR_THEME_MAP.keys())}.",
-                Colors.YELLOW
+                Colors.YELLOW,
             )
             return
         self.game_state.color_theme = applied_theme
-        self.game_state._print_color(f"Theme set to {self.game_state.color_theme}.", Colors.GREEN)
+        self.game_state._print_color(
+            f"Theme set to {self.game_state.color_theme}.", Colors.GREEN
+        )
 
     def _handle_verbosity_command(self, argument):
         if not argument:
             self.game_state._print_color(
                 f"Current verbosity: {self.game_state.verbosity_level}. Options: {', '.join(VERBOSITY_LEVELS)}.",
-                Colors.CYAN
+                Colors.CYAN,
             )
             return
         requested_level = str(argument).strip().lower()
         if requested_level not in VERBOSITY_LEVELS:
             self.game_state._print_color(
                 f"Unknown verbosity '{requested_level}'. Use: {', '.join(VERBOSITY_LEVELS)}.",
-                Colors.YELLOW
+                Colors.YELLOW,
             )
             return
         self.game_state.verbosity_level = requested_level
-        self.game_state._print_color(f"Verbosity set to {self.game_state.verbosity_level}.", Colors.GREEN)
+        self.game_state._print_color(
+            f"Verbosity set to {self.game_state.verbosity_level}.", Colors.GREEN
+        )
 
     def _handle_turnheaders_command(self, argument):
         if not argument:
             status_text = "on" if self.game_state.turn_headers_enabled else "off"
-            self.game_state._print_color(f"Turn headers are currently {status_text}. Use 'turnheaders on' or 'turnheaders off'.", Colors.CYAN)
+            self.game_state._print_color(
+                f"Turn headers are currently {status_text}. Use 'turnheaders on' or 'turnheaders off'.",
+                Colors.CYAN,
+            )
             return
         normalized = str(argument).strip().lower()
         if normalized in ["on", "true", "yes", "1"]:
@@ -370,14 +625,20 @@ class CommandHandler:
             self.game_state.turn_headers_enabled = False
             self.game_state._print_color("Turn headers disabled.", Colors.GREEN)
             return
-        self.game_state._print_color("Invalid value. Use 'turnheaders on' or 'turnheaders off'.", Colors.YELLOW)
+        self.game_state._print_color(
+            "Invalid value. Use 'turnheaders on' or 'turnheaders off'.", Colors.YELLOW
+        )
 
     def _handle_retry_or_rephrase(self, mode):
         if not self.game_state.last_ai_generated_text:
-            self.game_state._print_color("No recent AI text available to rework yet.", Colors.YELLOW)
+            self.game_state._print_color(
+                "No recent AI text available to rework yet.", Colors.YELLOW
+            )
             return False
         if not self.game_state.gemini_api.model or self.game_state.low_ai_data_mode:
-            self.game_state._print_color("Retry/rephrase requires active AI mode.", Colors.YELLOW)
+            self.game_state._print_color(
+                "Retry/rephrase requires active AI mode.", Colors.YELLOW
+            )
             return False
 
         if mode == "retry":
@@ -391,13 +652,19 @@ class CommandHandler:
                 f"{self.game_state.last_ai_generated_text}"
             )
 
-        regenerated_text = self.game_state.gemini_api._generate_content_with_fallback(prompt, f"{mode} last AI output")
-        if regenerated_text is None or (isinstance(regenerated_text, str) and regenerated_text.startswith("(OOC:")):
-            self.game_state._print_color("Could not generate an alternate version right now.", Colors.YELLOW)
+        regenerated_text = self.game_state.gemini_api._generate_content_with_fallback(
+            prompt, f"{mode} last AI output"
+        )
+        if regenerated_text is None or (
+            isinstance(regenerated_text, str) and regenerated_text.startswith("(OOC:")
+        ):
+            self.game_state._print_color(
+                "Could not generate an alternate version right now.", Colors.YELLOW
+            )
             return False
 
         final_text = self.game_state._apply_verbosity(regenerated_text)
-        self.game_state._print_color(f"{mode.title()}: \"{final_text}\"", Colors.CYAN)
+        self.game_state._print_color(f'{mode.title()}: "{final_text}"', Colors.CYAN)
         self.game_state._remember_ai_output(final_text, f"{mode}_command")
         return True
 
@@ -405,87 +672,194 @@ class CommandHandler:
         show_full_look_details = False
         if command == "look" or command == "move to":
             show_full_look_details = True
-        action_taken_this_turn = True; time_to_advance = TIME_UNITS_PER_PLAYER_ACTION; show_atmospherics_this_turn = True
-        if command == "quit": self.game_state._print_color("Exiting game. Goodbye.", Colors.MAGENTA); return False, False, 0, True
+        action_taken_this_turn = True
+        time_to_advance = TIME_UNITS_PER_PLAYER_ACTION
+        show_atmospherics_this_turn = True
+        if command == "quit":
+            self.game_state._print_color("Exiting game. Goodbye.", Colors.MAGENTA)
+            return False, False, 0, True
         elif command == "select_item":
             item_name_selected = argument
-            secondary_action_input = self.game_state._input_color(f"What to do with {Colors.GREEN}{item_name_selected}{Colors.WHITE}? (e.g., look at, take, use, read, give to...) {self.game_state._prompt_arrow()}", Colors.WHITE).strip().lower()
+            secondary_action_input = (
+                self.game_state._input_color(
+                    f"What to do with {Colors.GREEN}{item_name_selected}{Colors.WHITE}? (e.g., look at, take, use, read, give to...) {self.game_state._prompt_arrow()}",
+                    Colors.WHITE,
+                )
+                .strip()
+                .lower()
+            )
 
             if secondary_action_input == "look at":
-                self.game_state._handle_look_command(item_name_selected, show_full_look_details) # _handle_look_command doesn't return action_taken flags
+                self.game_state._handle_look_command(
+                    item_name_selected, show_full_look_details
+                )  # _handle_look_command doesn't return action_taken flags
                 return True, True, TIME_UNITS_PER_PLAYER_ACTION, False
             elif secondary_action_input == "take":
-                action_taken, show_atmospherics = self.game_state._handle_take_command(item_name_selected)
+                action_taken, show_atmospherics = self.game_state._handle_take_command(
+                    item_name_selected
+                )
                 time_units = TIME_UNITS_PER_PLAYER_ACTION if action_taken else 0
                 return action_taken, show_atmospherics, time_units, False
             elif secondary_action_input == "read":
-                action_taken = self.game_state.handle_use_item(item_name_selected, None, "read")
+                action_taken = self.game_state.handle_use_item(
+                    item_name_selected, None, "read"
+                )
                 time_units = TIME_UNITS_PER_PLAYER_ACTION if action_taken else 0
                 return action_taken, False, time_units, False
             elif secondary_action_input == "use":
-                action_taken = self.game_state.handle_use_item(item_name_selected, None, "use_self_implicit")
+                action_taken = self.game_state.handle_use_item(
+                    item_name_selected, None, "use_self_implicit"
+                )
                 time_units = TIME_UNITS_PER_PLAYER_ACTION if action_taken else 0
                 return action_taken, False, time_units, False
             elif secondary_action_input.startswith("give to "):
                 target_npc_name = secondary_action_input.replace("give to ", "").strip()
                 if not target_npc_name:
-                    self.game_state._print_color("Who do you want to give it to?", Colors.RED)
+                    self.game_state._print_color(
+                        "Who do you want to give it to?", Colors.RED
+                    )
                     return False, False, 0, False
-                action_taken = self.game_state.handle_use_item(item_name_selected, target_npc_name, "give")
+                action_taken = self.game_state.handle_use_item(
+                    item_name_selected, target_npc_name, "give"
+                )
                 time_units = TIME_UNITS_PER_PLAYER_ACTION if action_taken else 0
                 return action_taken, False, time_units, False
             elif secondary_action_input.startswith("use on "):
                 target_for_use = secondary_action_input.replace("use on ", "").strip()
                 if not target_for_use:
-                    self.game_state._print_color("What do you want to use it on?", Colors.RED)
+                    self.game_state._print_color(
+                        "What do you want to use it on?", Colors.RED
+                    )
                     return False, False, 0, False
-                action_taken = self.game_state.handle_use_item(item_name_selected, target_for_use, "use_on")
+                action_taken = self.game_state.handle_use_item(
+                    item_name_selected, target_for_use, "use_on"
+                )
                 time_units = TIME_UNITS_PER_PLAYER_ACTION if action_taken else 0
                 return action_taken, False, time_units, False
             else:
-                self.game_state._print_color(f"Invalid action '{secondary_action_input}' for {item_name_selected}.", Colors.RED)
+                self.game_state._print_color(
+                    f"Invalid action '{secondary_action_input}' for {item_name_selected}.",
+                    Colors.RED,
+                )
                 return False, False, 0, False
-        elif command == "save": self.game_state.save_game(argument); action_taken_this_turn = False; show_atmospherics_this_turn = False
+        elif command == "save":
+            self.game_state.save_game(argument)
+            action_taken_this_turn = False
+            show_atmospherics_this_turn = False
         elif command == "load":
-            if self.game_state.load_game(argument): show_atmospherics_this_turn = True
-            else: show_atmospherics_this_turn = False
-            action_taken_this_turn = False; return action_taken_this_turn, show_atmospherics_this_turn, 0, "load_triggered"
-        elif command == "help": self.game_state.display_help(argument); action_taken_this_turn = False; show_atmospherics_this_turn = False
+            if self.game_state.load_game(argument):
+                show_atmospherics_this_turn = True
+            else:
+                show_atmospherics_this_turn = False
+            action_taken_this_turn = False
+            return (
+                action_taken_this_turn,
+                show_atmospherics_this_turn,
+                0,
+                "load_triggered",
+            )
+        elif command == "help":
+            self.game_state.display_help(argument)
+            action_taken_this_turn = False
+            show_atmospherics_this_turn = False
         elif command == "journal":
-            if self.game_state.player_character: self.game_state._print_color(self.game_state.player_character.get_journal_summary(), Colors.CYAN)
-            action_taken_this_turn = False; show_atmospherics_this_turn = False
-        elif command == "look": self.game_state._handle_look_command(argument, show_full_look_details)
-        elif command == "inventory": self.game_state._handle_inventory_command(); action_taken_this_turn = False; show_atmospherics_this_turn = False
-        elif command == "take": action_taken_this_turn, show_atmospherics_this_turn = self.game_state._handle_take_command(argument)
-        elif command == "drop": action_taken_this_turn, show_atmospherics_this_turn = self.game_state._handle_drop_command(argument)
-        elif command == "use": action_taken_this_turn = self.game_state._handle_use_command(argument); show_atmospherics_this_turn = False
-        elif command == "objectives": self.game_state.display_objectives(); action_taken_this_turn = False; show_atmospherics_this_turn = False
-        elif command == "think": self.game_state._handle_think_command(); show_atmospherics_this_turn = True
-        elif command == "wait": time_to_advance = self.game_state._handle_wait_command(); show_atmospherics_this_turn = True
-        elif command == "talk to": action_taken_this_turn, show_atmospherics_this_turn = self.game_state._handle_talk_to_command(argument)
-        elif command == "move to": action_taken_this_turn, show_atmospherics_this_turn = self.game_state.world_manager._handle_move_to_command(argument)
-        elif command == "persuade": action_taken_this_turn, show_atmospherics_this_turn = self.game_state._handle_persuade_command(argument)
-        elif command == "status": self.game_state._handle_status_command(); action_taken_this_turn = False; show_atmospherics_this_turn = False
+            if self.game_state.player_character:
+                self.game_state._print_color(
+                    self.game_state.player_character.get_journal_summary(), Colors.CYAN
+                )
+            action_taken_this_turn = False
+            show_atmospherics_this_turn = False
+        elif command == "look":
+            self.game_state._handle_look_command(argument, show_full_look_details)
+        elif command == "inventory":
+            self.game_state._handle_inventory_command()
+            action_taken_this_turn = False
+            show_atmospherics_this_turn = False
+        elif command == "take":
+            action_taken_this_turn, show_atmospherics_this_turn = (
+                self.game_state._handle_take_command(argument)
+            )
+        elif command == "drop":
+            action_taken_this_turn, show_atmospherics_this_turn = (
+                self.game_state._handle_drop_command(argument)
+            )
+        elif command == "use":
+            action_taken_this_turn = self.game_state._handle_use_command(argument)
+            show_atmospherics_this_turn = False
+        elif command == "objectives":
+            self.game_state.display_objectives()
+            action_taken_this_turn = False
+            show_atmospherics_this_turn = False
+        elif command == "think":
+            self.game_state._handle_think_command()
+            show_atmospherics_this_turn = True
+        elif command == "wait":
+            time_to_advance = self.game_state._handle_wait_command()
+            show_atmospherics_this_turn = True
+        elif command == "talk to":
+            action_taken_this_turn, show_atmospherics_this_turn = (
+                self.game_state._handle_talk_to_command(argument)
+            )
+        elif command == "move to":
+            action_taken_this_turn, show_atmospherics_this_turn = (
+                self.game_state.world_manager._handle_move_to_command(argument)
+            )
+        elif command == "persuade":
+            action_taken_this_turn, show_atmospherics_this_turn = (
+                self.game_state._handle_persuade_command(argument)
+            )
+        elif command == "status":
+            self.game_state._handle_status_command()
+            action_taken_this_turn = False
+            show_atmospherics_this_turn = False
         elif command == "toggle_lowai":
             self.game_state.low_ai_data_mode = not self.game_state.low_ai_data_mode
-            self.game_state._print_color(f"Low AI Data Mode is now {'ON' if self.game_state.low_ai_data_mode else 'OFF'}.", Colors.MAGENTA)
-            return False, False, 0, False # No action, no time, no atmospherics
+            self.game_state._print_color(
+                f"Low AI Data Mode is now {'ON' if self.game_state.low_ai_data_mode else 'OFF'}.",
+                Colors.MAGENTA,
+            )
+            return False, False, 0, False  # No action, no time, no atmospherics
         elif command == "history":
-            self.game_state._display_command_history(); action_taken_this_turn = False; show_atmospherics_this_turn = False
+            self.game_state._display_command_history()
+            action_taken_this_turn = False
+            show_atmospherics_this_turn = False
         elif command == "theme":
-            self._handle_theme_command(argument); action_taken_this_turn = False; show_atmospherics_this_turn = False
+            self._handle_theme_command(argument)
+            action_taken_this_turn = False
+            show_atmospherics_this_turn = False
         elif command == "verbosity":
-            self._handle_verbosity_command(argument); action_taken_this_turn = False; show_atmospherics_this_turn = False
+            self._handle_verbosity_command(argument)
+            action_taken_this_turn = False
+            show_atmospherics_this_turn = False
         elif command == "turnheaders":
-            self._handle_turnheaders_command(argument); action_taken_this_turn = False; show_atmospherics_this_turn = False
+            self._handle_turnheaders_command(argument)
+            action_taken_this_turn = False
+            show_atmospherics_this_turn = False
         elif command == "retry":
-            self._handle_retry_or_rephrase("retry"); action_taken_this_turn = False; show_atmospherics_this_turn = False
+            self._handle_retry_or_rephrase("retry")
+            action_taken_this_turn = False
+            show_atmospherics_this_turn = False
         elif command == "rephrase":
-            self._handle_retry_or_rephrase("rephrase"); action_taken_this_turn = False; show_atmospherics_this_turn = False
+            self._handle_retry_or_rephrase("rephrase")
+            action_taken_this_turn = False
+            show_atmospherics_this_turn = False
         else:
             suggestions = self._get_command_suggestions(command)
-            suggestion_text = f" Did you mean: {', '.join(suggestions)}?" if suggestions else ""
-            self.game_state._print_color(f"Unknown command: '{command}'. Type 'help' for a list of actions.{suggestion_text}", Colors.RED)
-            self.game_state._print_color(f"Try: {', '.join(self._get_contextual_command_examples())}", Colors.DIM)
-            action_taken_this_turn = False; show_atmospherics_this_turn = False
-        return action_taken_this_turn, show_atmospherics_this_turn, time_to_advance, False
+            suggestion_text = (
+                f" Did you mean: {', '.join(suggestions)}?" if suggestions else ""
+            )
+            self.game_state._print_color(
+                f"Unknown command: '{command}'. Type 'help' for a list of actions.{suggestion_text}",
+                Colors.RED,
+            )
+            self.game_state._print_color(
+                f"Try: {', '.join(self._get_contextual_command_examples())}", Colors.DIM
+            )
+            action_taken_this_turn = False
+            show_atmospherics_this_turn = False
+        return (
+            action_taken_this_turn,
+            show_atmospherics_this_turn,
+            time_to_advance,
+            False,
+        )

--- a/game_engine/display_mixin.py
+++ b/game_engine/display_mixin.py
@@ -4,8 +4,7 @@
 import re
 import random
 
-from .game_config import (Colors, DEFAULT_ITEMS, DEFAULT_VERBOSITY_LEVEL,
-                         STATIC_ATMOSPHERIC_DETAILS)
+from .game_config import Colors, DEFAULT_ITEMS, STATIC_ATMOSPHERIC_DETAILS
 
 
 class DisplayMixin:
@@ -35,7 +34,7 @@ class DisplayMixin:
         if not normalized:
             return normalized
         if self.verbosity_level == "brief":
-            sentence = re.split(r'(?<=[.!?])\s+', normalized, maxsplit=1)[0]
+            sentence = re.split(r"(?<=[.!?])\s+", normalized, maxsplit=1)[0]
             if len(sentence) > 180:
                 sentence = sentence[:177].rstrip() + "..."
             return sentence
@@ -51,7 +50,7 @@ class DisplayMixin:
         self._print_color(self._separator_line(), Colors.DIM)
         self._print_color(
             f"[{time_info} | {location} | {self.last_turn_result_icon} | Mode: {self._get_mode_label()}]",
-            Colors.DIM
+            Colors.DIM,
         )
 
     def _describe_item_brief(self, item_name):
@@ -68,23 +67,33 @@ class DisplayMixin:
         return ", ".join(tags) if tags else "common item"
 
     def _describe_npc_brief(self, npc_name):
-        npc = next((n for n in self.npcs_in_current_location if n.name == npc_name), None)
+        npc = next(
+            (n for n in self.npcs_in_current_location if n.name == npc_name), None
+        )
         if npc is None:
             return "person here"
         return f"appears {npc.apparent_state}"
 
     def _display_item_properties(self, item_default):
         properties_to_display = []
-        if item_default.get('readable', False): properties_to_display.append(f"Type: Readable")
-        if item_default.get('consumable', False): properties_to_display.append(f"Type: Consumable")
-        if item_default.get('value') is not None: properties_to_display.append(f"Value: {item_default['value']} kopeks")
-        if item_default.get('is_notable', False): properties_to_display.append(f"Trait: Notable")
-        if item_default.get('stackable', False): properties_to_display.append(f"Trait: Stackable")
-        if item_default.get('owner'): properties_to_display.append(f"Belongs to: {item_default['owner']}")
-        if item_default.get('use_effect_player'): properties_to_display.append(f"Action: Can be 'used'")
+        if item_default.get("readable", False):
+            properties_to_display.append("Type: Readable")
+        if item_default.get("consumable", False):
+            properties_to_display.append("Type: Consumable")
+        if item_default.get("value") is not None:
+            properties_to_display.append(f"Value: {item_default['value']} kopeks")
+        if item_default.get("is_notable", False):
+            properties_to_display.append("Trait: Notable")
+        if item_default.get("stackable", False):
+            properties_to_display.append("Trait: Stackable")
+        if item_default.get("owner"):
+            properties_to_display.append(f"Belongs to: {item_default['owner']}")
+        if item_default.get("use_effect_player"):
+            properties_to_display.append("Action: Can be 'used'")
         if properties_to_display:
             self._print_color("--- Properties ---", Colors.BLUE + Colors.BOLD)
-            for prop_str in properties_to_display: self._print_color(f"- {prop_str}", Colors.BLUE)
+            for prop_str in properties_to_display:
+                self._print_color(f"- {prop_str}", Colors.BLUE)
             self._print_color("", Colors.RESET)
 
     def _display_command_history(self):
@@ -100,18 +109,22 @@ class DisplayMixin:
         if self.player_action_count >= self.tutorial_turn_limit:
             return
         step = self.player_action_count + 1
-        if hasattr(self, 'command_handler') and hasattr(self.command_handler, '_build_intent_context'):
+        if hasattr(self, "command_handler") and hasattr(
+            self.command_handler, "_build_intent_context"
+        ):
             context = self.command_handler._build_intent_context()
         else:
             context = "none"
         talk_target = context["npcs"][0] if context.get("npcs") else "someone nearby"
-        move_target = context["exits"][0]["name"] if context.get("exits") else "an available exit"
+        move_target = (
+            context["exits"][0]["name"] if context.get("exits") else "an available exit"
+        )
         tutorial_lines = {
             1: "Tutorial 1/5: Start by using 'look' to survey this location.",
             2: f"Tutorial 2/5: Try 'talk to {talk_target}' to open a social path.",
             3: "Tutorial 3/5: Use 'objectives' to check your active direction.",
             4: f"Tutorial 4/5: Travel with 'move to {move_target}' when you're ready.",
-            5: "Tutorial 5/5: Need focused help? Try 'help movement' or 'help social'."
+            5: "Tutorial 5/5: Need focused help? Try 'help movement' or 'help social'.",
         }
         self._print_color(tutorial_lines.get(step, ""), Colors.DIM)
 
@@ -120,92 +133,171 @@ class DisplayMixin:
             details = None
             ai_generated = False
             if not self.low_ai_data_mode and self.gemini_api.model:
-                recently_visited = getattr(self.world_manager, 'last_visited_location', None) == self.current_location_name
+                recently_visited = (
+                    getattr(self.world_manager, "last_visited_location", None)
+                    == self.current_location_name
+                )
                 details = self.gemini_api.get_atmospheric_details(
-                    self.player_character, self.current_location_name, self.world_manager.get_current_time_period(),
-                    self.last_significant_event_summary, self._get_objectives_summary(self.player_character), recently_visited)
+                    self.player_character,
+                    self.current_location_name,
+                    self.world_manager.get_current_time_period(),
+                    self.last_significant_event_summary,
+                    self._get_objectives_summary(self.player_character),
+                    recently_visited,
+                )
                 self.world_manager.last_visited_location = self.current_location_name
 
-            if details is None or (isinstance(details, str) and details.startswith("(OOC:")) or self.low_ai_data_mode:
+            if (
+                details is None
+                or (isinstance(details, str) and details.startswith("(OOC:"))
+                or self.low_ai_data_mode
+            ):
                 if STATIC_ATMOSPHERIC_DETAILS:
                     details = random.choice(STATIC_ATMOSPHERIC_DETAILS)
                 else:
-                    details = "The atmosphere is thick with unspoken stories." # Ultimate fallback
+                    details = "The atmosphere is thick with unspoken stories."  # Ultimate fallback
             else:
                 ai_generated = True
 
-            if details: # Ensure details is not None if fallbacks were empty
-                 final_details = self._apply_verbosity(details)
-                 self._print_color(f"\n{final_details}", Colors.CYAN)
-                 if ai_generated:
-                     self._remember_ai_output(final_details, "atmosphere")
+            if details:  # Ensure details is not None if fallbacks were empty
+                final_details = self._apply_verbosity(details)
+                self._print_color(f"\n{final_details}", Colors.CYAN)
+                if ai_generated:
+                    self._remember_ai_output(final_details, "atmosphere")
             self.last_significant_event_summary = None
 
     def display_objectives(self):
         self._print_color("\n--- Your Objectives ---", Colors.CYAN + Colors.BOLD)
         if not self.player_character or not self.player_character.objectives:
-            self._print_color("You have no specific objectives at the moment.", Colors.DIM); return
-        active_objectives = [obj for obj in self.player_character.objectives if obj.get("active", False) and not obj.get("completed", False)]
-        completed_objectives = [obj for obj in self.player_character.objectives if obj.get("completed", False)]
+            self._print_color(
+                "You have no specific objectives at the moment.", Colors.DIM
+            )
+            return
+        active_objectives = [
+            obj
+            for obj in self.player_character.objectives
+            if obj.get("active", False) and not obj.get("completed", False)
+        ]
+        completed_objectives = [
+            obj
+            for obj in self.player_character.objectives
+            if obj.get("completed", False)
+        ]
         if not active_objectives and not completed_objectives:
-            self._print_color("You have no specific objectives at the moment.", Colors.DIM); return
+            self._print_color(
+                "You have no specific objectives at the moment.", Colors.DIM
+            )
+            return
         if active_objectives:
             self._print_color("\nOngoing:", Colors.YELLOW + Colors.BOLD)
             for obj in active_objectives:
-                self._print_color(f"- {obj.get('description', 'Unnamed objective')}", Colors.WHITE)
-                current_stage = self.player_character.get_current_stage_for_objective(obj.get('id'))
-                if current_stage: self._print_color(f"  Current Stage: {current_stage.get('description', 'No stage description')}", Colors.CYAN)
-        else: self._print_color("\nNo active objectives right now.", Colors.DIM)
+                self._print_color(
+                    f"- {obj.get('description', 'Unnamed objective')}", Colors.WHITE
+                )
+                current_stage = self.player_character.get_current_stage_for_objective(
+                    obj.get("id")
+                )
+                if current_stage:
+                    self._print_color(
+                        f"  Current Stage: {current_stage.get('description', 'No stage description')}",
+                        Colors.CYAN,
+                    )
+        else:
+            self._print_color("\nNo active objectives right now.", Colors.DIM)
         if completed_objectives:
             self._print_color("\nCompleted:", Colors.GREEN + Colors.BOLD)
-            for obj in completed_objectives: self._print_color(f"- {obj.get('description', 'Unnamed objective')}", Colors.WHITE)
+            for obj in completed_objectives:
+                self._print_color(
+                    f"- {obj.get('description', 'Unnamed objective')}", Colors.WHITE
+                )
 
     def display_help(self, category=None):
-        self._print_color("\n--- Available Actions ---", Colors.CYAN + Colors.BOLD); self._print_color("", Colors.RESET)
+        self._print_color("\n--- Available Actions ---", Colors.CYAN + Colors.BOLD)
+        self._print_color("", Colors.RESET)
         self._print_color(
             f"Mode: {self._get_mode_label()} | Theme: {self.color_theme} | Verbosity: {self.verbosity_level}",
-            Colors.DIM
+            Colors.DIM,
         )
         action_groups = {
             "movement": [
-                ("look / l / examine / observe / look around", "Examine surroundings, see people, items, and exits."),
-                ("look at [thing/person/scenery]", "Examine something specific more closely."),
+                (
+                    "look / l / examine / observe / look around",
+                    "Examine surroundings, see people, items, and exits.",
+                ),
+                (
+                    "look at [thing/person/scenery]",
+                    "Examine something specific more closely.",
+                ),
                 ("move to [exit desc / location name]", "Change locations."),
-                ("wait", "Pass some time (may trigger dreams if troubled).")
+                ("wait", "Pass some time (may trigger dreams if troubled)."),
             ],
             "social": [
                 ("talk to [name]", "Speak with someone here."),
-                ("persuade [name] that/to [argument]", "Try to sway a character with a focused argument."),
-                ("give [item name] to [target name]", "Offer an item to another character."),
-                ("think / reflect", "Access your character's inner thoughts.")
+                (
+                    "persuade [name] that/to [argument]",
+                    "Try to sway a character with a focused argument.",
+                ),
+                (
+                    "give [item name] to [target name]",
+                    "Offer an item to another character.",
+                ),
+                ("think / reflect", "Access your character's inner thoughts."),
             ],
             "items": [
                 ("inventory / inv / i", "Check your possessions."),
                 ("take [item name]", "Pick up an item from the location."),
-                ("drop [item name]", "Leave an item from your inventory in the location."),
-                ("use [item name]", "Attempt to use an item from your inventory (often on yourself)."),
-                ("use [item name] on [target name/item]", "Use an item on something or someone specifically."),
-                ("read [item name]", "Read a readable item like a letter or newspaper.")
+                (
+                    "drop [item name]",
+                    "Leave an item from your inventory in the location.",
+                ),
+                (
+                    "use [item name]",
+                    "Attempt to use an item from your inventory (often on yourself).",
+                ),
+                (
+                    "use [item name] on [target name/item]",
+                    "Use an item on something or someone specifically.",
+                ),
+                (
+                    "read [item name]",
+                    "Read a readable item like a letter or newspaper.",
+                ),
             ],
             "meta": [
                 ("objectives / obj", "See your current goals."),
-                ("journal / notes", "Review your journal entries (rumors, news, etc.)."),
-                ("save [slot]", "Save your current game progress (optional slot name)."),
+                (
+                    "journal / notes",
+                    "Review your journal entries (rumors, news, etc.).",
+                ),
+                (
+                    "save [slot]",
+                    "Save your current game progress (optional slot name).",
+                ),
                 ("load [slot]", "Load a previously saved game (optional slot name)."),
                 ("help / commands", "Show this help message."),
-                ("status / char / profile / st", "Display your character's current status."),
+                (
+                    "status / char / profile / st",
+                    "Display your character's current status.",
+                ),
                 ("toggle lowai / lowaimode", "Toggle low AI data usage mode."),
                 ("history / /history", "Show recent commands."),
                 ("!!", "Repeat your previous command."),
-                ("retry / rephrase", "Generate an alternate wording of the last AI text."),
+                (
+                    "retry / rephrase",
+                    "Generate an alternate wording of the last AI text.",
+                ),
                 ("theme [default|high-contrast|mono]", "Switch color profile."),
                 ("verbosity [brief|standard|rich]", "Adjust narrative text density."),
                 ("turnheaders [on|off]", "Toggle turn boundary headers."),
-                ("quit / exit / q", "Exit the game.")
-            ]
+                ("quit / exit / q", "Exit the game."),
+            ],
         }
 
-        normalized_category = category.strip().lower() if isinstance(category, str) and category.strip() else "all"
+        normalized_category = (
+            category.strip().lower()
+            if isinstance(category, str) and category.strip()
+            else "all"
+        )
         if normalized_category == "all":
             actions = [item for group in action_groups.values() for item in group]
         elif normalized_category in action_groups:
@@ -215,13 +307,19 @@ class DisplayMixin:
             available = ", ".join(action_groups.keys())
             self._print_color(
                 f"Unknown help category '{category}'. Available: {available}. Showing all commands.",
-                Colors.YELLOW
+                Colors.YELLOW,
             )
             actions = [item for group in action_groups.values() for item in group]
 
-        for cmd, desc in actions: self._print_color(f"{cmd:<65} {Colors.WHITE}- {desc}{Colors.RESET}", Colors.MAGENTA)
+        for cmd, desc in actions:
+            self._print_color(
+                f"{cmd:<65} {Colors.WHITE}- {desc}{Colors.RESET}", Colors.MAGENTA
+            )
         self._print_color("", Colors.RESET)
-        self._print_color("Tip: use 'help movement', 'help social', 'help items', or 'help meta'.", Colors.DIM)
+        self._print_color(
+            "Tip: use 'help movement', 'help social', 'help items', or 'help meta'.",
+            Colors.DIM,
+        )
         self._print_color("", Colors.RESET)
 
     def _display_load_recap(self):
@@ -230,7 +328,9 @@ class DisplayMixin:
 
         self._print_color("\n--- Session Recap ---", Colors.CYAN + Colors.BOLD)
         self._print_color(f"Location: {self.current_location_name}", Colors.WHITE)
-        self._print_color(f"Time: {self._get_current_game_time_period_str()}", Colors.WHITE)
+        self._print_color(
+            f"Time: {self._get_current_game_time_period_str()}", Colors.WHITE
+        )
 
         active_objective = None
         for objective in self.player_character.objectives:
@@ -238,13 +338,20 @@ class DisplayMixin:
                 active_objective = objective
                 break
         if active_objective:
-            stage = self.player_character.get_current_stage_for_objective(active_objective.get("id"))
+            stage = self.player_character.get_current_stage_for_objective(
+                active_objective.get("id")
+            )
             stage_text = stage.get("description") if stage else "unspecified stage"
-            self._print_color(f"Objective: {active_objective.get('description', 'Unnamed objective')} ({stage_text})", Colors.WHITE)
+            self._print_color(
+                f"Objective: {active_objective.get('description', 'Unnamed objective')} ({stage_text})",
+                Colors.WHITE,
+            )
         else:
             self._print_color("Objective: No active objective.", Colors.WHITE)
 
-        recent_events = self.key_events_occurred[-3:] if self.key_events_occurred else []
+        recent_events = (
+            self.key_events_occurred[-3:] if self.key_events_occurred else []
+        )
         if recent_events:
             self._print_color("Recent events:", Colors.WHITE)
             for event in recent_events:
@@ -256,67 +363,137 @@ class DisplayMixin:
                 continue
             score = getattr(character_obj, "relationship_with_player", 0)
             if score != 0:
-                relationship_entries.append((abs(score), character_name, self.get_relationship_text(score)))
+                relationship_entries.append(
+                    (abs(score), character_name, self.get_relationship_text(score))
+                )
         relationship_entries.sort(reverse=True)
         if relationship_entries:
             self._print_color("Relationship highlights:", Colors.WHITE)
             for _, character_name, relationship_text in relationship_entries[:3]:
-                self._print_color(f"- {character_name}: {relationship_text}", Colors.DIM)
+                self._print_color(
+                    f"- {character_name}: {relationship_text}", Colors.DIM
+                )
 
     def _display_turn_feedback(self, show_atmospherics_this_turn, command):
-        if show_atmospherics_this_turn: self.display_atmospheric_details()
-        elif command == "load": self.last_significant_event_summary = None
+        if show_atmospherics_this_turn:
+            self.display_atmospheric_details()
+        elif command == "load":
+            self.last_significant_event_summary = None
 
     def _handle_status_command(self):
-        if not self.player_character: self._print_color("No player character loaded.", Colors.RED); return
+        if not self.player_character:
+            self._print_color("No player character loaded.", Colors.RED)
+            return
         self._print_color("\n--- Your Status ---", Colors.CYAN + Colors.BOLD)
-        self._print_color(f"Name: {Colors.GREEN}{self.player_character.name}{Colors.RESET}", Colors.WHITE)
-        self._print_color(f"Apparent State: {Colors.YELLOW}{self.player_character.apparent_state}{Colors.RESET}", Colors.WHITE)
-        self._print_color(f"Current Location: {Colors.CYAN}{self.current_location_name}{Colors.RESET}", Colors.WHITE)
+        self._print_color(
+            f"Name: {Colors.GREEN}{self.player_character.name}{Colors.RESET}",
+            Colors.WHITE,
+        )
+        self._print_color(
+            f"Apparent State: {Colors.YELLOW}{self.player_character.apparent_state}{Colors.RESET}",
+            Colors.WHITE,
+        )
+        self._print_color(
+            f"Current Location: {Colors.CYAN}{self.current_location_name}{Colors.RESET}",
+            Colors.WHITE,
+        )
         notoriety_desc = "Unknown"
-        if self.player_notoriety_level == 0: notoriety_desc = "Unknown"
-        elif self.player_notoriety_level < 0.5: notoriety_desc = "Barely Noticed"
-        elif self.player_notoriety_level < 1.5: notoriety_desc = "Slightly Known"
-        elif self.player_notoriety_level < 2.5: notoriety_desc = "Talked About"
-        else: notoriety_desc = "Infamous"
-        self._print_color(f"Notoriety: {Colors.MAGENTA}{notoriety_desc} (Level {self.player_notoriety_level:.1f}){Colors.RESET}", Colors.WHITE)
-        ai_mode = "Low AI / Fallback Friendly" if self.low_ai_data_mode else "AI Dynamic"
-        self._print_color(f"Narrative Mode: {Colors.CYAN}{ai_mode}{Colors.RESET}", Colors.WHITE)
+        if self.player_notoriety_level == 0:
+            notoriety_desc = "Unknown"
+        elif self.player_notoriety_level < 0.5:
+            notoriety_desc = "Barely Noticed"
+        elif self.player_notoriety_level < 1.5:
+            notoriety_desc = "Slightly Known"
+        elif self.player_notoriety_level < 2.5:
+            notoriety_desc = "Talked About"
+        else:
+            notoriety_desc = "Infamous"
+        self._print_color(
+            f"Notoriety: {Colors.MAGENTA}{notoriety_desc} (Level {self.player_notoriety_level:.1f}){Colors.RESET}",
+            Colors.WHITE,
+        )
+        ai_mode = (
+            "Low AI / Fallback Friendly" if self.low_ai_data_mode else "AI Dynamic"
+        )
+        self._print_color(
+            f"Narrative Mode: {Colors.CYAN}{ai_mode}{Colors.RESET}", Colors.WHITE
+        )
         self._print_color(f"Theme: {self.color_theme}", Colors.WHITE)
         self._print_color(f"Verbosity: {self.verbosity_level}", Colors.WHITE)
-        self._print_color(f"Turn Headers: {'on' if self.turn_headers_enabled else 'off'}", Colors.WHITE)
+        self._print_color(
+            f"Turn Headers: {'on' if self.turn_headers_enabled else 'off'}",
+            Colors.WHITE,
+        )
         if self.player_action_count < self.tutorial_turn_limit:
-            self._print_color(f"Tutorial Progress: {self.player_action_count}/{self.tutorial_turn_limit} actions", Colors.DIM)
+            self._print_color(
+                f"Tutorial Progress: {self.player_action_count}/{self.tutorial_turn_limit} actions",
+                Colors.DIM,
+            )
         self._print_color("\n--- Skills ---", Colors.CYAN + Colors.BOLD)
         if self.player_character.skills:
-            for skill_name, value in self.player_character.skills.items(): self._print_color(f"- {skill_name.capitalize()}: {value}", Colors.WHITE)
-        else: self._print_color("No specialized skills.", Colors.DIM)
+            for skill_name, value in self.player_character.skills.items():
+                self._print_color(f"- {skill_name.capitalize()}: {value}", Colors.WHITE)
+        else:
+            self._print_color("No specialized skills.", Colors.DIM)
         self._print_color("\n--- Active Objectives ---", Colors.CYAN + Colors.BOLD)
-        active_objectives = [obj for obj in self.player_character.objectives if obj.get("active", False) and not obj.get("completed", False)]
+        active_objectives = [
+            obj
+            for obj in self.player_character.objectives
+            if obj.get("active", False) and not obj.get("completed", False)
+        ]
         if active_objectives:
             for obj in active_objectives:
-                self._print_color(f"- {obj.get('description', 'Unnamed objective')}", Colors.WHITE)
-                current_stage = self.player_character.get_current_stage_for_objective(obj.get('id'))
-                if current_stage: self._print_color(f"  Current Stage: {current_stage.get('description', 'No stage description')}", Colors.CYAN)
-        else: self._print_color("No active objectives.", Colors.DIM)
+                self._print_color(
+                    f"- {obj.get('description', 'Unnamed objective')}", Colors.WHITE
+                )
+                current_stage = self.player_character.get_current_stage_for_objective(
+                    obj.get("id")
+                )
+                if current_stage:
+                    self._print_color(
+                        f"  Current Stage: {current_stage.get('description', 'No stage description')}",
+                        Colors.CYAN,
+                    )
+        else:
+            self._print_color("No active objectives.", Colors.DIM)
         self._print_color("\n--- Inventory Highlights ---", Colors.CYAN + Colors.BOLD)
         if self.player_character.inventory:
             highlights = []
             for item_obj in self.player_character.inventory:
-                item_name = item_obj["name"]; item_qty = item_obj.get("quantity", 1)
+                item_name = item_obj["name"]
+                item_qty = item_obj.get("quantity", 1)
                 item_default_props = DEFAULT_ITEMS.get(item_name, {})
-                if (item_default_props.get("stackable") or item_default_props.get("value") is not None) and item_qty > 1: highlights.append(f"{item_name} (x{item_qty})")
-                else: highlights.append(item_name)
-            if highlights: self._print_color(", ".join(highlights), Colors.GREEN)
-            else: self._print_color("Carrying some items.", Colors.DIM)
-        else: self._print_color("Carrying nothing of note.", Colors.DIM)
-        self._print_color("\n--- Relationships ---", Colors.CYAN + Colors.BOLD); meaningful_relationships = False
+                if (
+                    item_default_props.get("stackable")
+                    or item_default_props.get("value") is not None
+                ) and item_qty > 1:
+                    highlights.append(f"{item_name} (x{item_qty})")
+                else:
+                    highlights.append(item_name)
+            if highlights:
+                self._print_color(", ".join(highlights), Colors.GREEN)
+            else:
+                self._print_color("Carrying some items.", Colors.DIM)
+        else:
+            self._print_color("Carrying nothing of note.", Colors.DIM)
+        self._print_color("\n--- Relationships ---", Colors.CYAN + Colors.BOLD)
+        meaningful_relationships = False
         for char_name, char_obj in self.all_character_objects.items():
-            if char_obj.is_player: continue
-            if hasattr(char_obj, 'relationship_with_player') and char_obj.relationship_with_player != 0:
-                relationship_text = self.get_relationship_text(char_obj.relationship_with_player)
-                self._print_color(f"- {char_name}: {relationship_text}", Colors.WHITE); meaningful_relationships = True
-        if not meaningful_relationships: self._print_color("No significant relationships established yet.", Colors.DIM)
+            if char_obj.is_player:
+                continue
+            if (
+                hasattr(char_obj, "relationship_with_player")
+                and char_obj.relationship_with_player != 0
+            ):
+                relationship_text = self.get_relationship_text(
+                    char_obj.relationship_with_player
+                )
+                self._print_color(f"- {char_name}: {relationship_text}", Colors.WHITE)
+                meaningful_relationships = True
+        if not meaningful_relationships:
+            self._print_color(
+                "No significant relationships established yet.", Colors.DIM
+            )
         self._print_color("", Colors.RESET)
 
     def _handle_inventory_command(self):
@@ -325,11 +502,24 @@ class DisplayMixin:
             inv_desc = self.player_character.get_inventory_description()
             if inv_desc.startswith("You are carrying: "):
                 items_str = inv_desc.replace("You are carrying: ", "", 1)
-                if items_str.lower() == "nothing.": self._print_color("- Nothing", Colors.DIM)
+                if items_str.lower() == "nothing.":
+                    self._print_color("- Nothing", Colors.DIM)
                 else:
                     items_list = items_str.split(", ")
-                    for item_with_details in items_list: self._print_color(f"- {item_with_details.rstrip('.')}", Colors.GREEN)
-                    if items_list: self._print_color("(Hint: You can 'use [item]', 'read [item]', 'drop [item]', or 'give [item] to [person]'.)", Colors.DIM)
-            elif inv_desc.lower() == "you are carrying nothing.": self._print_color("- Nothing", Colors.DIM)
-            else: print(inv_desc)
-        else: self._print_color("Cannot display inventory: Player character not available.", Colors.RED)
+                    for item_with_details in items_list:
+                        self._print_color(
+                            f"- {item_with_details.rstrip('.')}", Colors.GREEN
+                        )
+                    if items_list:
+                        self._print_color(
+                            "(Hint: You can 'use [item]', 'read [item]', 'drop [item]', or 'give [item] to [person]'.)",
+                            Colors.DIM,
+                        )
+            elif inv_desc.lower() == "you are carrying nothing.":
+                self._print_color("- Nothing", Colors.DIM)
+            else:
+                print(inv_desc)
+        else:
+            self._print_color(
+                "Cannot display inventory: Player character not available.", Colors.RED
+            )

--- a/game_engine/event_manager.py
+++ b/game_engine/event_manager.py
@@ -1,8 +1,15 @@
 # event_manager.py
 import random
-from .game_config import (Colors, DEFAULT_ITEMS, DEBUG_LOGS,
-                         STATIC_PLAYER_REFLECTIONS, STATIC_ANONYMOUS_NOTE_CONTENT,
-                         STATIC_STREET_LIFE_EVENTS, STATIC_NPC_NPC_INTERACTIONS)
+from .game_config import (
+    Colors,
+    DEFAULT_ITEMS,
+    DEBUG_LOGS,
+    STATIC_PLAYER_REFLECTIONS,
+    STATIC_ANONYMOUS_NOTE_CONTENT,
+    STATIC_STREET_LIFE_EVENTS,
+    STATIC_NPC_NPC_INTERACTIONS,
+)
+
 
 class EventManager:
     def __init__(self, game_ref):
@@ -14,110 +21,169 @@ class EventManager:
                 "name": "Encounter with Marmeladov",
                 "trigger": self.trigger_marmeladov_encounter,
                 "action": self.action_marmeladov_encounter,
-                "one_time": True
+                "one_time": True,
             },
             {
                 "id": "raskolnikov_receives_letter",
                 "name": "Letter from Mother",
                 "trigger": self.trigger_letter_from_mother,
                 "action": self.action_letter_from_mother,
-                "one_time": True
+                "one_time": True,
             },
             {
                 "id": "katerina_ivanovna_public_lament",
                 "name": "Katerina Ivanovna's Public Lament",
                 "trigger": self.trigger_katerina_public_lament,
                 "action": self.action_katerina_public_lament,
-                "one_time": False # Can happen periodically
+                "one_time": False,  # Can happen periodically
             },
-            { # New event for finding an anonymous note
+            {  # New event for finding an anonymous note
                 "id": "find_anonymous_warning_note",
                 "name": "Find an Anonymous Warning Note",
                 "trigger": self.trigger_find_anonymous_note,
                 "action": self.action_find_anonymous_note,
-                "one_time": True # Or could be multiple different notes
+                "one_time": True,  # Or could be multiple different notes
             },
             {
                 "id": "street_life_haymarket",
                 "name": "Street Life in Haymarket",
                 "trigger": self.trigger_street_life_haymarket,
                 "action": self.action_street_life_haymarket,
-                "one_time": False # Repeatable
-            }
+                "one_time": False,  # Repeatable
+            },
         ]
 
     def _print_event(self, text):
-        self.game._print_color(f"\n{Colors.BOLD}{Colors.MAGENTA}--- Event ---{Colors.RESET}", Colors.MAGENTA)
+        self.game._print_color(
+            f"\n{Colors.BOLD}{Colors.MAGENTA}--- Event ---{Colors.RESET}",
+            Colors.MAGENTA,
+        )
         self.game._print_color(text, Colors.MAGENTA)
-        self.game._print_color(f"{Colors.BOLD}{Colors.MAGENTA}-------------{Colors.RESET}\n", Colors.MAGENTA)
+        self.game._print_color(
+            f"{Colors.BOLD}{Colors.MAGENTA}-------------{Colors.RESET}\n",
+            Colors.MAGENTA,
+        )
 
     # --- Event Triggers ---
     def trigger_marmeladov_encounter(self):
-        return (self.game.player_character and self.game.player_character.name == "Rodion Raskolnikov" and
-                self.game.current_location_name == "Tavern" and
-                self.game.game_time > 20 and self.game.game_time < 70 and # Specific time window
-                "marmeladov_tavern_encounter" not in self.triggered_events)
+        return (
+            self.game.player_character
+            and self.game.player_character.name == "Rodion Raskolnikov"
+            and self.game.current_location_name == "Tavern"
+            and self.game.game_time > 20
+            and self.game.game_time < 70  # Specific time window
+            and "marmeladov_tavern_encounter" not in self.triggered_events
+        )
 
     def trigger_letter_from_mother(self):
-        return (self.game.player_character and self.game.player_character.name == "Rodion Raskolnikov" and
-                self.game.current_location_name == "Raskolnikov's Garret" and
-                self.game.game_time > 10 and self.game.game_time < 60 and
-                "raskolnikov_receives_letter" not in self.triggered_events)
+        return (
+            self.game.player_character
+            and self.game.player_character.name == "Rodion Raskolnikov"
+            and self.game.current_location_name == "Raskolnikov's Garret"
+            and self.game.game_time > 10
+            and self.game.game_time < 60
+            and "raskolnikov_receives_letter" not in self.triggered_events
+        )
 
     def trigger_katerina_public_lament(self):
         katerina = self.game.all_character_objects.get("Katerina Ivanovna Marmeladova")
-        return (katerina and katerina.current_location == "Haymarket Square" and
-                self.game.current_location_name == "Haymarket Square" and
-                self.game.get_current_time_period() in ["Afternoon", "Evening"] and
-                random.random() < 0.10 and # Reduced chance
-                "katerina_ivanovna_public_lament_recent" not in self.triggered_events)
-    
+        return (
+            katerina
+            and katerina.current_location == "Haymarket Square"
+            and self.game.current_location_name == "Haymarket Square"
+            and self.game.get_current_time_period() in ["Afternoon", "Evening"]
+            and random.random() < 0.10  # Reduced chance
+            and "katerina_ivanovna_public_lament_recent" not in self.triggered_events
+        )
+
     def trigger_find_anonymous_note(self):
         # Trigger if Raskolnikov's notoriety is rising and he's in a less secure place
-        return (self.game.player_character and self.game.player_character.name == "Rodion Raskolnikov" and
-                self.game.player_notoriety_level >= 1.5 and
-                self.game.current_location_name in ["Raskolnikov's Garret", "Stairwell (Outside Raskolnikov's Garret)"] and
-                random.random() < 0.25 and # Not too common
-                "find_anonymous_warning_note" not in self.triggered_events)
-
+        return (
+            self.game.player_character
+            and self.game.player_character.name == "Rodion Raskolnikov"
+            and self.game.player_notoriety_level >= 1.5
+            and self.game.current_location_name
+            in ["Raskolnikov's Garret", "Stairwell (Outside Raskolnikov's Garret)"]
+            and random.random() < 0.25  # Not too common
+            and "find_anonymous_warning_note" not in self.triggered_events
+        )
 
     # --- Event Actions ---
     def action_marmeladov_encounter(self):
-        event_desc = ("As you sit nursing a cheap drink, a disheveled man with flushed cheeks and rambling speech stumbles towards your table. "
+        event_desc = (
+            "As you sit nursing a cheap drink, a disheveled man with flushed cheeks and rambling speech stumbles towards your table. "
             "It is Semyon Zakharovich Marmeladov. He begins a lengthy, sorrowful monologue about his misfortunes, his daughter Sonya, "
-            "and his own wretchedness. You listen, or perhaps only half-listen, to his tragic tale.")
+            "and his own wretchedness. You listen, or perhaps only half-listen, to his tragic tale."
+        )
         self._print_event(event_desc)
         if self.game.player_character:
-            self.game.player_character.add_player_memory(memory_type="event_marmeladov_encounter", turn=self.game.game_time, content={"summary": "Listened to Marmeladov's tragic story in the tavern."}, sentiment_impact=1)
+            self.game.player_character.add_player_memory(
+                memory_type="event_marmeladov_encounter",
+                turn=self.game.game_time,
+                content={
+                    "summary": "Listened to Marmeladov's tragic story in the tavern."
+                },
+                sentiment_impact=1,
+            )
             if self.game.player_character.get_objective_by_id("understand_theory"):
-                 self.game.player_character.add_player_memory(memory_type="reflection_marmeladov_suffering", turn=self.game.game_time, content={"summary": "Marmeladov's suffering gives pause to your theories."}, sentiment_impact=1)
-        self.game.last_significant_event_summary = "encountered Marmeladov in the tavern."
+                self.game.player_character.add_player_memory(
+                    memory_type="reflection_marmeladov_suffering",
+                    turn=self.game.game_time,
+                    content={
+                        "summary": "Marmeladov's suffering gives pause to your theories."
+                    },
+                    sentiment_impact=1,
+                )
+        self.game.last_significant_event_summary = (
+            "encountered Marmeladov in the tavern."
+        )
         self.game.key_events_occurred.append("Encountered Marmeladov.")
         # This encounter might add to "known_facts_about_crime" if Marmeladov mentions Sonya's situation vaguely.
         if "Sonya" not in " ".join(self.game.known_facts_about_crime):
-            self.game.known_facts_about_crime.append("Heard of Sonya Marmeladova's difficult circumstances.")
-
+            self.game.known_facts_about_crime.append(
+                "Heard of Sonya Marmeladova's difficult circumstances."
+            )
 
     def action_letter_from_mother(self):
-        event_desc = ("A letter arrives for you, bearing the familiar handwriting of your mother, Pulcheria Alexandrovna. "
+        event_desc = (
+            "A letter arrives for you, bearing the familiar handwriting of your mother, Pulcheria Alexandrovna. "
             "It is filled with news from home, expressions of her deep love and concern for you, and details about Dunya's "
             "unfortunate situation with Mr. Svidrigailov and her subsequent engagement to Mr. Luzhin. "
             "Your mother expresses her hopes that Luzhin might be able to help you in your career. "
-            "The letter speaks of their imminent arrival in St. Petersburg.")
+            "The letter speaks of their imminent arrival in St. Petersburg."
+        )
         self._print_event(event_desc)
         if self.game.player_character:
-            self.game.player_character.add_player_memory(memory_type="event_mother_letter", turn=self.game.game_time, content={"summary": "Received a troubling letter from mother about Dunya and Luzhin."}, sentiment_impact=-1) # "Troubling" suggests negative sentiment
-            obj_help_family = self.game.player_character.get_objective_by_id("help_family")
+            self.game.player_character.add_player_memory(
+                memory_type="event_mother_letter",
+                turn=self.game.game_time,
+                content={
+                    "summary": "Received a troubling letter from mother about Dunya and Luzhin."
+                },
+                sentiment_impact=-1,
+            )  # "Troubling" suggests negative sentiment
+            obj_help_family = self.game.player_character.get_objective_by_id(
+                "help_family"
+            )
             if obj_help_family and not obj_help_family.get("active", True):
                 self.game.player_character.activate_objective("help_family")
             if not self.game.player_character.has_item("mother's letter"):
                 self.game.player_character.add_to_inventory("mother's letter")
-                self.game._print_color("The letter is now in your possession.", Colors.GREEN)
-            self.game._print_color("This news weighs heavily on your mind.", Colors.YELLOW)
+                self.game._print_color(
+                    "The letter is now in your possession.", Colors.GREEN
+                )
+            self.game._print_color(
+                "This news weighs heavily on your mind.", Colors.YELLOW
+            )
 
             # --- Enhanced emotional impact ---
-            self.game.player_character.apparent_state = random.choice(["agitated", "burdened", "thoughtful"])
-            self.game._print_color(f"(The contents of the letter leave you feeling deeply {self.game.player_character.apparent_state}.)", Colors.YELLOW)
+            self.game.player_character.apparent_state = random.choice(
+                ["agitated", "burdened", "thoughtful"]
+            )
+            self.game._print_color(
+                f"(The contents of the letter leave you feeling deeply {self.game.player_character.apparent_state}.)",
+                Colors.YELLOW,
+            )
 
             reflection_context = (
                 f"After reading the distressing letter from his mother about Dunya's engagement to Luzhin, "
@@ -128,7 +194,9 @@ class EventManager:
             )
 
             # Assuming get_objectives_summary is available and suitable for Gemini context
-            objectives_summary = self.game._get_objectives_summary(self.game.player_character)
+            objectives_summary = self.game._get_objectives_summary(
+                self.game.player_character
+            )
             reflection_text = None
 
             if not self.game.low_ai_data_mode and self.game.gemini_api.model:
@@ -137,32 +205,59 @@ class EventManager:
                     current_location_name=self.game.current_location_name,
                     current_time_period=self.game.get_current_time_period(),
                     context_text=reflection_context,
-                    active_objectives_summary=objectives_summary
+                    active_objectives_summary=objectives_summary,
                 )
 
-            if reflection_text is None or (isinstance(reflection_text, str) and reflection_text.startswith("(OOC:")) or self.game.low_ai_data_mode:
+            if (
+                reflection_text is None
+                or (
+                    isinstance(reflection_text, str)
+                    and reflection_text.startswith("(OOC:")
+                )
+                or self.game.low_ai_data_mode
+            ):
                 if STATIC_PLAYER_REFLECTIONS:
                     reflection_text = random.choice(STATIC_PLAYER_REFLECTIONS)
                 else:
-                    reflection_text = "Your mind is a whirl of conflicting emotions and calculations." # Ultimate fallback
-                self.game._print_color(f"Your thoughts race: \"{reflection_text}\"", Colors.DIM) # Static in DIM
-            else: # AI success
-                self.game._print_color(f"Your thoughts race: \"{reflection_text}\"", Colors.CYAN)
+                    reflection_text = "Your mind is a whirl of conflicting emotions and calculations."  # Ultimate fallback
+                self.game._print_color(
+                    f'Your thoughts race: "{reflection_text}"', Colors.DIM
+                )  # Static in DIM
+            else:  # AI success
+                self.game._print_color(
+                    f'Your thoughts race: "{reflection_text}"', Colors.CYAN
+                )
             # --- End enhanced emotional impact ---
 
-        self.game.last_significant_event_summary = "received a letter from his mother about Dunya."
-        self.game.key_events_occurred.append("Received letter from mother regarding Dunya's situation.")
+        self.game.last_significant_event_summary = (
+            "received a letter from his mother about Dunya."
+        )
+        self.game.key_events_occurred.append(
+            "Received letter from mother regarding Dunya's situation."
+        )
 
     def action_katerina_public_lament(self):
-        event_desc = ("A commotion draws your attention. Katerina Ivanovna Marmeladova is in the square, flushed and feverish, "
+        event_desc = (
+            "A commotion draws your attention. Katerina Ivanovna Marmeladova is in the square, flushed and feverish, "
             "her voice rising in a shrill lament. She clutches her children, decrying her fate, the injustice of her poverty, "
-            "and the memory of her supposedly noble birth. A small, unsympathetic crowd gathers to watch the spectacle.")
+            "and the memory of her supposedly noble birth. A small, unsympathetic crowd gathers to watch the spectacle."
+        )
         self._print_event(event_desc)
         katerina = self.game.all_character_objects.get("Katerina Ivanovna Marmeladova")
-        if katerina: katerina.apparent_state = "highly agitated and feverish"
+        if katerina:
+            katerina.apparent_state = "highly agitated and feverish"
         if self.game.player_character:
-            self.game.player_character.add_player_memory(memory_type="event_katerina_lament", turn=self.game.game_time, content={"summary": "Witnessed Katerina Ivanovna's distressing public scene in Haymarket."}, sentiment_impact=-1) # "Distressing" suggests negative sentiment
-        self.game.last_significant_event_summary = "witnessed Katerina Ivanovna's public outburst."
+            self.game.player_character.add_player_memory(
+                memory_type="event_katerina_lament",
+                turn=self.game.game_time,
+                content={
+                    "summary": "Witnessed Katerina Ivanovna's distressing public scene in Haymarket."
+                },
+                sentiment_impact=-1,
+            )  # "Distressing" suggests negative sentiment
+        self.game.last_significant_event_summary = (
+            "witnessed Katerina Ivanovna's public outburst."
+        )
         self.game.key_events_occurred.append("Katerina Ivanovna caused a public scene.")
         self.triggered_events.add("katerina_ivanovna_public_lament_recent")
 
@@ -180,42 +275,76 @@ class EventManager:
                 subject_matter=note_subject,
                 desired_tone=note_tone,
                 key_info_to_include=note_key_info,
-                length_sentences=2
+                length_sentences=2,
             )
 
-        if note_text is None or (isinstance(note_text, str) and note_text.startswith("(OOC:")) or self.game.low_ai_data_mode:
-            note_text = STATIC_ANONYMOUS_NOTE_CONTENT # Direct use of the static string
+        if (
+            note_text is None
+            or (isinstance(note_text, str) and note_text.startswith("(OOC:"))
+            or self.game.low_ai_data_mode
+        ):
+            note_text = STATIC_ANONYMOUS_NOTE_CONTENT  # Direct use of the static string
             # Optionally, add a log or slightly different handling for static note if needed
-        
-        if note_text: # Check if note_text is not None or empty after potential fallback
-            event_desc = f"Tucked into your doorframe (or perhaps slipped under your door), you find a hastily folded piece of paper. It's an anonymous note."
+
+        if (
+            note_text
+        ):  # Check if note_text is not None or empty after potential fallback
+            event_desc = "Tucked into your doorframe (or perhaps slipped under your door), you find a hastily folded piece of paper. It's an anonymous note."
             self._print_event(event_desc)
-            
+
             # Create the "anonymous note" item instance with this specific content
             # Option 1: Add to location (player must then take it)
-            note_item_instance = {"name": "anonymous note", "quantity": 1, "generated_content": note_text}
+            note_item_instance = {
+                "name": "anonymous note",
+                "quantity": 1,
+                "generated_content": note_text,
+            }
             # Ensure the base "anonymous note" is in DEFAULT_ITEMS with readable=True
             if "anonymous note" in DEFAULT_ITEMS:
-                self.game.dynamic_location_items.setdefault(self.game.current_location_name, []).append(note_item_instance)
-                self.game._print_color(f"An {Colors.GREEN}anonymous note{Colors.RESET} appears on the floor.", Colors.YELLOW) # Changed self to self.game
-                self.game.player_character.add_journal_entry("Note Found", f"Found an anonymous note: {note_text[:30]}...", self.game._get_current_game_time_period_str())
+                self.game.dynamic_location_items.setdefault(
+                    self.game.current_location_name, []
+                ).append(note_item_instance)
+                self.game._print_color(
+                    f"An {Colors.GREEN}anonymous note{Colors.RESET} appears on the floor.",
+                    Colors.YELLOW,
+                )  # Changed self to self.game
+                self.game.player_character.add_journal_entry(
+                    "Note Found",
+                    f"Found an anonymous note: {note_text[:30]}...",
+                    self.game._get_current_game_time_period_str(),
+                )
 
-            else: # Fallback if item not defined well
-                 self.game._print_color(f"You find a strange note: \"{note_text}\"", Colors.YELLOW) # Changed self to self.game
+            else:  # Fallback if item not defined well
+                self.game._print_color(
+                    f'You find a strange note: "{note_text}"', Colors.YELLOW
+                )  # Changed self to self.game
 
             if self.game.player_character:
-                self.game.player_character.add_player_memory(memory_type="event_found_anon_note", turn=self.game.game_time, content={"summary": "Found an ominous anonymous note."}, sentiment_impact=-1) # "Ominous" suggests negative sentiment
+                self.game.player_character.add_player_memory(
+                    memory_type="event_found_anon_note",
+                    turn=self.game.game_time,
+                    content={"summary": "Found an ominous anonymous note."},
+                    sentiment_impact=-1,
+                )  # "Ominous" suggests negative sentiment
                 self.game.player_character.apparent_state = "paranoid"
-            self.game.last_significant_event_summary = "found an anonymous warning note."
+            self.game.last_significant_event_summary = (
+                "found an anonymous warning note."
+            )
             self.game.key_events_occurred.append("Found an anonymous warning note.")
-            self.game.player_notoriety_level = min(self.game.player_notoriety_level + 0.5, 3) # Finding a note means someone *is* watching
+            self.game.player_notoriety_level = min(
+                self.game.player_notoriety_level + 0.5, 3
+            )  # Finding a note means someone *is* watching
         else:
-            self._print_event("You thought you saw something, but it was just a trick of the light.")
+            self._print_event(
+                "You thought you saw something, but it was just a trick of the light."
+            )
 
     def trigger_street_life_haymarket(self):
-        return (self.game.current_location_name == "Haymarket Square" and
-                random.random() < 0.10 and
-                "street_life_haymarket_recent" not in self.triggered_events)
+        return (
+            self.game.current_location_name == "Haymarket Square"
+            and random.random() < 0.10
+            and "street_life_haymarket_recent" not in self.triggered_events
+        )
 
     def action_street_life_haymarket(self):
         player_context = "observing the surroundings"
@@ -227,54 +356,82 @@ class EventManager:
             description = self.game.gemini_api.get_street_life_event_description(
                 self.game.current_location_name,
                 self.game.get_current_time_period(),
-                player_context
+                player_context,
             )
 
-        if description is None or (isinstance(description, str) and description.startswith("(OOC:")) or self.game.low_ai_data_mode:
+        if (
+            description is None
+            or (isinstance(description, str) and description.startswith("(OOC:"))
+            or self.game.low_ai_data_mode
+        ):
             if STATIC_STREET_LIFE_EVENTS:
                 description = random.choice(STATIC_STREET_LIFE_EVENTS)
             else:
-                description = "The usual hustle and bustle of the Haymarket continues around you." # Ultimate fallback
+                description = "The usual hustle and bustle of the Haymarket continues around you."  # Ultimate fallback
             # Print static description, perhaps with a different color or note
-            if description: # Ensure not None if list was empty
-                 self.game._print_color(f"\n{Colors.DIM}(Nearby, {description}){Colors.RESET}", Colors.DIM)
-        elif description: # AI success and not OOC
-            self.game._print_color(f"\n{Colors.DIM}(Nearby, {description}){Colors.RESET}", Colors.DIM)
+            if description:  # Ensure not None if list was empty
+                self.game._print_color(
+                    f"\n{Colors.DIM}(Nearby, {description}){Colors.RESET}", Colors.DIM
+                )
+        elif description:  # AI success and not OOC
+            self.game._print_color(
+                f"\n{Colors.DIM}(Nearby, {description}){Colors.RESET}", Colors.DIM
+            )
 
         # Common logic for adding to journal if a description was obtained
         if description and self.game.player_character:
-            self.game.player_character.add_journal_entry("Observation", description, self.game._get_current_game_time_period_str())
+            self.game.player_character.add_journal_entry(
+                "Observation",
+                description,
+                self.game._get_current_game_time_period_str(),
+            )
 
         self.triggered_events.add("street_life_haymarket_recent")
 
-
     def check_and_trigger_events(self):
-        if self.game.game_time % 50 == 0: # Cooldown reset periodically
+        if self.game.game_time % 50 == 0:  # Cooldown reset periodically
             if DEBUG_LOGS:
-                print(f"[DEBUG] EventManager: Checking event cooldowns at game time {self.game.game_time}")
-            events_to_remove = {ev for ev in self.triggered_events if ev.endswith("_recent")}
-            for ev_rem in events_to_remove: self.triggered_events.remove(ev_rem)
+                print(
+                    f"[DEBUG] EventManager: Checking event cooldowns at game time {self.game.game_time}"
+                )
+            events_to_remove = {
+                ev for ev in self.triggered_events if ev.endswith("_recent")
+            }
+            for ev_rem in events_to_remove:
+                self.triggered_events.remove(ev_rem)
 
         for event in self.story_events:
             event_id = event["id"]
             is_one_time = event.get("one_time", True)
-            if is_one_time and event_id in self.triggered_events: continue
-            if not is_one_time and f"{event_id}_recent" in self.triggered_events: continue
+            if is_one_time and event_id in self.triggered_events:
+                continue
+            if not is_one_time and f"{event_id}_recent" in self.triggered_events:
+                continue
             trigger_result = False
             try:
-                if callable(event["trigger"]): trigger_result = event["trigger"]()
+                if callable(event["trigger"]):
+                    trigger_result = event["trigger"]()
             except Exception as e:
-                self.game._print_color(f"Error in event trigger for '{event.get('id', 'unknown event')}': {e}", Colors.RED)
+                self.game._print_color(
+                    f"Error in event trigger for '{event.get('id', 'unknown event')}': {e}",
+                    Colors.RED,
+                )
             if trigger_result:
                 try:
-                    if callable(event["action"]): event["action"]()
-                    if is_one_time: self.triggered_events.add(event_id)
+                    if callable(event["action"]):
+                        event["action"]()
+                    if is_one_time:
+                        self.triggered_events.add(event_id)
                     # For repeatable, action should add "_recent" flag if needed
                     return True
                 except Exception as e:
-                     self.game._print_color(f"Error in event action for '{event.get('id', 'unknown event')}': {e}", Colors.RED)
-                     if is_one_time: self.triggered_events.add(event_id);
-                     return False
+                    self.game._print_color(
+                        f"Error in event action for '{event.get('id', 'unknown event')}': {e}",
+                        Colors.RED,
+                    )
+                    if is_one_time:
+                        self.triggered_events.add(event_id)
+                    return False
         return False
 
     def attempt_npc_npc_interaction(self):
@@ -284,47 +441,76 @@ class EventManager:
             except ValueError:
                 return False
 
-            self.game._print_color(f"\n{Colors.MAGENTA}Nearby, you overhear a brief exchange...{Colors.RESET}", Colors.MAGENTA)
+            self.game._print_color(
+                f"\n{Colors.MAGENTA}Nearby, you overhear a brief exchange...{Colors.RESET}",
+                Colors.MAGENTA,
+            )
             interaction_text = None
 
             if not self.game.low_ai_data_mode and self.game.gemini_api.model:
                 interaction_text = self.game.gemini_api.get_npc_to_npc_interaction(
-                    npc1, npc2,
+                    npc1,
+                    npc2,
                     self.game.current_location_name,
                     self.game.get_current_time_period(),
                     npc1_objectives_summary=self.game._get_objectives_summary(npc1),
-                    npc2_objectives_summary=self.game._get_objectives_summary(npc2)
+                    npc2_objectives_summary=self.game._get_objectives_summary(npc2),
                 )
 
-            if interaction_text is None or (isinstance(interaction_text, str) and interaction_text.startswith("(OOC:")) or self.game.low_ai_data_mode:
+            if (
+                interaction_text is None
+                or (
+                    isinstance(interaction_text, str)
+                    and interaction_text.startswith("(OOC:")
+                )
+                or self.game.low_ai_data_mode
+            ):
                 if STATIC_NPC_NPC_INTERACTIONS:
                     interaction_text = random.choice(STATIC_NPC_NPC_INTERACTIONS)
                 else:
-                    interaction_text = f"{npc1.name} and {npc2.name} exchange a few quiet words." # Ultimate fallback
+                    interaction_text = f"{npc1.name} and {npc2.name} exchange a few quiet words."  # Ultimate fallback
                 # No specific color change for static here, just print it like AI would have.
                 # The (OOC:) check is handled, so it won't print that.
 
-            if interaction_text: # Check if not None from fallback
+            if interaction_text:  # Check if not None from fallback
                 # Print the interaction first
-                lines = interaction_text.split('\n')
+                lines = interaction_text.split("\n")
                 for line in lines:
                     if ":" in line:
                         speaker, dialogue = line.split(":", 1)
-                        self.game._print_color(f"{speaker.strip()}:", Colors.YELLOW, end=""); print(f" \"{dialogue.strip()}\"")
+                        self.game._print_color(
+                            f"{speaker.strip()}:", Colors.YELLOW, end=""
+                        )
+                        print(f' "{dialogue.strip()}"')
                     else:
-                        self.game._print_color(f"{Colors.DIM}{line}{Colors.RESET}", Colors.DIM)
+                        self.game._print_color(
+                            f"{Colors.DIM}{line}{Colors.RESET}", Colors.DIM
+                        )
 
                 # Now, try to identify and process rumors
-                rumor_keywords = ["did you hear", "they say", "i heard that", "word is", "gossip has it", "rumor is"]
+                rumor_keywords = [
+                    "did you hear",
+                    "they say",
+                    "i heard that",
+                    "word is",
+                    "gossip has it",
+                    "rumor is",
+                ]
                 potential_rumor_identified = False
                 extracted_rumor_core = ""
 
-                for line in lines: # Iterate again for rumor check
+                for line in lines:  # Iterate again for rumor check
                     for keyword in rumor_keywords:
                         if keyword in line.lower():
                             try:
-                                rumor_part_index = line.lower().find(keyword) + len(keyword)
-                                rumor_candidate = line[rumor_part_index:].strip(" .,;:!?-").capitalize()
+                                rumor_part_index = line.lower().find(keyword) + len(
+                                    keyword
+                                )
+                                rumor_candidate = (
+                                    line[rumor_part_index:]
+                                    .strip(" .,;:!?-")
+                                    .capitalize()
+                                )
                                 if len(rumor_candidate) > 15:
                                     extracted_rumor_core = rumor_candidate
                                     potential_rumor_identified = True
@@ -335,22 +521,29 @@ class EventManager:
                         break
 
                 if potential_rumor_identified and extracted_rumor_core:
-                    if not hasattr(self.game, 'overheard_rumors'):
+                    if not hasattr(self.game, "overheard_rumors"):
                         self.game.overheard_rumors = []
 
                     MAX_OVERHEARD_RUMORS = 10
                     if len(self.game.overheard_rumors) >= MAX_OVERHEARD_RUMORS:
                         self.game.overheard_rumors.pop(0)
 
-                    rumor_to_add = f"Overheard between {npc1.name} and {npc2.name}: \"{extracted_rumor_core[:150]}...\""
+                    rumor_to_add = f'Overheard between {npc1.name} and {npc2.name}: "{extracted_rumor_core[:150]}..."'
                     if rumor_to_add not in self.game.overheard_rumors:
-                         self.game.overheard_rumors.append(rumor_to_add)
+                        self.game.overheard_rumors.append(rumor_to_add)
 
-                    self.game._print_color(f"\n{Colors.MAGENTA}(You overhear an intriguing snippet of gossip...){Colors.RESET}", Colors.MAGENTA)
+                    self.game._print_color(
+                        f"\n{Colors.MAGENTA}(You overhear an intriguing snippet of gossip...){Colors.RESET}",
+                        Colors.MAGENTA,
+                    )
                     if self.game.player_character:
-                        self.game.player_character.add_journal_entry("Gossip Overheard", extracted_rumor_core, self.game._get_current_game_time_period_str())
+                        self.game.player_character.add_journal_entry(
+                            "Gossip Overheard",
+                            extracted_rumor_core,
+                            self.game._get_current_game_time_period_str(),
+                        )
 
-                return True # Interaction happened (and was printed)
+                return True  # Interaction happened (and was printed)
             else:
                 # self.game._print_color(f"{Colors.MAGENTA}...but it trails off into indistinct murmurs.{Colors.RESET}", Colors.MAGENTA)
                 pass

--- a/game_engine/game_config.py
+++ b/game_engine/game_config.py
@@ -3,82 +3,86 @@ import json
 import logging
 import sys
 import os
+import random
+
 
 def get_base_path():
     try:
         base_path = sys._MEIPASS
         logging.info(f"Using MEIPASS: {base_path}")
     except AttributeError:
-        base_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+        base_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
         logging.info(f"Using dirname: {base_path}")
     return base_path
+
 
 def get_data_path(relative_path):
     p = os.path.join(get_base_path(), relative_path)
     if not os.path.exists(p):
         print(f"ERROR: Could not find data path explicitly at: {p}")
-        # Try to resolve relative to CWD instead as an absolute last resort 
+        # Try to resolve relative to CWD instead as an absolute last resort
         alt_p = os.path.join(os.getcwd(), relative_path)
         if os.path.exists(alt_p):
-             print(f"Found it at alt_p: {alt_p}")
-             return alt_p
+            print(f"Found it at alt_p: {alt_p}")
+            return alt_p
     return p
+
 
 # --- ANSI Color Codes ---
 class Colors:
-    RESET = '\033[0m'
-    RED = '\033[91m'
-    GREEN = '\033[92m'
-    YELLOW = '\033[93m'
-    BLUE = '\033[94m'
-    MAGENTA = '\033[95m'
-    CYAN = '\033[96m'
-    WHITE = '\033[97m'
-    BOLD = '\033[1m'
-    DIM = '\033[2m' # For less prominent text like timestamps
-    UNDERLINE = '\033[4m'
+    RESET = "\033[0m"
+    RED = "\033[91m"
+    GREEN = "\033[92m"
+    YELLOW = "\033[93m"
+    BLUE = "\033[94m"
+    MAGENTA = "\033[95m"
+    CYAN = "\033[96m"
+    WHITE = "\033[97m"
+    BOLD = "\033[1m"
+    DIM = "\033[2m"  # For less prominent text like timestamps
+    UNDERLINE = "\033[4m"
 
 
 COLOR_THEME_MAP = {
     "default": {
-        "RESET": '\033[0m',
-        "RED": '\033[91m',
-        "GREEN": '\033[92m',
-        "YELLOW": '\033[93m',
-        "BLUE": '\033[94m',
-        "MAGENTA": '\033[95m',
-        "CYAN": '\033[96m',
-        "WHITE": '\033[97m',
-        "BOLD": '\033[1m',
-        "DIM": '\033[2m',
-        "UNDERLINE": '\033[4m',
+        "RESET": "\033[0m",
+        "RED": "\033[91m",
+        "GREEN": "\033[92m",
+        "YELLOW": "\033[93m",
+        "BLUE": "\033[94m",
+        "MAGENTA": "\033[95m",
+        "CYAN": "\033[96m",
+        "WHITE": "\033[97m",
+        "BOLD": "\033[1m",
+        "DIM": "\033[2m",
+        "UNDERLINE": "\033[4m",
     },
     "high-contrast": {
-        "RESET": '\033[0m',
-        "RED": '\033[1;97;41m',
-        "GREEN": '\033[1;30;102m',
-        "YELLOW": '\033[1;30;103m',
-        "BLUE": '\033[1;97;44m',
-        "MAGENTA": '\033[1;97;45m',
-        "CYAN": '\033[1;30;106m',
-        "WHITE": '\033[1;97m',
-        "BOLD": '\033[1m',
-        "DIM": '\033[2m',
-        "UNDERLINE": '\033[4m',
+        "RESET": "\033[0m",
+        "RED": "\033[1;97;41m",
+        "GREEN": "\033[1;30;102m",
+        "YELLOW": "\033[1;30;103m",
+        "BLUE": "\033[1;97;44m",
+        "MAGENTA": "\033[1;97;45m",
+        "CYAN": "\033[1;30;106m",
+        "WHITE": "\033[1;97m",
+        "BOLD": "\033[1m",
+        "DIM": "\033[2m",
+        "UNDERLINE": "\033[4m",
     },
     "mono": {
-        "RESET": '\033[0m',
-        "RED": '',
-        "GREEN": '',
-        "YELLOW": '',
-        "BLUE": '',
-        "MAGENTA": '',
-        "CYAN": '',
-        "WHITE": '',
-        "BOLD": '\033[1m',
-        "DIM": '\033[2m',
-        "UNDERLINE": '\033[4m',
-    }
+        "RESET": "\033[0m",
+        "RED": "",
+        "GREEN": "",
+        "YELLOW": "",
+        "BLUE": "",
+        "MAGENTA": "",
+        "CYAN": "",
+        "WHITE": "",
+        "BOLD": "\033[1m",
+        "DIM": "\033[2m",
+        "UNDERLINE": "\033[4m",
+    },
 }
 
 
@@ -102,23 +106,53 @@ apply_color_theme(DEFAULT_COLOR_THEME)
 SAVE_GAME_FILE = "savegame.json"
 
 # --- Gameplay Constants ---
-DREAM_CHANCE_NORMAL_STATE = 0.05 # Chance of dream on new day if normal state
-DREAM_CHANCE_TROUBLED_STATE = 0.35 # Chance if feverish, agitated etc. on new day/long wait
-RUMOR_CHANCE_PER_NPC_INTERACTION = 0.15 # Chance an NPC shares a rumor during dialogue
-AMBIENT_RUMOR_CHANCE_PUBLIC_PLACE = 0.05 # Chance to overhear ambient rumor in public
-NPC_SHARE_RUMOR_MIN_RELATIONSHIP = -2 # NPC won't share rumors if relationship is too low
+DREAM_CHANCE_NORMAL_STATE = 0.05  # Chance of dream on new day if normal state
+DREAM_CHANCE_TROUBLED_STATE = (
+    0.35  # Chance if feverish, agitated etc. on new day/long wait
+)
+RUMOR_CHANCE_PER_NPC_INTERACTION = 0.15  # Chance an NPC shares a rumor during dialogue
+AMBIENT_RUMOR_CHANCE_PUBLIC_PLACE = 0.05  # Chance to overhear ambient rumor in public
+NPC_SHARE_RUMOR_MIN_RELATIONSHIP = (
+    -2
+)  # NPC won't share rumors if relationship is too low
 DEBUG_LOGS = False
 
 # --- Phrases that might indicate a natural end to a conversation ---
 CONCLUDING_PHRASES = [
     r"\b(goodbye|farewell|i must be going|i have to go|until next time|that is all|nothing more to say|very well then|i see)\b",
     r"^(enough|that will be all|we are done here|indeed)\.?$",
-    r"\b(i'm done|nothing else|that's it|exit conversation|end dialogue|stop talking|no more questions)\b" # Added more ways
+    r"\b(i'm done|nothing else|that's it|exit conversation|end dialogue|stop talking|no more questions)\b",  # Added more ways
 ]
 
 # --- Simplified keywords for relationship adjustments ---
-POSITIVE_KEYWORDS = ["friend", "help", "thank", "agree", "understand", "kind", "sorry", "apologize", "sympathize", "comfort", "give", "offer"]
-NEGATIVE_KEYWORDS = ["hate", "stupid", "fool", "annoy", "disagree", "refuse", "threaten", "never", "accuse", "doubt", "take", "demand"]
+POSITIVE_KEYWORDS = [
+    "friend",
+    "help",
+    "thank",
+    "agree",
+    "understand",
+    "kind",
+    "sorry",
+    "apologize",
+    "sympathize",
+    "comfort",
+    "give",
+    "offer",
+]
+NEGATIVE_KEYWORDS = [
+    "hate",
+    "stupid",
+    "fool",
+    "annoy",
+    "disagree",
+    "refuse",
+    "threaten",
+    "never",
+    "accuse",
+    "doubt",
+    "take",
+    "demand",
+]
 
 # --- Time System ---
 TIME_UNITS_PER_PLAYER_ACTION = 1
@@ -131,17 +165,18 @@ TIME_PERIODS = {
     "Morning": (0, 50),
     "Afternoon": (51, 120),
     "Evening": (121, 180),
-    "Night": (181, 240)
+    "Night": (181, 240),
 }
 MAX_TIME_UNITS_PER_DAY = 240
+
 
 # --- Default Item Definitions ---
 def load_default_items(data_path=None):
     if data_path is None:
-        data_path = get_data_path('data/items.json')
+        data_path = get_data_path("data/items.json")
     """Loads default item data from a JSON file."""
     try:
-        with open(data_path, 'r', encoding='utf-8') as f:
+        with open(data_path, "r", encoding="utf-8") as f:
             return json.load(f)
     except FileNotFoundError:
         logging.error(f"Error: The items data file was not found at {data_path}")
@@ -150,11 +185,12 @@ def load_default_items(data_path=None):
         logging.error(f"Error: The items data file at {data_path} is not a valid JSON.")
         return {}
 
+
 DEFAULT_ITEMS = load_default_items()
 
 # --- Input Parsing ---
 COMMAND_SYNONYMS = {
-    "look": ["examine", "l", "observe", "look around"], # Added "look around"
+    "look": ["examine", "l", "observe", "look around"],  # Added "look around"
     "talk to": ["speak to", "chat with", "ask", "question"],
     "move to": ["go to", "walk to", "travel to", "head to"],
     "objectives": ["goals", "tasks", "obj", "purpose"],
@@ -170,7 +206,7 @@ COMMAND_SYNONYMS = {
     "save": ["save game"],
     "load": ["load game"],
     "quit": ["exit", "q"],
-    "persuade": ["convince", "argue with"], # New command
+    "persuade": ["convince", "argue with"],  # New command
     "status": ["char", "character", "profile", "st"],
     "toggle_lowai": ["toggle lowai", "lowaimode"],
     "history": ["/history", "hist"],
@@ -178,15 +214,30 @@ COMMAND_SYNONYMS = {
     "verbosity": ["density", "text density"],
     "turnheaders": ["turn headers", "turn header"],
     "retry": [],
-    "rephrase": []
+    "rephrase": [],
 }
 
 # --- Player States (for NPC reactions) ---
 PLAYER_APPARENT_STATES = [
-    "normal", "agitated", "feverish", "suspiciously calm", "despondent",
-    "injured", "contemplative", "thoughtful", "burdened", "dangerously agitated",
-    "less feverish", "slightly drunk", "remorseful", "resolved", "hopeful", "paranoid",
-    "haunted by dreams", "intrigued by rumors", "intensely persuasive"
+    "normal",
+    "agitated",
+    "feverish",
+    "suspiciously calm",
+    "despondent",
+    "injured",
+    "contemplative",
+    "thoughtful",
+    "burdened",
+    "dangerously agitated",
+    "less feverish",
+    "slightly drunk",
+    "remorseful",
+    "resolved",
+    "hopeful",
+    "paranoid",
+    "haunted by dreams",
+    "intrigued by rumors",
+    "intensely persuasive",
 ]
 
 # --- UI Elements ---
@@ -196,8 +247,12 @@ SPINNER_FRAMES = ["|", "/", "-", "\\"]
 
 # --- NPC Memory Configuration ---
 HIGHLY_NOTABLE_ITEMS_FOR_MEMORY = [
-    "raskolnikov's axe", "bloodied rag", "lizaveta's bundle",
-    "sonya's cypress cross", "sonya's new testament", "mother's letter"
+    "raskolnikov's axe",
+    "bloodied rag",
+    "lizaveta's bundle",
+    "sonya's cypress cross",
+    "sonya's new testament",
+    "mother's letter",
 ]
 
 # --- Generic Scenery Keywords (for "look at scenery") ---
@@ -205,82 +260,107 @@ HIGHLY_NOTABLE_ITEMS_FOR_MEMORY = [
 # If the player "looks at" one of these, and it's not a defined item,
 # the AI can generate a description.
 GENERIC_SCENERY_KEYWORDS = [
-    "wallpaper", "window", "stain", "floor", "ceiling", "door", "street",
-    "corner", "shadow", "light", "cobblestones", "wall", "furniture",
-    "table", "chair", "bed", "painting", "mirror", "dust", "grime",
-    "candle", "gaslight", "sky", "canal", "building", "crowd"
+    "wallpaper",
+    "window",
+    "stain",
+    "floor",
+    "ceiling",
+    "door",
+    "street",
+    "corner",
+    "shadow",
+    "light",
+    "cobblestones",
+    "wall",
+    "furniture",
+    "table",
+    "chair",
+    "bed",
+    "painting",
+    "mirror",
+    "dust",
+    "grime",
+    "candle",
+    "gaslight",
+    "sky",
+    "canal",
+    "building",
+    "crowd",
 ]
 
 # --- Static Fallbacks for AI Generation (if API fails or is not configured) ---
-import random
 
 STATIC_ATMOSPHERIC_DETAILS = [
     "The air is heavy and still.",
     "A distant sound briefly catches your attention, then fades.",
     "Shadows lengthen around you.",
     "The usual city noise drones on.",
-    "A sense of unease hangs in the air."
+    "A sense of unease hangs in the air.",
 ]
 
 STATIC_NPC_NPC_INTERACTIONS = [
     "NPC1: The times are hard, wouldn't you agree?\nNPC2: Indeed. One must be careful.",
     "NPC1: Did you see the price of bread today?\nNPC2: Scandalous!",
     "You overhear two figures nearby discussing trivial matters.",
-    "Two NPCs are talking nearby, but their words are indistinct."
+    "Two NPCs are talking nearby, but their words are indistinct.",
 ]
 
 STATIC_DREAM_SEQUENCES = [
     "You had a restless night filled with strange, fleeting images.",
     "Vague, unsettling dreams disturbed your sleep.",
-    "Fragments of a troubling dream cling to your mind, but the details are lost."
+    "Fragments of a troubling dream cling to your mind, but the details are lost.",
 ]
 
 STATIC_RUMORS = [
     "Someone mentions a recent string of petty thefts in the Haymarket.",
     "There's talk of a new decree from the governor.",
-    "People are saying the summer will be unusually hot."
+    "People are saying the summer will be unusually hot.",
 ]
 
 STATIC_NEWSPAPER_SNIPPETS = [
     "The newspaper reports on minor bureaucratic changes.",
     "An article discusses crop yields in a distant province. It holds little interest.",
     "The pages are filled with dull advertisements and local notices.",
-    "You scan the headlines, but nothing seems particularly noteworthy today."
+    "You scan the headlines, but nothing seems particularly noteworthy today.",
 ]
+
 
 def generate_static_scenery_observation(scenery_noun_phrase):
     options = [
         f"You observe the {scenery_noun_phrase}. It is as it seems.",
         f"The {scenery_noun_phrase} is unremarkable.",
-        f"You find nothing special about the {scenery_noun_phrase}."
+        f"You find nothing special about the {scenery_noun_phrase}.",
     ]
     return random.choice(options)
+
 
 STATIC_STREET_LIFE_EVENTS = [
     "A carriage rattles noisily down the cobblestones.",
     "Two merchants haggle loudly over a price.",
     "A stray dog darts through the crowd.",
-    "Children's laughter is heard from a nearby alley."
+    "Children's laughter is heard from a nearby alley.",
 ]
 
 STATIC_ENHANCED_OBSERVATIONS = [
     "You notice a few minor details, but nothing immediately actionable.",
     "Your keen senses pick up on the usual subtleties of the place.",
-    "Despite your efforts, nothing further of note catches your eye."
+    "Despite your efforts, nothing further of note catches your eye.",
 ]
 
 STATIC_PLAYER_REFLECTIONS = [
     "Your thoughts are a jumble.",
     "You ponder your situation.",
     "The weight of your circumstances presses upon you.",
-    "A wave of weariness washes over you."
+    "A wave of weariness washes over you.",
 ]
+
 
 def generate_static_item_interaction_description(item_name, action_type):
     options = [
         f"You {action_type} the {item_name} for a moment, but no special insight comes to mind.",
-        f"You handle the {item_name}, but it seems ordinary under your {action_type}."
+        f"You handle the {item_name}, but it seems ordinary under your {action_type}.",
     ]
     return random.choice(options)
+
 
 STATIC_ANONYMOUS_NOTE_CONTENT = "They know. Watched at every turn. The old woman is not the only ghost that haunts these streets. Burn this."

--- a/game_engine/game_state.py
+++ b/game_engine/game_state.py
@@ -3,27 +3,18 @@ import json
 import os
 import re
 import random
-import copy
-import difflib
 from typing import Set, Optional, List, Dict, Any, Tuple
 
-from .game_config import (Colors, SAVE_GAME_FILE, # API_CONFIG_FILE, GEMINI_MODEL_NAME removed
-                         CONCLUDING_PHRASES, POSITIVE_KEYWORDS, NEGATIVE_KEYWORDS,
-                         TIME_UNITS_PER_PLAYER_ACTION, MAX_TIME_UNITS_PER_DAY, TIME_PERIODS,
-                         TIME_UNITS_FOR_NPC_INTERACTION_CHANCE, NPC_INTERACTION_CHANCE,
-                         TIME_UNITS_FOR_NPC_SCHEDULE_UPDATE, NPC_MOVE_CHANCE,
-                         DEFAULT_ITEMS, COMMAND_SYNONYMS, PLAYER_APPARENT_STATES,
-                         DREAM_CHANCE_NORMAL_STATE, DREAM_CHANCE_TROUBLED_STATE,
-                         RUMOR_CHANCE_PER_NPC_INTERACTION, AMBIENT_RUMOR_CHANCE_PUBLIC_PLACE,
-                         NPC_SHARE_RUMOR_MIN_RELATIONSHIP, GENERIC_SCENERY_KEYWORDS,
-                         HIGHLY_NOTABLE_ITEMS_FOR_MEMORY,
-                         apply_color_theme, COLOR_THEME_MAP, DEFAULT_COLOR_THEME,
-                         DEFAULT_VERBOSITY_LEVEL, VERBOSITY_LEVELS,
-                         STATIC_ATMOSPHERIC_DETAILS, generate_static_scenery_observation, # Added
-                         STATIC_PLAYER_REFLECTIONS, STATIC_ENHANCED_OBSERVATIONS,      # Added
-                         STATIC_NEWSPAPER_SNIPPETS, STATIC_DREAM_SEQUENCES,            # Added
-                         generate_static_item_interaction_description, STATIC_RUMORS)  # Added
-from .game_config import DEBUG_LOGS
+from .game_config import (
+    Colors,
+    SAVE_GAME_FILE,  # API_CONFIG_FILE, GEMINI_MODEL_NAME removed
+    TIME_UNITS_PER_PLAYER_ACTION,
+    apply_color_theme,
+    DEFAULT_COLOR_THEME,
+    DEFAULT_VERBOSITY_LEVEL,
+    VERBOSITY_LEVELS,
+    STATIC_PLAYER_REFLECTIONS,
+)  # Added
 from .character_module import Character, CHARACTERS_DATA
 from .location_module import LOCATIONS_DATA
 from .gemini_interactions import GeminiAPI, NaturalLanguageParser
@@ -33,6 +24,15 @@ from .command_handler import CommandHandler
 from .item_interaction_handler import ItemInteractionHandler
 from .npc_interaction_handler import NPCInteractionHandler
 from .world_manager import WorldManager
+
+# Re-exported for test patching compatibility.
+from .game_config import (
+    STATIC_ATMOSPHERIC_DETAILS as STATIC_ATMOSPHERIC_DETAILS,
+)  # noqa: F401
+from .game_config import (
+    STATIC_NEWSPAPER_SNIPPETS as STATIC_NEWSPAPER_SNIPPETS,
+)  # noqa: F401
+
 
 class Game(DisplayMixin, ItemInteractionHandler, NPCInteractionHandler, EventManager):
     def __init__(self) -> None:
@@ -59,7 +59,9 @@ class Game(DisplayMixin, ItemInteractionHandler, NPCInteractionHandler, EventMan
         self.visited_locations: Set[str] = set()
 
         self.player_notoriety_level = 0
-        self.known_facts_about_crime = ["An old pawnbroker and her sister were murdered recently."]
+        self.known_facts_about_crime = [
+            "An old pawnbroker and her sister were murdered recently."
+        ]
         self.key_events_occurred = ["Game started."]
         self.numbered_actions_context: List[Any] = []
         self.current_conversation_log = []
@@ -89,17 +91,25 @@ class Game(DisplayMixin, ItemInteractionHandler, NPCInteractionHandler, EventMan
         active_objective_details = []
         for obj in character.objectives:
             if obj.get("active") and not obj.get("completed"):
-                obj_desc = obj.get('description', 'An unknown goal.')
-                current_stage = character.get_current_stage_for_objective(obj.get('id'))
+                obj_desc = obj.get("description", "An unknown goal.")
+                current_stage = character.get_current_stage_for_objective(obj.get("id"))
                 if isinstance(current_stage, dict):
-                    stage_desc = current_stage.get('description', 'unspecified stage')
-                    active_objective_details.append(f"{obj_desc} (Currently: {stage_desc})")
+                    stage_desc = current_stage.get("description", "unspecified stage")
+                    active_objective_details.append(
+                        f"{obj_desc} (Currently: {stage_desc})"
+                    )
                 else:
-                    active_objective_details.append(f"{obj_desc} (Currently: unspecified stage)")
+                    active_objective_details.append(
+                        f"{obj_desc} (Currently: unspecified stage)"
+                    )
 
         if not active_objective_details:
             return "Currently pursuing no specific objectives."
-        prefix = "Your current objectives: " if character.is_player else f"{character.name}'s current objectives: "
+        prefix = (
+            "Your current objectives: "
+            if character.is_player
+            else f"{character.name}'s current objectives: "
+        )
         return prefix + "; ".join(active_objective_details) + "."
 
     def _get_recent_events_summary(self, count: int = 3) -> str:
@@ -112,7 +122,6 @@ class Game(DisplayMixin, ItemInteractionHandler, NPCInteractionHandler, EventMan
             return "No specific details are widely known about the recent crime."
         return "Known facts about the crime: " + "; ".join(self.known_facts_about_crime)
 
-
     def _remember_ai_output(self, text: Optional[str], source_label: str) -> None:
         if not text or not isinstance(text, str):
             return
@@ -121,44 +130,16 @@ class Game(DisplayMixin, ItemInteractionHandler, NPCInteractionHandler, EventMan
         self.last_ai_generated_text = text.strip()
         self.last_ai_generation_source = source_label
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     def get_relationship_text(self, score: int) -> str:
-        if score > 5: return "very positive"
-        if score > 2: return "positive"
-        if score < -5: return "very negative"
-        if score < -2: return "negative"
+        if score > 5:
+            return "very positive"
+        if score > 2:
+            return "positive"
+        if score < -5:
+            return "very negative"
+        if score < -2:
+            return "negative"
         return "neutral"
-
-
-
-
-
-
 
     def _get_save_file_path(self, slot_name: Optional[str] = None) -> Optional[str]:
         if not slot_name:
@@ -168,16 +149,28 @@ class Game(DisplayMixin, ItemInteractionHandler, NPCInteractionHandler, EventMan
             return None
         return f"savegame_{sanitized}.json"
 
-    def save_game(self, slot_name: Optional[str] = None, is_autosave: bool = False) -> None:
-        if not self.player_character: self._print_color("Cannot save: Game not fully initialized.", Colors.RED); return
+    def save_game(
+        self, slot_name: Optional[str] = None, is_autosave: bool = False
+    ) -> None:
+        if not self.player_character:
+            self._print_color("Cannot save: Game not fully initialized.", Colors.RED)
+            return
         save_file = self._get_save_file_path(slot_name)
         if not save_file:
-            self._print_color("Invalid save slot name. Use letters, numbers, hyphens, or underscores.", Colors.RED)
+            self._print_color(
+                "Invalid save slot name. Use letters, numbers, hyphens, or underscores.",
+                Colors.RED,
+            )
             return
         game_state_data = {
-            "player_character_name": self.player_character.name, "current_location_name": self.current_location_name,
-            "game_time": self.game_time, "current_day": self.current_day,
-            "all_character_objects_state": {name: char.to_dict() for name, char in self.all_character_objects.items()},
+            "player_character_name": self.player_character.name,
+            "current_location_name": self.current_location_name,
+            "game_time": self.game_time,
+            "current_day": self.current_day,
+            "all_character_objects_state": {
+                name: char.to_dict()
+                for name, char in self.all_character_objects.items()
+            },
             "dynamic_location_items": self.dynamic_location_items,
             "triggered_events": list(self.event_manager.triggered_events),
             "last_significant_event_summary": self.last_significant_event_summary,
@@ -192,34 +185,58 @@ class Game(DisplayMixin, ItemInteractionHandler, NPCInteractionHandler, EventMan
             "color_theme": self.color_theme,
             "verbosity_level": self.verbosity_level,
             "turn_headers_enabled": self.turn_headers_enabled,
-            "command_history": self.command_history[-self.max_command_history:]
+            "command_history": self.command_history[-self.max_command_history :],
         }
         try:
-            with open(save_file, 'w') as f: json.dump(game_state_data, f, indent=4)
+            with open(save_file, "w") as f:
+                json.dump(game_state_data, f, indent=4)
             if is_autosave:
                 self._print_color(f"Autosaved to {save_file}", Colors.DIM)
             else:
                 self._print_color(f"Game saved to {save_file}", Colors.GREEN)
-        except Exception as e: self._print_color(f"Error saving game: {e}", Colors.RED)
+        except Exception as e:
+            self._print_color(f"Error saving game: {e}", Colors.RED)
 
     def load_game(self, slot_name: Optional[str] = None) -> bool:
         save_file = self._get_save_file_path(slot_name)
         if not save_file:
-            self._print_color("Invalid save slot name. Use letters, numbers, hyphens, or underscores.", Colors.RED)
+            self._print_color(
+                "Invalid save slot name. Use letters, numbers, hyphens, or underscores.",
+                Colors.RED,
+            )
             return False
-        if not os.path.exists(save_file): self._print_color(f"No save file found at {save_file}.", Colors.YELLOW); return False
+        if not os.path.exists(save_file):
+            self._print_color(f"No save file found at {save_file}.", Colors.YELLOW)
+            return False
         try:
-            with open(save_file, 'r') as f: game_state_data = json.load(f)
-            self.game_time = game_state_data.get("game_time", 0); self.current_day = game_state_data.get("current_day", 1)
+            with open(save_file, "r") as f:
+                game_state_data = json.load(f)
+            self.game_time = game_state_data.get("game_time", 0)
+            self.current_day = game_state_data.get("current_day", 1)
             self.current_location_name = game_state_data.get("current_location_name")
-            self.dynamic_location_items = game_state_data.get("dynamic_location_items", {})
-            self.event_manager.triggered_events = set(game_state_data.get("triggered_events", []))
-            self.last_significant_event_summary = game_state_data.get("last_significant_event_summary")
-            self.player_notoriety_level = game_state_data.get("player_notoriety_level", 0)
-            self.known_facts_about_crime = game_state_data.get("known_facts_about_crime", ["An old pawnbroker and her sister were murdered recently."])
-            self.key_events_occurred = game_state_data.get("key_events_occurred", ["Game loaded."])
+            self.dynamic_location_items = game_state_data.get(
+                "dynamic_location_items", {}
+            )
+            self.event_manager.triggered_events = set(
+                game_state_data.get("triggered_events", [])
+            )
+            self.last_significant_event_summary = game_state_data.get(
+                "last_significant_event_summary"
+            )
+            self.player_notoriety_level = game_state_data.get(
+                "player_notoriety_level", 0
+            )
+            self.known_facts_about_crime = game_state_data.get(
+                "known_facts_about_crime",
+                ["An old pawnbroker and her sister were murdered recently."],
+            )
+            self.key_events_occurred = game_state_data.get(
+                "key_events_occurred", ["Game loaded."]
+            )
             self.visited_locations = set(game_state_data.get("visited_locations", []))
-            self.current_location_description_shown_this_visit = game_state_data.get("current_location_description_shown_this_visit", False)
+            self.current_location_description_shown_this_visit = game_state_data.get(
+                "current_location_description_shown_this_visit", False
+            )
             self.low_ai_data_mode = game_state_data.get("low_ai_data_mode", False)
             self.player_action_count = game_state_data.get("player_action_count", 0)
             loaded_theme = game_state_data.get("color_theme", DEFAULT_COLOR_THEME)
@@ -228,31 +245,66 @@ class Game(DisplayMixin, ItemInteractionHandler, NPCInteractionHandler, EventMan
                 apply_color_theme(DEFAULT_COLOR_THEME)
                 applied_theme = DEFAULT_COLOR_THEME
             self.color_theme = applied_theme
-            self.verbosity_level = game_state_data.get("verbosity_level", DEFAULT_VERBOSITY_LEVEL)
+            self.verbosity_level = game_state_data.get(
+                "verbosity_level", DEFAULT_VERBOSITY_LEVEL
+            )
             if self.verbosity_level not in VERBOSITY_LEVELS:
                 self.verbosity_level = DEFAULT_VERBOSITY_LEVEL
-            self.turn_headers_enabled = game_state_data.get("turn_headers_enabled", True)
+            self.turn_headers_enabled = game_state_data.get(
+                "turn_headers_enabled", True
+            )
             loaded_history = game_state_data.get("command_history", [])
-            self.command_history = loaded_history[-self.max_command_history:] if isinstance(loaded_history, list) else []
+            self.command_history = (
+                loaded_history[-self.max_command_history :]
+                if isinstance(loaded_history, list)
+                else []
+            )
             saved_model_name = game_state_data.get("chosen_gemini_model")
-            if saved_model_name: self.gemini_api.chosen_model_name = saved_model_name; self._print_color(f"Loaded preferred Gemini model: {saved_model_name}", Colors.DIM)
+            if saved_model_name:
+                self.gemini_api.chosen_model_name = saved_model_name
+                self._print_color(
+                    f"Loaded preferred Gemini model: {saved_model_name}", Colors.DIM
+                )
             self.all_character_objects = {}
             saved_char_states = game_state_data.get("all_character_objects_state", {})
             for char_name, char_state_data in saved_char_states.items():
                 static_data = CHARACTERS_DATA.get(char_name)
-                if not static_data: self._print_color(f"Warning: Character '{char_name}' from save file not found in current CHARACTERS_DATA. Skipping.", Colors.YELLOW); continue
-                self.all_character_objects[char_name] = Character.from_dict(char_state_data, static_data)
+                if not static_data:
+                    self._print_color(
+                        f"Warning: Character '{char_name}' from save file not found in current CHARACTERS_DATA. Skipping.",
+                        Colors.YELLOW,
+                    )
+                    continue
+                self.all_character_objects[char_name] = Character.from_dict(
+                    char_state_data, static_data
+                )
             player_name = game_state_data.get("player_character_name")
             if player_name and player_name in self.all_character_objects:
                 self.player_character = self.all_character_objects[player_name]
-                if self.player_character: self.player_character.is_player = True
-            else: self._print_color(f"Error: Saved player character '{player_name}' not found or invalid. Load failed.", Colors.RED); self.player_character = None; return False
-            if not self.current_location_name and self.player_character: self.current_location_name = self.player_character.current_location
-            if not self.dynamic_location_items: self.world_manager.initialize_dynamic_location_items()
-            self.world_manager.update_npcs_in_current_location(); self._print_color("Game loaded successfully.", Colors.GREEN)
+                if self.player_character:
+                    self.player_character.is_player = True
+            else:
+                self._print_color(
+                    f"Error: Saved player character '{player_name}' not found or invalid. Load failed.",
+                    Colors.RED,
+                )
+                self.player_character = None
+                return False
+            if not self.current_location_name and self.player_character:
+                self.current_location_name = self.player_character.current_location
+            if not self.dynamic_location_items:
+                self.world_manager.initialize_dynamic_location_items()
+            self.world_manager.update_npcs_in_current_location()
+            self._print_color("Game loaded successfully.", Colors.GREEN)
             self._display_load_recap()
-            self.world_manager.update_current_location_details(from_explicit_look_cmd=False); return True
-        except Exception as e: self._print_color(f"Error loading game: {e}", Colors.RED); self.player_character = None; return False
+            self.world_manager.update_current_location_details(
+                from_explicit_look_cmd=False
+            )
+            return True
+        except Exception as e:
+            self._print_color(f"Error loading game: {e}", Colors.RED)
+            self.player_character = None
+            return False
 
     def _initialize_game(self) -> bool:
         # Call configure and get results
@@ -261,7 +313,10 @@ class Game(DisplayMixin, ItemInteractionHandler, NPCInteractionHandler, EventMan
         # The GeminiAPI.configure method already prints the Low AI Mode status upon selection.
         # No need for an additional print here unless desired for game-level confirmation.
 
-        self._print_color("\n--- Crime and Punishment: A Text Adventure ---", Colors.CYAN + Colors.BOLD)
+        self._print_color(
+            "\n--- Crime and Punishment: A Text Adventure ---",
+            Colors.CYAN + Colors.BOLD,
+        )
         self.world_manager._validate_item_data()
 
         game_loaded_successfully = False
@@ -271,127 +326,166 @@ class Game(DisplayMixin, ItemInteractionHandler, NPCInteractionHandler, EventMan
             self.low_ai_data_mode = config_results.get("low_ai_preference", False)
             self.world_manager.load_all_characters()
             if not self.world_manager.select_player_character(non_interactive=True):
-                self._print_color("Critical Error: Could not initialize player character. Exiting.", Colors.RED)
+                self._print_color(
+                    "Critical Error: Could not initialize player character. Exiting.",
+                    Colors.RED,
+                )
                 return False
         else:
-            self._print_color("Type 'load' to load a saved game, or press Enter to start a new game.", Colors.MAGENTA)
-            initial_action = self._input_color(f"{self._prompt_arrow()}", Colors.WHITE).strip().lower()
+            self._print_color(
+                "Type 'load' to load a saved game, or press Enter to start a new game.",
+                Colors.MAGENTA,
+            )
+            initial_action = (
+                self._input_color(f"{self._prompt_arrow()}", Colors.WHITE)
+                .strip()
+                .lower()
+            )
             if initial_action == "load":
                 if self.load_game():
                     game_loaded_successfully = True
                 else:
-                    self._print_color("Failed to load game. Starting a new game instead.", Colors.YELLOW)
+                    self._print_color(
+                        "Failed to load game. Starting a new game instead.",
+                        Colors.YELLOW,
+                    )
 
             if not game_loaded_successfully:
                 self.low_ai_data_mode = config_results.get("low_ai_preference", False)
                 self.world_manager.load_all_characters()
                 if not self.world_manager.select_player_character():
-                    self._print_color("Critical Error: Could not initialize player character. Exiting.", Colors.RED)
+                    self._print_color(
+                        "Critical Error: Could not initialize player character. Exiting.",
+                        Colors.RED,
+                    )
                     return False
-        if not self.player_character or not self.current_location_name: self._print_color("Game initialization failed critically. Exiting.", Colors.RED); return False
+        if not self.player_character or not self.current_location_name:
+            self._print_color(
+                "Game initialization failed critically. Exiting.", Colors.RED
+            )
+            return False
         if not game_loaded_successfully:
-            self.world_manager.update_current_location_details(from_explicit_look_cmd=False); self.display_atmospheric_details()
+            self.world_manager.update_current_location_details(
+                from_explicit_look_cmd=False
+            )
+            self.display_atmospheric_details()
         self._print_color("\n--- Game Start ---", Colors.CYAN + Colors.BOLD)
-        if not game_loaded_successfully: self.display_help()
+        if not game_loaded_successfully:
+            self.display_help()
         return True
 
-
-
-
-
-
-
-
-
-
-
     def run(self) -> None:
-        if not self._initialize_game(): return
+        if not self._initialize_game():
+            return
         while True:
             if not LOCATIONS_DATA.get(self.current_location_name):
-                 self._print_color(f"Critical Error: Current location '{self.current_location_name}' data not found. Exiting.", Colors.RED); break
+                self._print_color(
+                    f"Critical Error: Current location '{self.current_location_name}' data not found. Exiting.",
+                    Colors.RED,
+                )
+                break
             self._print_turn_header()
             self._display_tutorial_hint()
-            self.world_manager._handle_ambient_rumors(); command, argument = self.command_handler._get_player_input()
-            if command is None and argument is None: continue
+            self.world_manager._handle_ambient_rumors()
+            command, argument = self.command_handler._get_player_input()
+            if command is None and argument is None:
+                continue
             self.command_handler._record_command_history(command, argument)
-            action_taken, show_atmospherics, time_units, special_flag = self.command_handler._process_command(command, argument)
+            action_taken, show_atmospherics, time_units, special_flag = (
+                self.command_handler._process_command(command, argument)
+            )
             if special_flag == "load_triggered":
                 self.last_turn_result_icon = "LOAD"
                 continue
             if special_flag:
                 self.last_turn_result_icon = "QUIT"
                 break
-            self.world_manager._update_world_state_after_action(command, action_taken, time_units)
+            self.world_manager._update_world_state_after_action(
+                command, action_taken, time_units
+            )
             self._display_turn_feedback(show_atmospherics, command)
             if action_taken:
                 self.last_turn_result_icon = "OK"
-            elif command in ["help", "status", "history", "theme", "verbosity", "turnheaders", "retry", "rephrase", "save", "load", "toggle_lowai"]:
+            elif command in [
+                "help",
+                "status",
+                "history",
+                "theme",
+                "verbosity",
+                "turnheaders",
+                "retry",
+                "rephrase",
+                "save",
+                "load",
+                "toggle_lowai",
+            ]:
                 self.last_turn_result_icon = "INFO"
             else:
                 self.last_turn_result_icon = "NOOP"
-            if self.world_manager._check_game_ending_conditions(): break
-
-
-
-
-
-
-
-
-
-
-
-
+            if self.world_manager._check_game_ending_conditions():
+                break
 
     def _handle_think_command(self) -> None:
-        if not self.player_character: self._print_color("Cannot think: Player character not available.", Colors.RED); return
+        if not self.player_character:
+            self._print_color(
+                "Cannot think: Player character not available.", Colors.RED
+            )
+            return
         self._print_color("You pause to reflect...", Colors.MAGENTA)
-        full_reflection_context = self._get_objectives_summary(self.player_character) + \
-                                f"\nInventory: {self.player_character.get_inventory_description()}" + \
-                                f"\nYour current apparent state is '{self.player_character.apparent_state}'." + \
-                                f"\nRecent notable events: {self._get_recent_events_summary()}"
+        full_reflection_context = (
+            self._get_objectives_summary(self.player_character)
+            + f"\nInventory: {self.player_character.get_inventory_description()}"
+            + f"\nYour current apparent state is '{self.player_character.apparent_state}'."
+            + f"\nRecent notable events: {self._get_recent_events_summary()}"
+        )
         if self.player_character.name == "Rodion Raskolnikov":
-            theory_objective = self.player_character.get_objective_by_id("understand_theory")
+            theory_objective = self.player_character.get_objective_by_id(
+                "understand_theory"
+            )
             if theory_objective and theory_objective.get("active"):
-                current_stage_obj = self.player_character.get_current_stage_for_objective("understand_theory")
-                current_stage_desc = current_stage_obj.get("description", "an unknown stage") if current_stage_obj else "an unknown stage"
-                full_reflection_context += (f"\nHe is particularly wrestling with his 'extraordinary man' theory (currently at stage: '{current_stage_desc}'). How do his immediate surroundings, recent events, or current feelings intersect with or challenge this core belief?")
+                current_stage_obj = (
+                    self.player_character.get_current_stage_for_objective(
+                        "understand_theory"
+                    )
+                )
+                current_stage_desc = (
+                    current_stage_obj.get("description", "an unknown stage")
+                    if current_stage_obj
+                    else "an unknown stage"
+                )
+                full_reflection_context += f"\nHe is particularly wrestling with his 'extraordinary man' theory (currently at stage: '{current_stage_desc}'). How do his immediate surroundings, recent events, or current feelings intersect with or challenge this core belief?"
 
         reflection = None
         ai_generated = False
         if not self.low_ai_data_mode and self.gemini_api.model:
-            reflection = self.gemini_api.get_player_reflection(self.player_character, self.current_location_name, self.world_manager.get_current_time_period(), full_reflection_context)
+            reflection = self.gemini_api.get_player_reflection(
+                self.player_character,
+                self.current_location_name,
+                self.world_manager.get_current_time_period(),
+                full_reflection_context,
+            )
 
-        if reflection is None or (isinstance(reflection, str) and reflection.startswith("(OOC:")) or self.low_ai_data_mode:
+        if (
+            reflection is None
+            or (isinstance(reflection, str) and reflection.startswith("(OOC:"))
+            or self.low_ai_data_mode
+        ):
             if STATIC_PLAYER_REFLECTIONS:
                 reflection = random.choice(STATIC_PLAYER_REFLECTIONS)
             else:
-                reflection = "Your mind is a whirl of thoughts." # Ultimate fallback
+                reflection = "Your mind is a whirl of thoughts."  # Ultimate fallback
         else:
             ai_generated = True
 
         final_reflection = self._apply_verbosity(reflection)
-        self._print_color(f"Inner thought: \"{final_reflection}\"", Colors.GREEN) # Print whatever reflection is chosen
+        self._print_color(
+            f'Inner thought: "{final_reflection}"', Colors.GREEN
+        )  # Print whatever reflection is chosen
         if ai_generated:
             self._remember_ai_output(final_reflection, "think")
         self.last_significant_event_summary = "was lost in thought."
 
     def _handle_wait_command(self) -> int:
-        self._print_color("You wait for a while...", Colors.MAGENTA); self.last_significant_event_summary = "waited, letting time and thoughts drift."
+        self._print_color("You wait for a while...", Colors.MAGENTA)
+        self.last_significant_event_summary = "waited, letting time and thoughts drift."
         return TIME_UNITS_PER_PLAYER_ACTION * random.randint(3, 6)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/game_engine/gemini_interactions.py
+++ b/game_engine/gemini_interactions.py
@@ -1,5 +1,6 @@
 # gemini_interactions.py
 import os
+
 os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
 import json
 import importlib
@@ -7,15 +8,14 @@ import importlib.util
 import re
 import sys
 import threading
-import time
 from types import SimpleNamespace
+
+from .game_config import Colors, SPINNER_FRAMES
 
 # --- Self-contained API Configuration Constants ---
 API_CONFIG_FILE = "gemini_config.json"
 GEMINI_API_KEY_ENV_VAR = "GEMINI_API_KEY"
-DEFAULT_GEMINI_MODEL_NAME = 'gemini-3-flash-preview'
-
-from .game_config import Colors, SPINNER_FRAMES
+DEFAULT_GEMINI_MODEL_NAME = "gemini-3-flash-preview"
 
 
 class NaturalLanguageParser:
@@ -24,7 +24,7 @@ class NaturalLanguageParser:
     INTENT_SCHEMA = {
         "intent": ["move", "take", "examine", "talk", "unknown"],
         "target": "string",
-        "confidence": "float (0-1)"
+        "confidence": "float (0-1)",
     }
 
     def __init__(self, gemini_api):
@@ -39,7 +39,7 @@ class NaturalLanguageParser:
             "harm myself",
             "bomb",
             "terrorist",
-            "rape"
+            "rape",
         ]
         return any(phrase in lowered for phrase in unsafe_phrases)
 
@@ -47,7 +47,9 @@ class NaturalLanguageParser:
         if not self.gemini_api._load_genai() or not self.gemini_api.client:
             return self.gemini_api.model
         try:
-            return self.gemini_api._GeminiModelAdapter(self.gemini_api.client, "gemini-3-flash-preview")
+            return self.gemini_api._GeminiModelAdapter(
+                self.gemini_api.client, "gemini-3-flash-preview"
+            )
         except Exception:
             return self.gemini_api.model
 
@@ -65,15 +67,22 @@ class NaturalLanguageParser:
         npcs = current_context.get("npcs", [])
         inventory = current_context.get("inventory", [])
 
-        exits_text = ", ".join(
-            [f"{exit_info['name']} ({exit_info['description']})" for exit_info in exits]
-        ) if exits else "none"
+        exits_text = (
+            ", ".join(
+                [
+                    f"{exit_info['name']} ({exit_info['description']})"
+                    for exit_info in exits
+                ]
+            )
+            if exits
+            else "none"
+        )
         items_text = ", ".join(items) if items else "none"
         npcs_text = ", ".join(npcs) if npcs else "none"
         inventory_text = ", ".join(inventory) if inventory else "none"
 
         schema = json.dumps(self.INTENT_SCHEMA, ensure_ascii=False)
-        sanitized_input = input_text.replace("\"", "\\\"")
+        sanitized_input = input_text.replace('"', '\\"')
 
         prompt = (
             "You are an intent classifier for a text adventure game. "
@@ -87,7 +96,7 @@ class NaturalLanguageParser:
             f"Available items in room: {items_text}\n"
             f"Available NPCs: {npcs_text}\n"
             f"Player inventory: {inventory_text}\n"
-            f"Player input: \"{sanitized_input}\"\n"
+            f'Player input: "{sanitized_input}"\n'
         )
 
         model = self._select_intent_model()
@@ -101,7 +110,11 @@ class NaturalLanguageParser:
         try:
             response = model.generate_content(
                 prompt,
-                generation_config={"candidate_count": 1, "max_output_tokens": 120, "temperature": 0.1},
+                generation_config={
+                    "candidate_count": 1,
+                    "max_output_tokens": 120,
+                    "temperature": 0.1,
+                },
             )
         except Exception:
             return default_response
@@ -111,7 +124,9 @@ class NaturalLanguageParser:
             sys.stdout.write("\r" + " " * 60 + "\r")
             sys.stdout.flush()
 
-        raw_text = response.text.strip() if hasattr(response, "text") and response.text else ""
+        raw_text = (
+            response.text.strip() if hasattr(response, "text") and response.text else ""
+        )
         payload = self.gemini_api._extract_json_payload(raw_text)
         if not isinstance(payload, dict):
             return default_response
@@ -130,15 +145,20 @@ class NaturalLanguageParser:
         confidence = max(0.0, min(1.0, confidence))
         return {"intent": intent, "target": target.strip(), "confidence": confidence}
 
+
 class GeminiAPI:
     def __init__(self):
         self.model = None
         self.client = None
         self.genai = None
         self._genai_warning_shown = False
-        self.chosen_model_name = DEFAULT_GEMINI_MODEL_NAME # Initialize with default
-        self._print_color_func = lambda text, color, end="\n": print(f"{color}{text}{Colors.RESET}", end=end)
-        self._input_color_func = lambda prompt, color: input(f"{color}{prompt}{Colors.RESET}")
+        self.chosen_model_name = DEFAULT_GEMINI_MODEL_NAME  # Initialize with default
+        self._print_color_func = lambda text, color, end="\n": print(
+            f"{color}{text}{Colors.RESET}", end=end
+        )
+        self._input_color_func = lambda prompt, color: input(
+            f"{color}{prompt}{Colors.RESET}"
+        )
 
     def _load_genai(self):
         if self.genai:
@@ -148,7 +168,9 @@ class GeminiAPI:
             self.genai = SimpleNamespace(
                 Client=lambda **kwargs: SimpleNamespace(
                     models=SimpleNamespace(
-                        generate_content=lambda *args, **kwargs: SimpleNamespace(text="test")
+                        generate_content=lambda *args, **kwargs: SimpleNamespace(
+                            text="test"
+                        )
                     )
                 )
             )
@@ -156,7 +178,10 @@ class GeminiAPI:
         spec = importlib.util.find_spec("google.genai")
         if spec is None:
             if not self._genai_warning_shown:
-                self._log_message("Gemini API library not installed. Running with placeholder responses.", Colors.YELLOW)
+                self._log_message(
+                    "Gemini API library not installed. Running with placeholder responses.",
+                    Colors.YELLOW,
+                )
                 self._genai_warning_shown = True
             return False
         self.genai = importlib.import_module("google.genai")
@@ -167,7 +192,9 @@ class GeminiAPI:
             self.client = client
             self.model_name = model_name
 
-        def generate_content(self, prompt, generation_config=None, safety_settings=None):
+        def generate_content(
+            self, prompt, generation_config=None, safety_settings=None
+        ):
             config = {}
             if generation_config:
                 if isinstance(generation_config, dict):
@@ -189,13 +216,15 @@ class GeminiAPI:
         i = 0
         while not stop_event.is_set():
             frame = frames[i % len(frames)]
-            sys.stdout.write(f"\r{Colors.DIM}{Colors.MAGENTA}{frame} AI is thinking...{Colors.RESET}")
+            sys.stdout.write(
+                f"\r{Colors.DIM}{Colors.MAGENTA}{frame} AI is thinking...{Colors.RESET}"
+            )
             sys.stdout.flush()
             i += 1
             stop_event.wait(0.1)
 
     def _log_message(self, text, color, end="\n"):
-        if hasattr(self, '_print_color_func') and callable(self._print_color_func):
+        if hasattr(self, "_print_color_func") and callable(self._print_color_func):
             self._print_color_func(text, color, end=end)
         else:
             print(f"{text}")
@@ -203,35 +232,56 @@ class GeminiAPI:
     def load_api_key_from_file(self):
         try:
             if os.path.exists(API_CONFIG_FILE):
-                with open(API_CONFIG_FILE, 'r') as f:
+                with open(API_CONFIG_FILE, "r") as f:
                     config = json.load(f)
                     # Return just the key, model preference is handled separately now
                     return config.get("gemini_api_key")
         except Exception as e:
-            self._log_message(f"Could not load API key from {API_CONFIG_FILE}: {e}", Colors.RED)
+            self._log_message(
+                f"Could not load API key from {API_CONFIG_FILE}: {e}", Colors.RED
+            )
         return None
 
     def save_api_key_to_file(self, api_key):
         try:
             # When saving, also save the currently chosen model name for persistence
-            with open(API_CONFIG_FILE, 'w') as f:
-                json.dump({"gemini_api_key": api_key, "chosen_model_name": self.chosen_model_name}, f)
-            self._log_message(f"API key and chosen model ({self.chosen_model_name}) saved to {API_CONFIG_FILE}.", Colors.MAGENTA)
+            with open(API_CONFIG_FILE, "w") as f:
+                json.dump(
+                    {
+                        "gemini_api_key": api_key,
+                        "chosen_model_name": self.chosen_model_name,
+                    },
+                    f,
+                )
+            self._log_message(
+                f"API key and chosen model ({self.chosen_model_name}) saved to {API_CONFIG_FILE}.",
+                Colors.MAGENTA,
+            )
         except Exception as e:
-            self._log_message(f"Could not save API key/model to {API_CONFIG_FILE}: {e}", Colors.RED)
+            self._log_message(
+                f"Could not save API key/model to {API_CONFIG_FILE}: {e}", Colors.RED
+            )
 
     def _rename_invalid_config_file(self, config_file_path, suffix="invalid_key"):
         if os.path.exists(config_file_path):
             try:
                 invalid_file_name = config_file_path + f".{suffix}"
                 os.rename(config_file_path, invalid_file_name)
-                self._print_color_func(f"Renamed potentially problematic {config_file_path} to {invalid_file_name}.", Colors.YELLOW)
+                self._print_color_func(
+                    f"Renamed potentially problematic {config_file_path} to {invalid_file_name}.",
+                    Colors.YELLOW,
+                )
             except OSError as ose:
-                self._print_color_func(f"Could not rename {config_file_path}: {ose}", Colors.YELLOW)
+                self._print_color_func(
+                    f"Could not rename {config_file_path}: {ose}", Colors.YELLOW
+                )
 
     def _attempt_api_setup(self, api_key, source, model_to_use):
         if not api_key:
-            self._log_message(f"Internal: _attempt_api_setup called with no API key from {source}.", Colors.RED)
+            self._log_message(
+                f"Internal: _attempt_api_setup called with no API key from {source}.",
+                Colors.RED,
+            )
             self.model = None
             return False
         if not self._load_genai():
@@ -241,46 +291,75 @@ class GeminiAPI:
         if genai_module is None:
             self.model = None
             return False
-            
+
         try:
             self.client = genai_module.Client(api_key=api_key)
         except Exception as e_config:
-            self._print_color_func(f"Error configuring Gemini API (Client init using key from {source}): {e_config}", Colors.RED)
+            self._print_color_func(
+                f"Error configuring Gemini API (Client init using key from {source}): {e_config}",
+                Colors.RED,
+            )
             self.model = None
             return False
 
         try:
             model_instance = self._GeminiModelAdapter(self.client, model_to_use)
         except Exception as model_e:
-            self._print_color_func(f"Error instantiating Gemini model '{model_to_use}' (key from {source}): {model_e}", Colors.RED)
-            self._print_color_func(f"The API key might be valid, but there's an issue with model '{model_to_use}' (e.g., name, access permissions).", Colors.YELLOW)
+            self._print_color_func(
+                f"Error instantiating Gemini model '{model_to_use}' (key from {source}): {model_e}",
+                Colors.RED,
+            )
+            self._print_color_func(
+                f"The API key might be valid, but there's an issue with model '{model_to_use}' (e.g., name, access permissions).",
+                Colors.YELLOW,
+            )
             self.model = None
             return False
 
-        self._print_color_func(f"Verifying API key from {source} with model '{model_to_use}'...", Colors.MAGENTA)
+        self._print_color_func(
+            f"Verifying API key from {source} with model '{model_to_use}'...",
+            Colors.MAGENTA,
+        )
         try:
             safety_settings = [
                 {"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_NONE"},
                 {"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_NONE"},
-                {"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT", "threshold": "BLOCK_NONE"},
-                {"category": "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold": "BLOCK_NONE"},
+                {
+                    "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+                    "threshold": "BLOCK_NONE",
+                },
+                {
+                    "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+                    "threshold": "BLOCK_NONE",
+                },
             ]
             test_response = model_instance.generate_content(
                 "This is a test of the API. Please respond with the word 'test' to confirm.",
                 generation_config={"candidate_count": 1, "max_output_tokens": 5},
-                safety_settings=safety_settings
+                safety_settings=safety_settings,
             )
 
-            if hasattr(test_response, 'text') and 'test' in test_response.text.lower():
-                self._print_color_func(f"API key from {source} verified successfully for model '{model_to_use}'.", Colors.GREEN)
+            if hasattr(test_response, "text") and "test" in test_response.text.lower():
+                self._print_color_func(
+                    f"API key from {source} verified successfully for model '{model_to_use}'.",
+                    Colors.GREEN,
+                )
                 self.model = model_instance
-                self.chosen_model_name = model_to_use # Confirm the successfully validated model
+                self.chosen_model_name = (
+                    model_to_use  # Confirm the successfully validated model
+                )
                 return True
             else:
                 feedback_text = "Unknown issue during verification."
-                if hasattr(test_response, 'prompt_feedback') and hasattr(test_response.prompt_feedback, 'block_reason') and test_response.prompt_feedback.block_reason:
-                    feedback_text = f"Blocked due to: {test_response.prompt_feedback.block_reason}."
-                elif not hasattr(test_response, 'text') or not test_response.text:
+                if (
+                    hasattr(test_response, "prompt_feedback")
+                    and hasattr(test_response.prompt_feedback, "block_reason")
+                    and test_response.prompt_feedback.block_reason
+                ):
+                    feedback_text = (
+                        f"Blocked due to: {test_response.prompt_feedback.block_reason}."
+                    )
+                elif not hasattr(test_response, "text") or not test_response.text:
                     try:
                         if test_response.candidates:
                             finish_reason = test_response.candidates[0].finish_reason
@@ -288,36 +367,59 @@ class GeminiAPI:
                         else:
                             feedback_text = "API key test call returned an empty or non-text response and no candidates."
                     except (AttributeError, IndexError):
-                        feedback_text = "API key test call returned an empty or non-text response."
+                        feedback_text = (
+                            "API key test call returned an empty or non-text response."
+                        )
                 else:
                     feedback_text = f"API key test call returned unexpected text: '{test_response.text[:50]}...'"
-                self._print_color_func(f"API key verification with model '{model_to_use}' (key from {source}) failed: {feedback_text}", Colors.RED)
+                self._print_color_func(
+                    f"API key verification with model '{model_to_use}' (key from {source}) failed: {feedback_text}",
+                    Colors.RED,
+                )
                 self.model = None
                 return False
         except Exception as e_test:
-            self._print_color_func(f"Error during API key verification call (from {source}, model '{model_to_use}'): {e_test}", Colors.RED)
+            self._print_color_func(
+                f"Error during API key verification call (from {source}, model '{model_to_use}'): {e_test}",
+                Colors.RED,
+            )
             error_str = str(e_test).lower()
             auth_keywords = [
-                "api key not valid", "permission_denied", "authentication_failed", 
-                "invalid api key", "credential is invalid", "unauthenticated", 
-                "api_key_invalid", "user_location_invalid" 
+                "api key not valid",
+                "permission_denied",
+                "authentication_failed",
+                "invalid api key",
+                "credential is invalid",
+                "unauthenticated",
+                "api_key_invalid",
+                "user_location_invalid",
             ]
             grpc_permission_denied = getattr(e_test, "grpc_status_code", None) == 7
-            is_auth_error = grpc_permission_denied or any(keyword in error_str for keyword in auth_keywords)
+            is_auth_error = grpc_permission_denied or any(
+                keyword in error_str for keyword in auth_keywords
+            )
             if is_auth_error:
-                self._print_color_func(f"The API key from '{source}' appears invalid or lacks permissions for model '{model_to_use}'/region.", Colors.RED)
+                self._print_color_func(
+                    f"The API key from '{source}' appears invalid or lacks permissions for model '{model_to_use}'/region.",
+                    Colors.RED,
+                )
             else:
-                self._print_color_func(f"Unexpected error during verification with model '{model_to_use}'.", Colors.YELLOW)
+                self._print_color_func(
+                    f"Unexpected error during verification with model '{model_to_use}'.",
+                    Colors.YELLOW,
+                )
             self.model = None
             return False
 
     def _ask_for_model_selection(self):
         # DEFAULT_GEMINI_MODEL_NAME is defined at file level
 
-        self._print_color_func("\nPlease select which Gemini model to use:", Colors.CYAN)
+        self._print_color_func(
+            "\nPlease select which Gemini model to use:", Colors.CYAN
+        )
         models_map = {
             "1": {"name": "Gemini 3 Pro Preview", "id": "gemini-3-pro-preview"},
-            "2": {"name": "Gemini 3 Flash Preview", "id": "gemini-3-flash-preview"}
+            "2": {"name": "Gemini 3 Flash Preview", "id": "gemini-3-flash-preview"},
         }
 
         # Dynamically create the display map to ensure the default model from DEFAULT_GEMINI_MODEL_NAME is marked
@@ -325,29 +427,49 @@ class GeminiAPI:
         default_model_display_name = ""
 
         for key, model_info_iter in models_map.items():
-            is_default = (model_info_iter["id"] == DEFAULT_GEMINI_MODEL_NAME)
+            is_default = model_info_iter["id"] == DEFAULT_GEMINI_MODEL_NAME
             display_name_iter = model_info_iter["name"]
             if is_default:
                 # Remove existing "(Default)" then add it back to ensure only one is marked
-                display_name_iter = display_name_iter.replace(" (Default)", "") + " (Default)"
+                display_name_iter = (
+                    display_name_iter.replace(" (Default)", "") + " (Default)"
+                )
                 default_model_display_name = display_name_iter
-            display_map_for_prompt[key] = {"name": display_name_iter, "id": model_info_iter["id"]}
-
+            display_map_for_prompt[key] = {
+                "name": display_name_iter,
+                "id": model_info_iter["id"],
+            }
 
         for key_prompt, model_info_prompt in display_map_for_prompt.items():
-            self._print_color_func(f"{key_prompt}. {model_info_prompt['name']} (ID: {model_info_prompt['id']})", Colors.WHITE)
-        
+            self._print_color_func(
+                f"{key_prompt}. {model_info_prompt['name']} (ID: {model_info_prompt['id']})",
+                Colors.WHITE,
+            )
+
         while True:
             # Adjust prompt for new number of choices
-            choice = self._input_color_func(f"Enter your choice (1-{len(display_map_for_prompt)}), or press Enter for default): ", Colors.MAGENTA).strip()
-            if not choice: 
-                self._print_color_func(f"Using default model: {default_model_display_name}", Colors.YELLOW)
+            choice = self._input_color_func(
+                f"Enter your choice (1-{len(display_map_for_prompt)}), or press Enter for default): ",
+                Colors.MAGENTA,
+            ).strip()
+            if not choice:
+                self._print_color_func(
+                    f"Using default model: {default_model_display_name}", Colors.YELLOW
+                )
                 return DEFAULT_GEMINI_MODEL_NAME
-            if choice in display_map_for_prompt: # Check against keys of display_map_for_prompt
-                self._print_color_func(f"You selected: {display_map_for_prompt[choice]['name']}", Colors.GREEN)
-                return display_map_for_prompt[choice]['id']
+            if (
+                choice in display_map_for_prompt
+            ):  # Check against keys of display_map_for_prompt
+                self._print_color_func(
+                    f"You selected: {display_map_for_prompt[choice]['name']}",
+                    Colors.GREEN,
+                )
+                return display_map_for_prompt[choice]["id"]
             else:
-                self._print_color_func(f"Invalid choice. Please enter a number from the list (1-{len(display_map_for_prompt)}).", Colors.RED)
+                self._print_color_func(
+                    f"Invalid choice. Please enter a number from the list (1-{len(display_map_for_prompt)}).",
+                    Colors.RED,
+                )
 
     def _prompt_for_low_ai_mode(self):
         low_ai_choice_prompt = (
@@ -356,25 +478,42 @@ class GeminiAPI:
             "Recommended if you have limited API quota or prefer less AI processing.)\n"
             "Enter 'y' for yes, or 'n' for no (default is 'n'): "
         )
-        low_ai_input = self._input_color_func(low_ai_choice_prompt, Colors.YELLOW).strip().lower()
-        low_ai_preference = (low_ai_input == 'y')
+        low_ai_input = (
+            self._input_color_func(low_ai_choice_prompt, Colors.YELLOW).strip().lower()
+        )
+        low_ai_preference = low_ai_input == "y"
 
         if low_ai_preference:
             self._print_color_func("Low AI Data Mode will be ENABLED.", Colors.GREEN)
         else:
-            self._print_color_func("Low AI Data Mode will be DISABLED (default).", Colors.GREEN)
+            self._print_color_func(
+                "Low AI Data Mode will be DISABLED (default).", Colors.GREEN
+            )
         return low_ai_preference
 
     def _handle_env_key(self):
         env_key = os.getenv(GEMINI_API_KEY_ENV_VAR)
         if env_key:
-            self._log_message(f"Found API key in environment variable '{GEMINI_API_KEY_ENV_VAR}'.", Colors.YELLOW)
-            self._log_message(f"Attempting non-interactive setup with model '{DEFAULT_GEMINI_MODEL_NAME}'...", Colors.YELLOW)
-            if self._attempt_api_setup(env_key, f"environment variable '{GEMINI_API_KEY_ENV_VAR}'", DEFAULT_GEMINI_MODEL_NAME):
+            self._log_message(
+                f"Found API key in environment variable '{GEMINI_API_KEY_ENV_VAR}'.",
+                Colors.YELLOW,
+            )
+            self._log_message(
+                f"Attempting non-interactive setup with model '{DEFAULT_GEMINI_MODEL_NAME}'...",
+                Colors.YELLOW,
+            )
+            if self._attempt_api_setup(
+                env_key,
+                f"environment variable '{GEMINI_API_KEY_ENV_VAR}'",
+                DEFAULT_GEMINI_MODEL_NAME,
+            ):
                 self._log_message("Non-interactive setup successful.", Colors.GREEN)
                 return {"api_configured": True, "low_ai_preference": False}
             else:
-                self._log_message("Non-interactive setup with environment variable failed. The game will run with placeholder responses.", Colors.RED)
+                self._log_message(
+                    "Non-interactive setup with environment variable failed. The game will run with placeholder responses.",
+                    Colors.RED,
+                )
                 self.model = None
                 return {"api_configured": False, "low_ai_preference": False}
         return None
@@ -382,32 +521,52 @@ class GeminiAPI:
     def _handle_config_file_key(self):
         if os.path.exists(API_CONFIG_FILE):
             try:
-                with open(API_CONFIG_FILE, 'r') as f:
+                with open(API_CONFIG_FILE, "r") as f:
                     config = json.load(f)
                 key_to_try = config.get("gemini_api_key")
                 if not key_to_try:
                     return None
-                
+
                 key_source = API_CONFIG_FILE
-                preferred_model_from_config = config.get("chosen_model_name", DEFAULT_GEMINI_MODEL_NAME)
-                self._log_message(f"Found API key in config file '{API_CONFIG_FILE}'.", Colors.YELLOW)
+                preferred_model_from_config = config.get(
+                    "chosen_model_name", DEFAULT_GEMINI_MODEL_NAME
+                )
+                self._log_message(
+                    f"Found API key in config file '{API_CONFIG_FILE}'.", Colors.YELLOW
+                )
                 if preferred_model_from_config != DEFAULT_GEMINI_MODEL_NAME:
-                    self._log_message(f"Loaded preferred model '{preferred_model_from_config}' from config.", Colors.YELLOW)
+                    self._log_message(
+                        f"Loaded preferred model '{preferred_model_from_config}' from config.",
+                        Colors.YELLOW,
+                    )
 
                 if not self._load_genai():
                     return {"api_configured": False, "low_ai_preference": False}
 
-                if self._attempt_api_setup(key_to_try, key_source, preferred_model_from_config):
+                if self._attempt_api_setup(
+                    key_to_try, key_source, preferred_model_from_config
+                ):
                     low_ai_pref = self._prompt_for_low_ai_mode()
                     if self.chosen_model_name != preferred_model_from_config:
                         self.save_api_key_to_file(key_to_try)
                     return {"api_configured": True, "low_ai_preference": low_ai_pref}
                 else:
-                    self._rename_invalid_config_file(API_CONFIG_FILE, f"failed_setup_with_{preferred_model_from_config.replace('/','_')}")
-                    self._print_color_func(f"API key from {key_source} (with model '{preferred_model_from_config}') failed validation or setup.", Colors.YELLOW)
+                    self._rename_invalid_config_file(
+                        API_CONFIG_FILE,
+                        f"failed_setup_with_{preferred_model_from_config.replace('/','_')}",
+                    )
+                    self._print_color_func(
+                        f"API key from {key_source} (with model '{preferred_model_from_config}') failed validation or setup.",
+                        Colors.YELLOW,
+                    )
             except Exception as e:
-                self._log_message(f"Error processing config file {API_CONFIG_FILE}: {e}", Colors.YELLOW)
-                self._rename_invalid_config_file(API_CONFIG_FILE, "initial_config_error")
+                self._log_message(
+                    f"Error processing config file {API_CONFIG_FILE}: {e}",
+                    Colors.YELLOW,
+                )
+                self._rename_invalid_config_file(
+                    API_CONFIG_FILE, "initial_config_error"
+                )
         else:
             self._log_message(f"Config file '{API_CONFIG_FILE}' not found.", Colors.DIM)
         return None
@@ -415,41 +574,67 @@ class GeminiAPI:
     def _handle_manual_key_input(self):
         while True:
             manual_api_key_input = self._input_color_func(
-                f"Please enter your Gemini API key (or type 'skip' to use placeholder responses): ",
-                Colors.MAGENTA
+                "Please enter your Gemini API key (or type 'skip' to use placeholder responses): ",
+                Colors.MAGENTA,
             ).strip()
 
             if not manual_api_key_input:
-                self._print_color_func("No API key entered. Please provide a key or type 'skip'.", Colors.YELLOW)
-                continue 
+                self._print_color_func(
+                    "No API key entered. Please provide a key or type 'skip'.",
+                    Colors.YELLOW,
+                )
+                continue
 
-            if manual_api_key_input.lower() == 'skip':
-                self._print_color_func("\nSkipping API key entry. Game will run with placeholder responses.", Colors.RED)
-                self.model = None 
+            if manual_api_key_input.lower() == "skip":
+                self._print_color_func(
+                    "\nSkipping API key entry. Game will run with placeholder responses.",
+                    Colors.RED,
+                )
+                self.model = None
                 return {"api_configured": False, "low_ai_preference": False}
-            
+
             if not self._load_genai():
                 return {"api_configured": False, "low_ai_preference": False}
 
             selected_model_id_manual = self._ask_for_model_selection()
 
-            if self._attempt_api_setup(manual_api_key_input, "user input", selected_model_id_manual):
+            if self._attempt_api_setup(
+                manual_api_key_input, "user input", selected_model_id_manual
+            ):
                 low_ai_pref = self._prompt_for_low_ai_mode()
-                save_choice = self._input_color_func(
-                    f"Save this valid key and model ('{self.chosen_model_name}') to {API_CONFIG_FILE}? (y/n) (Not recommended if sharing project): ",
-                    Colors.YELLOW
-                ).strip().lower()
-                if save_choice == 'y':
-                    self.save_api_key_to_file(manual_api_key_input) 
+                save_choice = (
+                    self._input_color_func(
+                        f"Save this valid key and model ('{self.chosen_model_name}') to {API_CONFIG_FILE}? (y/n) (Not recommended if sharing project): ",
+                        Colors.YELLOW,
+                    )
+                    .strip()
+                    .lower()
+                )
+                if save_choice == "y":
+                    self.save_api_key_to_file(manual_api_key_input)
                 else:
-                    self._print_color_func(f"API key and model choice not saved for future sessions.", Colors.YELLOW)
+                    self._print_color_func(
+                        "API key and model choice not saved for future sessions.",
+                        Colors.YELLOW,
+                    )
                 return {"api_configured": True, "low_ai_preference": low_ai_pref}
 
-            self._print_color_func(f"The manually entered API key with model '{selected_model_id_manual}' failed validation.", Colors.RED)
-            retry_choice = self._input_color_func("Try entering a different API key? (y/n): ", Colors.YELLOW).strip().lower()
-            if retry_choice != 'y':
-                self._print_color_func("\nProceeding with placeholder responses.", Colors.RED)
-                self.model = None 
+            self._print_color_func(
+                f"The manually entered API key with model '{selected_model_id_manual}' failed validation.",
+                Colors.RED,
+            )
+            retry_choice = (
+                self._input_color_func(
+                    "Try entering a different API key? (y/n): ", Colors.YELLOW
+                )
+                .strip()
+                .lower()
+            )
+            if retry_choice != "y":
+                self._print_color_func(
+                    "\nProceeding with placeholder responses.", Colors.RED
+                )
+                self.model = None
                 return {"api_configured": False, "low_ai_preference": False}
 
     def configure(self, print_func, input_func):
@@ -469,8 +654,10 @@ class GeminiAPI:
             return config_file_result
 
         return self._handle_manual_key_input()
-    
-    def _generate_content_with_fallback(self, prompt, error_message_context="generating content"):
+
+    def _generate_content_with_fallback(
+        self, prompt, error_message_context="generating content"
+    ):
         if not self.model:
             return f"(OOC: Gemini API not configured or key invalid. Cannot fulfill request for {error_message_context}.)"
         spinner_stop = threading.Event()
@@ -481,49 +668,98 @@ class GeminiAPI:
         )
         spinner_thread.start()
         try:
-            safety_settings=[
-                {"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_MEDIUM_AND_ABOVE"},
-                {"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_MEDIUM_AND_ABOVE"},
-                {"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT", "threshold": "BLOCK_MEDIUM_AND_ABOVE"},
-                {"category": "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold": "BLOCK_MEDIUM_AND_ABOVE"},
+            safety_settings = [
+                {
+                    "category": "HARM_CATEGORY_HARASSMENT",
+                    "threshold": "BLOCK_MEDIUM_AND_ABOVE",
+                },
+                {
+                    "category": "HARM_CATEGORY_HATE_SPEECH",
+                    "threshold": "BLOCK_MEDIUM_AND_ABOVE",
+                },
+                {
+                    "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+                    "threshold": "BLOCK_MEDIUM_AND_ABOVE",
+                },
+                {
+                    "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+                    "threshold": "BLOCK_MEDIUM_AND_ABOVE",
+                },
             ]
-            response = self.model.generate_content(prompt, safety_settings=safety_settings)
-            
-            if not hasattr(response, 'text') or not response.text: 
+            response = self.model.generate_content(
+                prompt, safety_settings=safety_settings
+            )
+
+            if not hasattr(response, "text") or not response.text:
                 block_reason_str = ""
                 # Check for block reason in prompt_feedback
-                if hasattr(response, 'prompt_feedback') and hasattr(response.prompt_feedback, 'block_reason') and response.prompt_feedback.block_reason:
-                    block_reason_str = f" (Reason: {response.prompt_feedback.block_reason})"
+                if (
+                    hasattr(response, "prompt_feedback")
+                    and hasattr(response.prompt_feedback, "block_reason")
+                    and response.prompt_feedback.block_reason
+                ):
+                    block_reason_str = (
+                        f" (Reason: {response.prompt_feedback.block_reason})"
+                    )
                 # Check for finish reason in candidates if text is empty
-                elif hasattr(response, 'candidates') and len(response.candidates) > 0 and hasattr(response.candidates[0], 'finish_reason'):
+                elif (
+                    hasattr(response, "candidates")
+                    and len(response.candidates) > 0
+                    and hasattr(response.candidates[0], "finish_reason")
+                ):
                     finish_reason = response.candidates[0].finish_reason
                     # FINISH_REASON_STOP (1) is normal. Other reasons (SAFETY, RECITATION, OTHER, etc.) are issues.
-                    if finish_reason != 1: # Assuming 1 is FINISH_REASON_STOP
-                         block_reason_str = f" (Finish Reason: {finish_reason})"
-                
-                refusal_phrases = ["cannot fulfill", "unable to provide", "cannot generate", "not able to create", "i am unable to"]
-                if hasattr(response, 'text') and response.text and any(phrase in response.text.lower() for phrase in refusal_phrases):
-                     self._log_message(f"Warning: Gemini returned a refusal-like response for {error_message_context}.{block_reason_str} Prompt: {prompt[:200]}...", Colors.YELLOW)
-                     return f"(OOC: My thoughts on this are restricted at the moment.{block_reason_str})"
+                    if finish_reason != 1:  # Assuming 1 is FINISH_REASON_STOP
+                        block_reason_str = f" (Finish Reason: {finish_reason})"
 
-                self._log_message(f"Warning: Gemini returned an empty or non-text response for {error_message_context}.{block_reason_str} Model: {self.chosen_model_name}. Prompt: {prompt[:200]}...", Colors.YELLOW)
+                refusal_phrases = [
+                    "cannot fulfill",
+                    "unable to provide",
+                    "cannot generate",
+                    "not able to create",
+                    "i am unable to",
+                ]
+                if (
+                    hasattr(response, "text")
+                    and response.text
+                    and any(
+                        phrase in response.text.lower() for phrase in refusal_phrases
+                    )
+                ):
+                    self._log_message(
+                        f"Warning: Gemini returned a refusal-like response for {error_message_context}.{block_reason_str} Prompt: {prompt[:200]}...",
+                        Colors.YELLOW,
+                    )
+                    return f"(OOC: My thoughts on this are restricted at the moment.{block_reason_str})"
+
+                self._log_message(
+                    f"Warning: Gemini returned an empty or non-text response for {error_message_context}.{block_reason_str} Model: {self.chosen_model_name}. Prompt: {prompt[:200]}...",
+                    Colors.YELLOW,
+                )
                 return f"(OOC: My thoughts on this are unclear or restricted at the moment.{block_reason_str})"
             return response.text.strip()
         except Exception as e:
-            self._log_message(f"Error calling Gemini API for {error_message_context} using model {self.chosen_model_name}: {e}", Colors.RED)
+            self._log_message(
+                f"Error calling Gemini API for {error_message_context} using model {self.chosen_model_name}: {e}",
+                Colors.RED,
+            )
             block_reason = None
             # Look for block reason in the exception response if available (some errors wrap the response)
             response_obj = getattr(e, "response", None)
             prompt_feedback = getattr(response_obj, "prompt_feedback", None)
             block_reason = getattr(prompt_feedback, "block_reason", None)
-            
+
             if block_reason:
                 self._log_message(f"Blocked due to: {block_reason}", Colors.YELLOW)
                 return f"(OOC: My response was blocked: {block_reason})"
-            
+
             if getattr(e, "grpc_status_code", None) == 7:
-                 return f"(OOC: API key error - Permission Denied. My thoughts are muddled.)"
-            return f"(OOC: My thoughts are... muddled due to an error: {str(e)[:100]}...)"
+                return (
+                    "(OOC: API key error - Permission Denied. My thoughts are muddled.)"
+                )
+            return (
+                f"(OOC: My thoughts are... muddled due to an error: {str(e)[:100]}...)"
+            )
         finally:
             spinner_stop.set()
             spinner_thread.join()
@@ -550,7 +786,10 @@ class GeminiAPI:
                 return None
 
     def generate_npc_response(self, npc_profile, player_input, current_stats):
-        fallback_response = {"response_text": "The character stares at you silently.", "stat_changes": {}}
+        fallback_response = {
+            "response_text": "The character stares at you silently.",
+            "stat_changes": {},
+        }
         if not npc_profile:
             return fallback_response
 
@@ -578,7 +817,9 @@ class GeminiAPI:
         - Output JSON only. No markdown, no code fences.
         - Maintain 19th-century Russian literary tone.
         """
-        raw_text = self._generate_content_with_fallback(prompt, f"NPC psychological response for {npc_profile.get('name')}")
+        raw_text = self._generate_content_with_fallback(
+            prompt, f"NPC psychological response for {npc_profile.get('name')}"
+        )
         if not raw_text:
             return fallback_response
         if raw_text.startswith("(OOC:"):
@@ -597,7 +838,11 @@ class GeminiAPI:
             stat_changes = {}
         else:
             allowed_stats = {"suspicion", "fear", "respect"}
-            stat_changes = {key: value for key, value in stat_changes.items() if key in allowed_stats}
+            stat_changes = {
+                key: value
+                for key, value in stat_changes.items()
+                if key in allowed_stats
+            }
 
         return {"response_text": response_text.strip(), "stat_changes": stat_changes}
 
@@ -606,14 +851,24 @@ class GeminiAPI:
     # with the user's chosen model name.
     # (The prompt construction inside these methods does not need to change for this request)
 
-    def get_npc_dialogue(self, npc_character, player_character, player_dialogue,
-                         current_location_name, current_time_period, relationship_status_text,
-                         npc_memory_summary, player_apparent_state="normal",
-                         player_notable_items_summary="nothing noteworthy",
-                         recent_game_events_summary="No significant recent events.",
-                         npc_objectives_summary="No specific objectives.",
-                         player_objectives_summary="No specific objectives."):
-        conversation_context = npc_character.get_formatted_history(player_character.name)
+    def get_npc_dialogue(
+        self,
+        npc_character,
+        player_character,
+        player_dialogue,
+        current_location_name,
+        current_time_period,
+        relationship_status_text,
+        npc_memory_summary,
+        player_apparent_state="normal",
+        player_notable_items_summary="nothing noteworthy",
+        recent_game_events_summary="No significant recent events.",
+        npc_objectives_summary="No specific objectives.",
+        player_objectives_summary="No specific objectives.",
+    ):
+        conversation_context = npc_character.get_formatted_history(
+            player_character.name
+        )
         situation_summary = (
             f"You, {npc_character.name} (current internal state/mood: '{npc_character.apparent_state}', pursuing: {npc_objectives_summary}), "
             f"are in {current_location_name} during the {current_time_period}. "
@@ -649,25 +904,43 @@ class GeminiAPI:
         npc_profile = {
             "name": npc_character.name,
             "persona": npc_character.persona,
-            "situation_summary": "\n".join([
-                situation_summary,
-                player_state_consideration.strip(),
-                player_items_consideration.strip(),
-                npc_objective_consideration.strip(),
-            ]),
-            "conversation_history": conversation_context if conversation_context else "No prior conversation in this session.",
+            "situation_summary": "\n".join(
+                [
+                    situation_summary,
+                    player_state_consideration.strip(),
+                    player_items_consideration.strip(),
+                    npc_objective_consideration.strip(),
+                ]
+            ),
+            "conversation_history": (
+                conversation_context
+                if conversation_context
+                else "No prior conversation in this session."
+            ),
         }
-        response_payload = self.generate_npc_response(npc_profile, player_dialogue, npc_character.psychology)
-        ai_text = response_payload.get("response_text", "The character stares at you silently.")
+        response_payload = self.generate_npc_response(
+            npc_profile, player_dialogue, npc_character.psychology
+        )
+        ai_text = response_payload.get(
+            "response_text", "The character stares at you silently."
+        )
         npc_character.apply_psychology_changes(response_payload.get("stat_changes", {}))
 
         # Always add player's dialogue to history
-        npc_character.add_to_history(player_character.name, player_character.name, player_dialogue)
-        player_character.add_to_history(npc_character.name, player_character.name, player_dialogue)
+        npc_character.add_to_history(
+            player_character.name, player_character.name, player_dialogue
+        )
+        player_character.add_to_history(
+            npc_character.name, player_character.name, player_dialogue
+        )
 
         processed_ai_text = ai_text.replace('\\"', '"')
 
-        if len(processed_ai_text) >= 2 and processed_ai_text.startswith('"') and processed_ai_text.endswith('"'):
+        if (
+            len(processed_ai_text) >= 2
+            and processed_ai_text.startswith('"')
+            and processed_ai_text.endswith('"')
+        ):
             processed_ai_text = processed_ai_text[1:-1]
 
         final_ai_text = processed_ai_text
@@ -675,14 +948,24 @@ class GeminiAPI:
         if final_ai_text.startswith("(OOC:"):
             return final_ai_text
 
-        npc_character.add_to_history(player_character.name, npc_character.name, final_ai_text)
-        player_character.add_to_history(npc_character.name, npc_character.name, final_ai_text)
+        npc_character.add_to_history(
+            player_character.name, npc_character.name, final_ai_text
+        )
+        player_character.add_to_history(
+            npc_character.name, npc_character.name, final_ai_text
+        )
         return final_ai_text
 
-    def get_player_reflection(self, player_character, current_location_name, current_time_period,
-                              context_text, recent_interactions_summary="Nothing specific recently.",
-                              inventory_highlights="You carry your usual burdens.",
-                              active_objectives_summary="Your goals weigh on you."):
+    def get_player_reflection(
+        self,
+        player_character,
+        current_location_name,
+        current_time_period,
+        context_text,
+        recent_interactions_summary="Nothing specific recently.",
+        inventory_highlights="You carry your usual burdens.",
+        active_objectives_summary="Your goals weigh on you.",
+    ):
         prompt = f"""
         **Roleplay Mandate: Embody the internal thoughts of {player_character.name} from Dostoevsky's "Crime and Punishment".**
         **Your Persona, {player_character.name}:**
@@ -695,18 +978,32 @@ class GeminiAPI:
         **Reflection Guidelines (Strict Adherence Required):** Deeply Personal, Dostoevskian Style, First-Person, Contextual, Concise, No OOC, Output Only Thought.
         Generate {player_character.name}'s inner thought now:
         """
-        return self._generate_content_with_fallback(prompt, f"player reflection for {player_character.name}")
+        return self._generate_content_with_fallback(
+            prompt, f"player reflection for {player_character.name}"
+        )
 
-    def get_atmospheric_details(self, player_character, location_name, time_period,
-                                recent_event_summary=None, player_objective_focus=None, recently_visited=False):
-        context = (f"{player_character.name} (state: {player_character.apparent_state}, preoccupied with: {player_objective_focus if player_objective_focus else 'usual thoughts'}) "
-                   f"is in {location_name} during {time_period}. ")
-        if recent_event_summary: context += f"Recently, {recent_event_summary}. "
-        
-        brevity_instruction = "Describe subtle, psychologically resonant detail (1-2 sentences)."
+    def get_atmospheric_details(
+        self,
+        player_character,
+        location_name,
+        time_period,
+        recent_event_summary=None,
+        player_objective_focus=None,
+        recently_visited=False,
+    ):
+        context = (
+            f"{player_character.name} (state: {player_character.apparent_state}, preoccupied with: {player_objective_focus if player_objective_focus else 'usual thoughts'}) "
+            f"is in {location_name} during {time_period}. "
+        )
+        if recent_event_summary:
+            context += f"Recently, {recent_event_summary}. "
+
+        brevity_instruction = (
+            "Describe subtle, psychologically resonant detail (1-2 sentences)."
+        )
         if recently_visited:
             brevity_instruction = "Keep it extremely brief (1 short sentence), as the character was just here. Focus on a single fleeting detail."
-            
+
         prompt = f"""
         **Task: Evoke Dostoevsky's St. Petersburg atmosphere via {player_character.name}'s perception.**
         **Context:** {context}
@@ -715,9 +1012,15 @@ class GeminiAPI:
         """
         return self._generate_content_with_fallback(prompt, "atmospheric details")
 
-    def get_npc_to_npc_interaction(self, npc1, npc2, location_name, game_time_period,
-                                   npc1_objectives_summary="their usual concerns",
-                                   npc2_objectives_summary="their usual concerns"):
+    def get_npc_to_npc_interaction(
+        self,
+        npc1,
+        npc2,
+        location_name,
+        game_time_period,
+        npc1_objectives_summary="their usual concerns",
+        npc2_objectives_summary="their usual concerns",
+    ):
         prompt = f"""
         **Task: Simulate brief, ambient, Dostoevskian NPC-to-NPC interaction (1-3 lines).**
         **Setting:** {location_name}, {game_time_period}.
@@ -738,11 +1041,20 @@ class GeminiAPI:
         **Output:** Generate only the dialogue lines as specified.
         Generate the interaction now:
         """
-        return self._generate_content_with_fallback(prompt, f"NPC-to-NPC interaction between {npc1.name} and {npc2.name}")
+        return self._generate_content_with_fallback(
+            prompt, f"NPC-to-NPC interaction between {npc1.name} and {npc2.name}"
+        )
 
-    def get_item_interaction_description(self, character, item_name, item_details, action_type="examine",
-                                         location_name="an undisclosed location", time_period="an unknown time",
-                                         target_details=None):
+    def get_item_interaction_description(
+        self,
+        character,
+        item_name,
+        item_details,
+        action_type="examine",
+        location_name="an undisclosed location",
+        time_period="an unknown time",
+        target_details=None,
+    ):
         prompt = f"""
         **Roleplay Mandate: Generate {character.name}'s internal, first-person Dostoevskian thought for item interaction.**
         **Context:** {character.name} ({character.apparent_state}) in {location_name} at {time_period}.
@@ -752,18 +1064,37 @@ class GeminiAPI:
         **Guidelines:** Psychologically resonant, first-person, sensory, concise, no OOC.
         Generate {character.name}'s thought/observation now:
         """
-        return self._generate_content_with_fallback(prompt, f"item interaction with {item_name} by {character.name}")
+        return self._generate_content_with_fallback(
+            prompt, f"item interaction with {item_name} by {character.name}"
+        )
 
-    def get_dream_sequence(self, character_obj, recent_events_summary, current_objectives_summary, key_relationships_summary="No specific key relationships."):
+    def get_dream_sequence(
+        self,
+        character_obj,
+        recent_events_summary,
+        current_objectives_summary,
+        key_relationships_summary="No specific key relationships.",
+    ):
         prompt = f"""
         **Task: Describe a symbolic, surreal, Dostoevskian dream for {character_obj.name}.**
         **Dreamer Profile:** {character_obj.name} ({character_obj.apparent_state}). Recent: {recent_events_summary}. Concerns: {current_objectives_summary}. Relationships: {key_relationships_summary}.
         **Guidelines:** Symbolic/surreal, Dostoevskian tone, vivid/fragmented imagery, emotional impact, concise (3-5 sentences), output only dream.
         Generate dream for {character_obj.name} now:
         """
-        return self._generate_content_with_fallback(prompt, f"{character_obj.name}'s dream sequence")
+        return self._generate_content_with_fallback(
+            prompt, f"{character_obj.name}'s dream sequence"
+        )
 
-    def get_rumor_or_gossip(self, npc_obj, location_name, game_time_period, known_facts_about_crime_summary, player_notoriety_level, npc_relationship_with_player_text="neutral", npc_current_concerns="their usual worries"):
+    def get_rumor_or_gossip(
+        self,
+        npc_obj,
+        location_name,
+        game_time_period,
+        known_facts_about_crime_summary,
+        player_notoriety_level,
+        npc_relationship_with_player_text="neutral",
+        npc_current_concerns="their usual worries",
+    ):
         prompt = f"""
         **Task: Generate brief, in-character Dostoevskian gossip/rumor (1-2 sentences) from {npc_obj.name}.**
         **Context:** {npc_obj.name} in {location_name} ({game_time_period}). Player relationship: {npc_relationship_with_player_text}. Concerns: {npc_current_concerns}.
@@ -771,10 +1102,17 @@ class GeminiAPI:
         **Guidelines:** In-character, Dostoevskian, varied content, subtle re:notoriety, plausible, concise, output only rumor.
         Generate rumor from {npc_obj.name} now:
         """
-        return self._generate_content_with_fallback(prompt, f"rumor from {npc_obj.name}")
+        return self._generate_content_with_fallback(
+            prompt, f"rumor from {npc_obj.name}"
+        )
 
-    def get_newspaper_article_snippet(self, game_day, key_events_occurred_summary,
-                                      relevant_themes_for_raskolnikov_summary, city_mood="tense and anxious"):
+    def get_newspaper_article_snippet(
+        self,
+        game_day,
+        key_events_occurred_summary,
+        relevant_themes_for_raskolnikov_summary,
+        city_mood="tense and anxious",
+    ):
         prompt = f"""
         **Task: Generate short St. Petersburg newspaper snippet (2-4 sentences).**
         **Context:** Day {game_day}. Events: {key_events_occurred_summary}. Themes: {relevant_themes_for_raskolnikov_summary}. Mood: {city_mood}.
@@ -783,8 +1121,14 @@ class GeminiAPI:
         """
         return self._generate_content_with_fallback(prompt, "newspaper article snippet")
 
-    def get_scenery_observation(self, character_obj, scenery_noun_phrase, location_name, time_period,
-                                character_active_objectives_summary="their current thoughts"):
+    def get_scenery_observation(
+        self,
+        character_obj,
+        scenery_noun_phrase,
+        location_name,
+        time_period,
+        character_active_objectives_summary="their current thoughts",
+    ):
         prompt = f"""
         **Roleplay Mandate: Generate {character_obj.name}'s Dostoevskian observation of scenery.**
         **Context:** {character_obj.name} ({character_obj.apparent_state}) in {location_name} ({time_period}). Focus: '{scenery_noun_phrase}'. Preoccupations: {character_active_objectives_summary}.
@@ -792,27 +1136,50 @@ class GeminiAPI:
         **Guidelines:** Psychologically resonant, deeper meaning, first-person, concise, no OOC, output observation.
         Generate {character_obj.name}'s scenery observation now:
         """
-        return self._generate_content_with_fallback(prompt, f"scenery observation of {scenery_noun_phrase}")
+        return self._generate_content_with_fallback(
+            prompt, f"scenery observation of {scenery_noun_phrase}"
+        )
 
-    def get_generated_text_document(self, document_type, author_persona_hint="an unknown person",
-                                    recipient_persona_hint="the recipient", subject_matter="an important matter",
-                                    desired_tone="neutral", key_info_to_include="some key details",
-                                    length_sentences=3, purpose_of_document_in_game="To convey information."):
+    def get_generated_text_document(
+        self,
+        document_type,
+        author_persona_hint="an unknown person",
+        recipient_persona_hint="the recipient",
+        subject_matter="an important matter",
+        desired_tone="neutral",
+        key_info_to_include="some key details",
+        length_sentences=3,
+        purpose_of_document_in_game="To convey information.",
+    ):
         prompt = f"""
         **Task: Generate text for a '{document_type}' in Dostoevsky's world.**
         **Specs:** Author: {author_persona_hint}. Recipient: {recipient_persona_hint}. Subject: {subject_matter}. Tone: {desired_tone}. Key Info: {key_info_to_include}. Length: {length_sentences} sentences. Style: 19th-C St. Petersburg. Purpose: {purpose_of_document_in_game}.
         **Guidelines:** Authentic voice, Dostoevskian flavor, convey info subtly, output only document text.
         Generate text for '{document_type}' now:
         """
-        return self._generate_content_with_fallback(prompt, f"generated text for {document_type}")
+        return self._generate_content_with_fallback(
+            prompt, f"generated text for {document_type}"
+        )
 
-    def get_npc_dialogue_persuasion_attempt(self, npc_character, player_character, player_persuasive_statement, 
-                                            current_location_name, current_time_period, relationship_status_text, 
-                                            npc_memory_summary, player_apparent_state, 
-                                            player_notable_items_summary, recent_game_events_summary, 
-                                            npc_objectives_summary, player_objectives_summary, 
-                                            persuasion_skill_check_result_text):
-        conversation_context = npc_character.get_formatted_history(player_character.name)
+    def get_npc_dialogue_persuasion_attempt(
+        self,
+        npc_character,
+        player_character,
+        player_persuasive_statement,
+        current_location_name,
+        current_time_period,
+        relationship_status_text,
+        npc_memory_summary,
+        player_apparent_state,
+        player_notable_items_summary,
+        recent_game_events_summary,
+        npc_objectives_summary,
+        player_objectives_summary,
+        persuasion_skill_check_result_text,
+    ):
+        conversation_context = npc_character.get_formatted_history(
+            player_character.name
+        )
         situation_summary = (
             f"You, {npc_character.name} (current internal state/mood: '{npc_character.apparent_state}', pursuing: {npc_objectives_summary}), "
             f"are in {current_location_name} during the {current_time_period}. "
@@ -868,17 +1235,38 @@ class GeminiAPI:
 
         Respond now as {npc_character.name}:
         """
-        ai_text = self._generate_content_with_fallback(prompt, f"NPC persuasion response for {npc_character.name}")
-        
+        ai_text = self._generate_content_with_fallback(
+            prompt, f"NPC persuasion response for {npc_character.name}"
+        )
+
         # Add to history (persuasion attempt is also a form of dialogue)
         if not ai_text.startswith("(OOC:"):
-            npc_character.add_to_history(player_character.name, player_character.name, f"(Attempting to persuade) {player_persuasive_statement}")
-            npc_character.add_to_history(player_character.name, npc_character.name, ai_text)
-            player_character.add_to_history(npc_character.name, player_character.name, f"(My persuasive attempt) {player_persuasive_statement}")
-            player_character.add_to_history(npc_character.name, npc_character.name, ai_text)
+            npc_character.add_to_history(
+                player_character.name,
+                player_character.name,
+                f"(Attempting to persuade) {player_persuasive_statement}",
+            )
+            npc_character.add_to_history(
+                player_character.name, npc_character.name, ai_text
+            )
+            player_character.add_to_history(
+                npc_character.name,
+                player_character.name,
+                f"(My persuasive attempt) {player_persuasive_statement}",
+            )
+            player_character.add_to_history(
+                npc_character.name, npc_character.name, ai_text
+            )
         return ai_text
 
-    def get_enhanced_observation(self, character_obj, target_name, target_category, base_description, skill_check_context):
+    def get_enhanced_observation(
+        self,
+        character_obj,
+        target_name,
+        target_category,
+        base_description,
+        skill_check_context,
+    ):
         prompt = f"""
         **Roleplay Mandate: Provide a subtle, insightful observation for {character_obj.name}, reflecting a successful Observation skill check.**
         **Character Making Observation:** {character_obj.name} (State: {character_obj.apparent_state})
@@ -901,9 +1289,13 @@ class GeminiAPI:
 
         Generate the enhanced observation now:
         """
-        return self._generate_content_with_fallback(prompt, f"enhanced observation of {target_name}")
+        return self._generate_content_with_fallback(
+            prompt, f"enhanced observation of {target_name}"
+        )
 
-    def get_street_life_event_description(self, location_name, time_period, player_character_context="present in the area"):
+    def get_street_life_event_description(
+        self, location_name, time_period, player_character_context="present in the area"
+    ):
         prompt = f"""
         **Task: Generate a brief, atmospheric 'street life' event (1-2 sentences) for St. Petersburg.**
         **Setting:** {location_name}, {time_period}.
@@ -921,4 +1313,6 @@ class GeminiAPI:
         - Output only the 1-2 sentence description of the event.
         Generate the street life event description now:
         """
-        return self._generate_content_with_fallback(prompt, f"street life event in {location_name}")
+        return self._generate_content_with_fallback(
+            prompt, f"street life event in {location_name}"
+        )

--- a/game_engine/item_interaction_handler.py
+++ b/game_engine/item_interaction_handler.py
@@ -1,47 +1,76 @@
-
 import random
-import re
-from .game_config import (Colors, DEFAULT_ITEMS, GENERIC_SCENERY_KEYWORDS,
-                         STATIC_ENHANCED_OBSERVATIONS, STATIC_PLAYER_REFLECTIONS,
-                         HIGHLY_NOTABLE_ITEMS_FOR_MEMORY, STATIC_NEWSPAPER_SNIPPETS,
-                         TIME_UNITS_PER_PLAYER_ACTION, POSITIVE_KEYWORDS, NEGATIVE_KEYWORDS,
-                         DEBUG_LOGS, generate_static_item_interaction_description,
-                         generate_static_scenery_observation)
+from .game_config import (
+    Colors,
+    DEFAULT_ITEMS,
+    GENERIC_SCENERY_KEYWORDS,
+    STATIC_ENHANCED_OBSERVATIONS,
+    STATIC_PLAYER_REFLECTIONS,
+    HIGHLY_NOTABLE_ITEMS_FOR_MEMORY,
+    STATIC_NEWSPAPER_SNIPPETS,
+    generate_static_item_interaction_description,
+    generate_static_scenery_observation,
+)
 from .location_module import LOCATIONS_DATA
 
+
 class ItemInteractionHandler:
-    def _inspect_item(self, item_name, item_default, action_context, observation_context, allow_npc_memory):
+    def _inspect_item(
+        self,
+        item_name,
+        item_default,
+        action_context,
+        observation_context,
+        allow_npc_memory,
+    ):
         if not self.player_character:
-            self._print_color("Cannot inspect item: Player character not available.", Colors.RED)
+            self._print_color(
+                "Cannot inspect item: Player character not available.", Colors.RED
+            )
             return
         player_character = self.player_character
         current_location_name = self.current_location_name or "Unknown Location"
         self._print_color(f"You examine the {item_name}:", Colors.GREEN)
         gen_desc = None
-        base_desc_for_skill_check = item_default.get('description', "An ordinary item.")
+        base_desc_for_skill_check = item_default.get("description", "An ordinary item.")
 
         if not self.low_ai_data_mode and self.gemini_api.model:
             gen_desc = self.gemini_api.get_item_interaction_description(
-                player_character, item_name, item_default, action_context,
-                current_location_name, self.get_current_time_period()
+                player_character,
+                item_name,
+                item_default,
+                action_context,
+                current_location_name,
+                self.get_current_time_period(),
             )
 
-        if gen_desc is not None and not (isinstance(gen_desc, str) and gen_desc.startswith("(OOC:")) and not self.low_ai_data_mode:
+        if (
+            gen_desc is not None
+            and not (isinstance(gen_desc, str) and gen_desc.startswith("(OOC:"))
+            and not self.low_ai_data_mode
+        ):
             gen_desc = self._apply_verbosity(gen_desc)
-            self._print_color(f"\"{gen_desc}\"", Colors.GREEN)
+            self._print_color(f'"{gen_desc}"', Colors.GREEN)
             base_desc_for_skill_check = gen_desc
             self._remember_ai_output(gen_desc, "item_inspection")
         else:
-            if self.low_ai_data_mode or gen_desc is None or (isinstance(gen_desc, str) and gen_desc.startswith("(OOC:")):
-                gen_desc = generate_static_item_interaction_description(item_name, "examine")
-                self._print_color(f"\"{self._apply_verbosity(gen_desc)}\"", Colors.CYAN)
+            if (
+                self.low_ai_data_mode
+                or gen_desc is None
+                or (isinstance(gen_desc, str) and gen_desc.startswith("(OOC:"))
+            ):
+                gen_desc = generate_static_item_interaction_description(
+                    item_name, "examine"
+                )
+                self._print_color(f'"{self._apply_verbosity(gen_desc)}"', Colors.CYAN)
             else:
                 self._print_color(f"({base_desc_for_skill_check})", Colors.DIM)
 
         self._display_item_properties(item_default)
 
         if player_character.check_skill("Observation", 1):
-            self._print_color("(Your keen eye picks up on finer details...)", Colors.CYAN + Colors.DIM)
+            self._print_color(
+                "(Your keen eye picks up on finer details...)", Colors.CYAN + Colors.DIM
+            )
             detailed_observation = None
             if not self.low_ai_data_mode and self.gemini_api.model:
                 detailed_observation = self.gemini_api.get_enhanced_observation(
@@ -49,38 +78,61 @@ class ItemInteractionHandler:
                     target_name=item_name,
                     target_category="item",
                     base_description=base_desc_for_skill_check,
-                    skill_check_context=observation_context
+                    skill_check_context=observation_context,
                 )
 
-            if detailed_observation is None or (isinstance(detailed_observation, str) and detailed_observation.startswith("(OOC:")) or self.low_ai_data_mode:
+            if (
+                detailed_observation is None
+                or (
+                    isinstance(detailed_observation, str)
+                    and detailed_observation.startswith("(OOC:")
+                )
+                or self.low_ai_data_mode
+            ):
                 if STATIC_ENHANCED_OBSERVATIONS:
                     detailed_observation = random.choice(STATIC_ENHANCED_OBSERVATIONS)
                 else:
-                    detailed_observation = "You notice a few more mundane details, but nothing striking."
+                    detailed_observation = (
+                        "You notice a few more mundane details, but nothing striking."
+                    )
                 if detailed_observation:
-                    self._print_color(f"Detail: \"{self._apply_verbosity(detailed_observation)}\"", Colors.CYAN)
+                    self._print_color(
+                        f'Detail: "{self._apply_verbosity(detailed_observation)}"',
+                        Colors.CYAN,
+                    )
             elif detailed_observation:
                 final_detail = self._apply_verbosity(detailed_observation)
-                self._print_color(f"Detail: \"{final_detail}\"", Colors.GREEN)
+                self._print_color(f'Detail: "{final_detail}"', Colors.GREEN)
                 self._remember_ai_output(final_detail, "item_detail")
 
         if allow_npc_memory and item_name in HIGHLY_NOTABLE_ITEMS_FOR_MEMORY:
             for npc_observer in self.npcs_in_current_location:
                 if npc_observer.name != player_character.name:
-                    sentiment_impact = -2 if item_name in ["raskolnikov's axe", "bloodied rag"] else -1
+                    sentiment_impact = (
+                        -2 if item_name in ["raskolnikov's axe", "bloodied rag"] else -1
+                    )
                     npc_observer.add_player_memory(
                         memory_type="player_action_observed",
                         turn=self.game_time,
-                        content={"action": "examined_item", "item_name": item_name, "location": current_location_name},
-                        sentiment_impact=sentiment_impact
+                        content={
+                            "action": "examined_item",
+                            "item_name": item_name,
+                            "location": current_location_name,
+                        },
+                        sentiment_impact=sentiment_impact,
                     )
 
     def _handle_look_at_location_item(self, target_to_look_at):
         if not self.player_character:
-            self._print_color("Cannot inspect location items: Player character not available.", Colors.RED)
+            self._print_color(
+                "Cannot inspect location items: Player character not available.",
+                Colors.RED,
+            )
             return True
         player_character = self.player_character
-        item_info, ambiguous = self.command_handler._get_matching_location_item(target_to_look_at)
+        item_info, ambiguous = self.command_handler._get_matching_location_item(
+            target_to_look_at
+        )
         if ambiguous:
             return True
         if item_info:
@@ -96,14 +148,16 @@ class ItemInteractionHandler:
                     item_default,
                     "examine closely in environment",
                     observation_context,
-                    allow_npc_memory=True
+                    allow_npc_memory=True,
                 )
                 return True
         return False
 
     def _handle_look_at_inventory_item(self, target_to_look_at):
         if self.player_character:
-            inv_item_info, ambiguous = self.command_handler._get_matching_inventory_item(target_to_look_at)
+            inv_item_info, ambiguous = (
+                self.command_handler._get_matching_inventory_item(target_to_look_at)
+            )
             if ambiguous:
                 return True
             if inv_item_info:
@@ -119,14 +173,16 @@ class ItemInteractionHandler:
                         item_default,
                         "examine closely from inventory",
                         observation_context,
-                        allow_npc_memory=True
+                        allow_npc_memory=True,
                     )
                     return True
         return False
 
     def _handle_look_at_npc(self, target_to_look_at):
         if not self.player_character:
-            self._print_color("Cannot inspect people: Player character not available.", Colors.RED)
+            self._print_color(
+                "Cannot inspect people: Player character not available.", Colors.RED
+            )
             return True
         player_character = self.player_character
         current_location_name = self.current_location_name or "Unknown Location"
@@ -134,31 +190,60 @@ class ItemInteractionHandler:
         if ambiguous:
             return True
         if npc:
-            self._print_color(f"You look closely at {Colors.YELLOW}{npc.name}{Colors.RESET} (appears {npc.apparent_state}):", Colors.WHITE)
-            base_desc_for_skill_check = npc.persona[:100] if npc.persona else f"{npc.name} is present." # Initialize base_desc
+            self._print_color(
+                f"You look closely at {Colors.YELLOW}{npc.name}{Colors.RESET} (appears {npc.apparent_state}):",
+                Colors.WHITE,
+            )
+            base_desc_for_skill_check = (
+                npc.persona[:100] if npc.persona else f"{npc.name} is present."
+            )  # Initialize base_desc
             observation = None
 
             if not self.low_ai_data_mode and self.gemini_api.model:
                 observation_prompt = f"observing {npc.name} in {current_location_name}. They appear to be '{npc.apparent_state}'. You recall: {npc.get_player_memory_summary(self.game_time)}"
-                observation = self.gemini_api.get_player_reflection(player_character, current_location_name, self.get_current_time_period(), observation_prompt, player_character.get_inventory_description(), self._get_objectives_summary(player_character))
+                observation = self.gemini_api.get_player_reflection(
+                    player_character,
+                    current_location_name,
+                    self.get_current_time_period(),
+                    observation_prompt,
+                    player_character.get_inventory_description(),
+                    self._get_objectives_summary(player_character),
+                )
 
-            if observation is not None and not (isinstance(observation, str) and observation.startswith("(OOC:")) and not self.low_ai_data_mode:
+            if (
+                observation is not None
+                and not (
+                    isinstance(observation, str) and observation.startswith("(OOC:")
+                )
+                and not self.low_ai_data_mode
+            ):
                 final_observation = self._apply_verbosity(observation)
-                self._print_color(f"\"{final_observation}\"", Colors.GREEN)
+                self._print_color(f'"{final_observation}"', Colors.GREEN)
                 base_desc_for_skill_check = final_observation
                 self._remember_ai_output(final_observation, "look_npc")
             else:
-                if self.low_ai_data_mode or observation is None or (isinstance(observation, str) and observation.startswith("(OOC:")) :
+                if (
+                    self.low_ai_data_mode
+                    or observation is None
+                    or (
+                        isinstance(observation, str) and observation.startswith("(OOC:")
+                    )
+                ):
                     if STATIC_PLAYER_REFLECTIONS:
                         observation = f"{npc.name} is here. {random.choice(STATIC_PLAYER_REFLECTIONS)}"
                     else:
                         observation = f"You observe {npc.name}. They seem to be going about their business."
-                    self._print_color(f"\"{self._apply_verbosity(observation)}\"", Colors.CYAN)
+                    self._print_color(
+                        f'"{self._apply_verbosity(observation)}"', Colors.CYAN
+                    )
                 else:
                     self._print_color(f"({base_desc_for_skill_check})", Colors.DIM)
 
             if player_character.check_skill("Observation", 1):
-                self._print_color("(Your keen observation notices something more...)", Colors.CYAN + Colors.DIM)
+                self._print_color(
+                    "(Your keen observation notices something more...)",
+                    Colors.CYAN + Colors.DIM,
+                )
                 observation_context = (
                     f"Player ({player_character.name}) succeeded an Observation skill check while looking at "
                     f"{npc.name} (appears {npc.apparent_state}). What subtle, non-obvious detail does "
@@ -168,82 +253,150 @@ class ItemInteractionHandler:
                 detailed_observation = None
                 if not self.low_ai_data_mode and self.gemini_api.model:
                     detailed_observation = self.gemini_api.get_enhanced_observation(
-                        player_character, target_name=npc.name, target_category="person",
-                        base_description=base_desc_for_skill_check, skill_check_context=observation_context
+                        player_character,
+                        target_name=npc.name,
+                        target_category="person",
+                        base_description=base_desc_for_skill_check,
+                        skill_check_context=observation_context,
                     )
 
-                if detailed_observation is None or (isinstance(detailed_observation, str) and detailed_observation.startswith("(OOC:")) or self.low_ai_data_mode:
+                if (
+                    detailed_observation is None
+                    or (
+                        isinstance(detailed_observation, str)
+                        and detailed_observation.startswith("(OOC:")
+                    )
+                    or self.low_ai_data_mode
+                ):
                     if STATIC_ENHANCED_OBSERVATIONS:
-                        detailed_observation = random.choice(STATIC_ENHANCED_OBSERVATIONS)
+                        detailed_observation = random.choice(
+                            STATIC_ENHANCED_OBSERVATIONS
+                        )
                     else:
                         detailed_observation = "You notice some subtle cues, but their full meaning eludes you."
                     if detailed_observation:
-                        self._print_color(f"Insight: \"{self._apply_verbosity(detailed_observation)}\"", Colors.CYAN)
+                        self._print_color(
+                            f'Insight: "{self._apply_verbosity(detailed_observation)}"',
+                            Colors.CYAN,
+                        )
                 elif detailed_observation:
                     final_detail = self._apply_verbosity(detailed_observation)
-                    self._print_color(f"Insight: \"{final_detail}\"", Colors.GREEN)
+                    self._print_color(f'Insight: "{final_detail}"', Colors.GREEN)
                     self._remember_ai_output(final_detail, "look_npc_detail")
             return True
         return False
 
     def _handle_look_at_scenery(self, target_to_look_at):
         if not self.player_character:
-            self._print_color("Cannot inspect scenery: Player character not available.", Colors.RED)
+            self._print_color(
+                "Cannot inspect scenery: Player character not available.", Colors.RED
+            )
             return True
         player_character = self.player_character
         current_location_name = self.current_location_name or "Unknown Location"
-        loc_data = LOCATIONS_DATA.get(self.current_location_name, {}); loc_desc_lower = loc_data.get("description", "").lower()
-        is_scenery = any(keyword in target_to_look_at for keyword in GENERIC_SCENERY_KEYWORDS) or target_to_look_at in loc_desc_lower
+        loc_data = LOCATIONS_DATA.get(self.current_location_name, {})
+        loc_desc_lower = loc_data.get("description", "").lower()
+        is_scenery = (
+            any(keyword in target_to_look_at for keyword in GENERIC_SCENERY_KEYWORDS)
+            or target_to_look_at in loc_desc_lower
+        )
         if is_scenery:
             self._print_color(f"You focus on the {target_to_look_at}...", Colors.WHITE)
-            base_desc_for_skill_check = f"The general scenery of {current_location_name}, focusing on {target_to_look_at}." # Initial base
+            base_desc_for_skill_check = f"The general scenery of {current_location_name}, focusing on {target_to_look_at}."  # Initial base
             observation = None
 
             if not self.low_ai_data_mode and self.gemini_api.model:
-                observation = self.gemini_api.get_scenery_observation(player_character, target_to_look_at, current_location_name, self.get_current_time_period(), self._get_objectives_summary(player_character))
+                observation = self.gemini_api.get_scenery_observation(
+                    player_character,
+                    target_to_look_at,
+                    current_location_name,
+                    self.get_current_time_period(),
+                    self._get_objectives_summary(player_character),
+                )
 
-            if observation is not None and not (isinstance(observation, str) and observation.startswith("(OOC:")) and not self.low_ai_data_mode:
+            if (
+                observation is not None
+                and not (
+                    isinstance(observation, str) and observation.startswith("(OOC:")
+                )
+                and not self.low_ai_data_mode
+            ):
                 # AI success
                 final_observation = self._apply_verbosity(observation)
-                self._print_color(f"\"{final_observation}\"", Colors.CYAN)
-                base_desc_for_skill_check = final_observation # Update for skill check
+                self._print_color(f'"{final_observation}"', Colors.CYAN)
+                base_desc_for_skill_check = final_observation  # Update for skill check
                 self._remember_ai_output(final_observation, "look_scenery")
             else:
                 # Fallback or AI failed/OOC or low_ai_mode
-                if self.low_ai_data_mode or observation is None or (isinstance(observation, str) and observation.startswith("(OOC:")) :
+                if (
+                    self.low_ai_data_mode
+                    or observation is None
+                    or (
+                        isinstance(observation, str) and observation.startswith("(OOC:")
+                    )
+                ):
                     observation = generate_static_scenery_observation(target_to_look_at)
                     # base_desc_for_skill_check remains the initial general one
-                    self._print_color(f"\"{self._apply_verbosity(observation)}\"", Colors.DIM) # Static in DIM
-                else: # Should not be reached
-                     self._print_color(f"The {target_to_look_at} is just as it seems.", Colors.DIM)
+                    self._print_color(
+                        f'"{self._apply_verbosity(observation)}"', Colors.DIM
+                    )  # Static in DIM
+                else:  # Should not be reached
+                    self._print_color(
+                        f"The {target_to_look_at} is just as it seems.", Colors.DIM
+                    )
 
             if player_character.check_skill("Observation", 0):
-                self._print_color("(You scan the area more intently...)", Colors.CYAN + Colors.DIM)
+                self._print_color(
+                    "(You scan the area more intently...)", Colors.CYAN + Colors.DIM
+                )
                 observation_context = f"Player ({player_character.name}) passed an Observation check while looking at '{target_to_look_at}' in {current_location_name}. What specific, easily missed detail about '{target_to_look_at}' or its immediate surroundings catches their eye, perhaps hinting at a past event, a hidden element, or the general atmosphere in a more profound way?"
                 detailed_observation = None
                 if not self.low_ai_data_mode and self.gemini_api.model:
-                    detailed_observation = self.gemini_api.get_enhanced_observation(player_character, target_name=target_to_look_at, target_category="scenery", base_description=base_desc_for_skill_check, skill_check_context=observation_context)
+                    detailed_observation = self.gemini_api.get_enhanced_observation(
+                        player_character,
+                        target_name=target_to_look_at,
+                        target_category="scenery",
+                        base_description=base_desc_for_skill_check,
+                        skill_check_context=observation_context,
+                    )
 
-                if detailed_observation is None or (isinstance(detailed_observation, str) and detailed_observation.startswith("(OOC:")) or self.low_ai_data_mode:
+                if (
+                    detailed_observation is None
+                    or (
+                        isinstance(detailed_observation, str)
+                        and detailed_observation.startswith("(OOC:")
+                    )
+                    or self.low_ai_data_mode
+                ):
                     if STATIC_ENHANCED_OBSERVATIONS:
-                        detailed_observation = random.choice(STATIC_ENHANCED_OBSERVATIONS)
+                        detailed_observation = random.choice(
+                            STATIC_ENHANCED_OBSERVATIONS
+                        )
                     else:
-                        detailed_observation = "The scene offers no further secrets to your gaze." # Ultimate fallback
-                    if detailed_observation: # Check if not None
-                        self._print_color(f"You also notice: \"{self._apply_verbosity(detailed_observation)}\"", Colors.CYAN) # Static in Cyan
-                elif detailed_observation: # AI success
+                        detailed_observation = "The scene offers no further secrets to your gaze."  # Ultimate fallback
+                    if detailed_observation:  # Check if not None
+                        self._print_color(
+                            f'You also notice: "{self._apply_verbosity(detailed_observation)}"',
+                            Colors.CYAN,
+                        )  # Static in Cyan
+                elif detailed_observation:  # AI success
                     final_detail = self._apply_verbosity(detailed_observation)
-                    self._print_color(f"You also notice: \"{final_detail}\"", Colors.GREEN)
+                    self._print_color(
+                        f'You also notice: "{final_detail}"', Colors.GREEN
+                    )
                     self._remember_ai_output(final_detail, "look_scenery_detail")
                 # If still None, nothing printed.
             return True
         return False
 
     def _handle_look_command(self, argument, show_full_look_details=False):
-        self.numbered_actions_context.clear(); action_number = 1
+        self.numbered_actions_context.clear()
+        action_number = 1
         current_location_data = LOCATIONS_DATA.get(self.current_location_name)
-        is_general_look = (argument is None or argument.lower() in ["around", ""])
-        self.world_manager.update_current_location_details(from_explicit_look_cmd=is_general_look)
+        is_general_look = argument is None or argument.lower() in ["around", ""]
+        self.world_manager.update_current_location_details(
+            from_explicit_look_cmd=is_general_look
+        )
 
         if argument and not is_general_look:
             target_to_look_at = argument.lower()
@@ -256,60 +409,134 @@ class ItemInteractionHandler:
             elif self._handle_look_at_scenery(target_to_look_at):
                 self._print_color(self._separator_line(), Colors.DIM)
             else:
-                self._print_color(f"You don't see '{argument}' here to look at specifically.", Colors.RED)
+                self._print_color(
+                    f"You don't see '{argument}' here to look at specifically.",
+                    Colors.RED,
+                )
                 self._print_color(self._separator_line(), Colors.DIM)
 
         if show_full_look_details:
             self._print_color("", Colors.RESET)
-            self._print_color("--- People Here ---", Colors.YELLOW + Colors.BOLD); npcs_present_for_hint = False
+            self._print_color("--- People Here ---", Colors.YELLOW + Colors.BOLD)
+            npcs_present_for_hint = False
             if self.npcs_in_current_location:
                 for npc in self.npcs_in_current_location:
-                    look_at_npc_display = f"Look at {npc.name}"; self.numbered_actions_context.append({'type': 'look_at_npc', 'target': npc.name, 'display': look_at_npc_display})
-                    self._print_color(f"{action_number}. {look_at_npc_display}", Colors.YELLOW, end=""); print(f" (Appears: {npc.apparent_state}, Relationship: {self.get_relationship_text(npc.relationship_with_player)})"); action_number += 1; npcs_present_for_hint = True
-                    talk_to_npc_display = f"Talk to {npc.name}"; self.numbered_actions_context.append({'type': 'talk', 'target': npc.name, 'display': talk_to_npc_display})
-                    self._print_color(f"{action_number}. {talk_to_npc_display}", Colors.YELLOW); action_number += 1
-            else: self._print_color("You see no one else of note here.", Colors.DIM)
-            self._print_color("", Colors.RESET); self._print_color("--- Items Here ---", Colors.YELLOW + Colors.BOLD)
-            current_loc_items = self.dynamic_location_items.get(self.current_location_name, []); items_present_for_hint = False
+                    look_at_npc_display = f"Look at {npc.name}"
+                    self.numbered_actions_context.append(
+                        {
+                            "type": "look_at_npc",
+                            "target": npc.name,
+                            "display": look_at_npc_display,
+                        }
+                    )
+                    self._print_color(
+                        f"{action_number}. {look_at_npc_display}", Colors.YELLOW, end=""
+                    )
+                    print(
+                        f" (Appears: {npc.apparent_state}, Relationship: {self.get_relationship_text(npc.relationship_with_player)})"
+                    )
+                    action_number += 1
+                    npcs_present_for_hint = True
+                    talk_to_npc_display = f"Talk to {npc.name}"
+                    self.numbered_actions_context.append(
+                        {
+                            "type": "talk",
+                            "target": npc.name,
+                            "display": talk_to_npc_display,
+                        }
+                    )
+                    self._print_color(
+                        f"{action_number}. {talk_to_npc_display}", Colors.YELLOW
+                    )
+                    action_number += 1
+            else:
+                self._print_color("You see no one else of note here.", Colors.DIM)
+            self._print_color("", Colors.RESET)
+            self._print_color("--- Items Here ---", Colors.YELLOW + Colors.BOLD)
+            current_loc_items = self.dynamic_location_items.get(
+                self.current_location_name, []
+            )
+            items_present_for_hint = False
             if current_loc_items:
                 for item_info in current_loc_items:
-                    item_name = item_info["name"]; item_qty = item_info.get("quantity", 1)
+                    item_name = item_info["name"]
+                    item_qty = item_info.get("quantity", 1)
                     item_default_info = DEFAULT_ITEMS.get(item_name, {})
 
-                    full_description = item_default_info.get('description', 'An undescribed item.')
+                    full_description = item_default_info.get(
+                        "description", "An undescribed item."
+                    )
 
                     qty_str = ""
-                    if (item_default_info.get("stackable") or item_default_info.get("value") is not None) and item_qty > 1:
+                    if (
+                        item_default_info.get("stackable")
+                        or item_default_info.get("value") is not None
+                    ) and item_qty > 1:
                         qty_str = f" (x{item_qty})"
 
                     item_display_line = f"{item_name}{qty_str} - {full_description}"
-                    self._print_color(f"{action_number}. {item_display_line}", Colors.GREEN)
+                    self._print_color(
+                        f"{action_number}. {item_display_line}", Colors.GREEN
+                    )
 
-                    self.numbered_actions_context.append({
-                        'type': 'select_item', # Changed from 'item_reference'
-                        'target': item_name,
-                        'display': item_name
-                    })
+                    self.numbered_actions_context.append(
+                        {
+                            "type": "select_item",  # Changed from 'item_reference'
+                            "target": item_name,
+                            "display": item_name,
+                        }
+                    )
                     action_number += 1
                     items_present_for_hint = True
             else:
                 self._print_color("No loose items of interest here.", Colors.DIM)
-            self._print_color("", Colors.RESET); self._print_color("--- Exits ---", Colors.BLUE + Colors.BOLD); has_accessible_exits = False
-            if current_location_data and current_location_data.get("exits"):
-                for exit_target_loc, exit_desc in current_location_data["exits"].items():
-                    display_text = f"{exit_desc} (to {exit_target_loc})"; self.numbered_actions_context.append({'type': 'move', 'target': exit_target_loc, 'description': exit_desc, 'display': display_text})
-                    self._print_color(f"{action_number}. {display_text}", Colors.BLUE); action_number += 1; has_accessible_exits = True
-            if not has_accessible_exits: self._print_color("There are no obvious exits from here.", Colors.DIM)
             self._print_color("", Colors.RESET)
-            if items_present_for_hint: self._print_color("(Hint: You can 'take [item name]', 'look at [item name]', or use a number to interact with items.)", Colors.DIM)
-            if npcs_present_for_hint: self._print_color("(Hint: You can 'talk to [npc name]', 'look at [npc name]', or use a number to interact with people.)", Colors.DIM)
+            self._print_color("--- Exits ---", Colors.BLUE + Colors.BOLD)
+            has_accessible_exits = False
+            if current_location_data and current_location_data.get("exits"):
+                for exit_target_loc, exit_desc in current_location_data[
+                    "exits"
+                ].items():
+                    display_text = f"{exit_desc} (to {exit_target_loc})"
+                    self.numbered_actions_context.append(
+                        {
+                            "type": "move",
+                            "target": exit_target_loc,
+                            "description": exit_desc,
+                            "display": display_text,
+                        }
+                    )
+                    self._print_color(f"{action_number}. {display_text}", Colors.BLUE)
+                    action_number += 1
+                    has_accessible_exits = True
+            if not has_accessible_exits:
+                self._print_color("There are no obvious exits from here.", Colors.DIM)
+            self._print_color("", Colors.RESET)
+            if items_present_for_hint:
+                self._print_color(
+                    "(Hint: You can 'take [item name]', 'look at [item name]', or use a number to interact with items.)",
+                    Colors.DIM,
+                )
+            if npcs_present_for_hint:
+                self._print_color(
+                    "(Hint: You can 'talk to [npc name]', 'look at [npc name]', or use a number to interact with people.)",
+                    Colors.DIM,
+                )
 
     def _handle_take_command(self, argument):
-        if not argument: self._print_color("What do you want to take?", Colors.RED); return False, False
-        if not self.player_character: self._print_color("Cannot take items: Player character not available.", Colors.RED); return False, False
+        if not argument:
+            self._print_color("What do you want to take?", Colors.RED)
+            return False, False
+        if not self.player_character:
+            self._print_color(
+                "Cannot take items: Player character not available.", Colors.RED
+            )
+            return False, False
         item_to_take_name = argument.lower()
         location_items = self.dynamic_location_items.get(self.current_location_name, [])
-        item_found_in_loc, ambiguous = self.command_handler._get_matching_location_item(item_to_take_name)
+        item_found_in_loc, ambiguous = self.command_handler._get_matching_location_item(
+            item_to_take_name
+        )
         item_idx_in_loc = -1
         if item_found_in_loc:
             item_idx_in_loc = location_items.index(item_found_in_loc)
@@ -318,281 +545,776 @@ class ItemInteractionHandler:
         if item_found_in_loc:
             item_default_props = DEFAULT_ITEMS.get(item_found_in_loc["name"], {})
             if item_default_props.get("takeable", False):
-                take_quantity = 1; actual_taken_qty = 0
-                if item_default_props.get("stackable") or item_default_props.get("value") is not None:
-                    current_qty_in_loc = item_found_in_loc.get("quantity", 1); actual_taken_qty = min(take_quantity, current_qty_in_loc)
+                take_quantity = 1
+                actual_taken_qty = 0
+                if (
+                    item_default_props.get("stackable")
+                    or item_default_props.get("value") is not None
+                ):
+                    current_qty_in_loc = item_found_in_loc.get("quantity", 1)
+                    actual_taken_qty = min(take_quantity, current_qty_in_loc)
                     item_found_in_loc["quantity"] -= actual_taken_qty
-                    if item_found_in_loc["quantity"] <= 0: location_items.pop(item_idx_in_loc)
-                else: actual_taken_qty = 1; location_items.pop(item_idx_in_loc)
-                if self.player_character.add_to_inventory(item_found_in_loc["name"], actual_taken_qty):
-                    self._print_color(f"You take the {item_found_in_loc['name']}" + (f" (x{actual_taken_qty})" if actual_taken_qty > 1 and (item_default_props.get("stackable") or item_default_props.get("value") is not None) else "") + ".", Colors.GREEN)
-                    self.last_significant_event_summary = f"took the {item_found_in_loc['name']}."
-                    if item_default_props.get("is_notable"): self.player_character.apparent_state = random.choice(["thoughtful", "burdened"])
-                    if self.player_character.name == "Rodion Raskolnikov" and item_found_in_loc["name"] == "raskolnikov's axe":
-                        self.player_notoriety_level = min(3, max(0, self.player_notoriety_level + 0.5)); self._print_color("(Reclaiming the axe sends a shiver down your spine, a feeling of being marked.)", Colors.RED + Colors.DIM)
+                    if item_found_in_loc["quantity"] <= 0:
+                        location_items.pop(item_idx_in_loc)
+                else:
+                    actual_taken_qty = 1
+                    location_items.pop(item_idx_in_loc)
+                if self.player_character.add_to_inventory(
+                    item_found_in_loc["name"], actual_taken_qty
+                ):
+                    self._print_color(
+                        f"You take the {item_found_in_loc['name']}"
+                        + (
+                            f" (x{actual_taken_qty})"
+                            if actual_taken_qty > 1
+                            and (
+                                item_default_props.get("stackable")
+                                or item_default_props.get("value") is not None
+                            )
+                            else ""
+                        )
+                        + ".",
+                        Colors.GREEN,
+                    )
+                    self.last_significant_event_summary = (
+                        f"took the {item_found_in_loc['name']}."
+                    )
+                    if item_default_props.get("is_notable"):
+                        self.player_character.apparent_state = random.choice(
+                            ["thoughtful", "burdened"]
+                        )
+                    if (
+                        self.player_character.name == "Rodion Raskolnikov"
+                        and item_found_in_loc["name"] == "raskolnikov's axe"
+                    ):
+                        self.player_notoriety_level = min(
+                            3, max(0, self.player_notoriety_level + 0.5)
+                        )
+                        self._print_color(
+                            "(Reclaiming the axe sends a shiver down your spine, a feeling of being marked.)",
+                            Colors.RED + Colors.DIM,
+                        )
                     for npc in self.npcs_in_current_location:
                         if npc.name != self.player_character.name:
-                            npc.add_player_memory(memory_type="player_action_observed", turn=self.game_time, content={"action": "took_item", "item_name": item_found_in_loc["name"], "quantity": actual_taken_qty, "location": self.current_location_name}, sentiment_impact= -1 if item_default_props.get("is_notable") else 0)
-                    taken_item_name = item_found_in_loc["name"]; taken_item_props = DEFAULT_ITEMS.get(taken_item_name, {}) # Changed: self.game_config
-                    if taken_item_props.get("readable"): self._print_color(f"(Hint: You can now 'read {taken_item_name}'.)", Colors.DIM)
-                    elif taken_item_props.get("use_effect_player") and taken_item_name != "worn coin": self._print_color(f"(Hint: You can try to 'use {taken_item_name}'.)", Colors.DIM)
+                            npc.add_player_memory(
+                                memory_type="player_action_observed",
+                                turn=self.game_time,
+                                content={
+                                    "action": "took_item",
+                                    "item_name": item_found_in_loc["name"],
+                                    "quantity": actual_taken_qty,
+                                    "location": self.current_location_name,
+                                },
+                                sentiment_impact=(
+                                    -1 if item_default_props.get("is_notable") else 0
+                                ),
+                            )
+                    taken_item_name = item_found_in_loc["name"]
+                    taken_item_props = DEFAULT_ITEMS.get(
+                        taken_item_name, {}
+                    )  # Changed: self.game_config
+                    if taken_item_props.get("readable"):
+                        self._print_color(
+                            f"(Hint: You can now 'read {taken_item_name}'.)", Colors.DIM
+                        )
+                    elif (
+                        taken_item_props.get("use_effect_player")
+                        and taken_item_name != "worn coin"
+                    ):
+                        self._print_color(
+                            f"(Hint: You can try to 'use {taken_item_name}'.)",
+                            Colors.DIM,
+                        )
                     return True, False
                 else:
                     # Check if the failure was due to trying to take a non-stackable item already possessed
                     item_name_failed_to_add = item_found_in_loc["name"]
                     item_props_failed = DEFAULT_ITEMS.get(item_name_failed_to_add, {})
-                    is_non_stackable_unique = not item_props_failed.get("stackable", False) and item_props_failed.get("value") is None
+                    is_non_stackable_unique = (
+                        not item_props_failed.get("stackable", False)
+                        and item_props_failed.get("value") is None
+                    )
 
-                    if is_non_stackable_unique and self.player_character.has_item(item_name_failed_to_add):
-                        self._print_color(f"You cannot carry another '{item_name_failed_to_add}'.", Colors.YELLOW)
+                    if is_non_stackable_unique and self.player_character.has_item(
+                        item_name_failed_to_add
+                    ):
+                        self._print_color(
+                            f"You cannot carry another '{item_name_failed_to_add}'.",
+                            Colors.YELLOW,
+                        )
                     else:
                         # Generic failure message if not the specific non-stackable case
-                        self._print_color(f"Failed to add {item_name_failed_to_add} to inventory.", Colors.RED)
-                    return False, False # Action was attempted (hence True for show_atmospherics) but failed
-            else: self._print_color(f"You can't take the {item_found_in_loc['name']}.", Colors.YELLOW); return False, False
-        else: self._print_color(f"You don't see any '{item_to_take_name}' here to take.", Colors.RED); return False, False
+                        self._print_color(
+                            f"Failed to add {item_name_failed_to_add} to inventory.",
+                            Colors.RED,
+                        )
+                    return (
+                        False,
+                        False,
+                    )  # Action was attempted (hence True for show_atmospherics) but failed
+            else:
+                self._print_color(
+                    f"You can't take the {item_found_in_loc['name']}.", Colors.YELLOW
+                )
+                return False, False
+        else:
+            self._print_color(
+                f"You don't see any '{item_to_take_name}' here to take.", Colors.RED
+            )
+            return False, False
 
     def _handle_drop_command(self, argument):
-        if not argument: self._print_color("What do you want to drop?", Colors.RED); return False, False
-        if not self.player_character: self._print_color("Cannot drop items: Player character not available.", Colors.RED); return False, False
+        if not argument:
+            self._print_color("What do you want to drop?", Colors.RED)
+            return False, False
+        if not self.player_character:
+            self._print_color(
+                "Cannot drop items: Player character not available.", Colors.RED
+            )
+            return False, False
         item_to_drop_name_input = argument.lower()
-        item_in_inventory_obj, ambiguous = self.command_handler._get_matching_inventory_item(item_to_drop_name_input)
+        item_in_inventory_obj, ambiguous = (
+            self.command_handler._get_matching_inventory_item(item_to_drop_name_input)
+        )
         if ambiguous:
             return False, False
         if item_in_inventory_obj:
-            item_name_to_drop = item_in_inventory_obj["name"]; item_default_props = DEFAULT_ITEMS.get(item_name_to_drop, {}); drop_quantity = 1
-            if self.player_character.remove_from_inventory(item_name_to_drop, drop_quantity):
-                location_items = self.dynamic_location_items.setdefault(self.current_location_name, []); existing_loc_item = None
+            item_name_to_drop = item_in_inventory_obj["name"]
+            item_default_props = DEFAULT_ITEMS.get(item_name_to_drop, {})
+            drop_quantity = 1
+            if self.player_character.remove_from_inventory(
+                item_name_to_drop, drop_quantity
+            ):
+                location_items = self.dynamic_location_items.setdefault(
+                    self.current_location_name, []
+                )
+                existing_loc_item = None
                 for loc_item in location_items:
-                    if loc_item["name"] == item_name_to_drop: existing_loc_item = loc_item; break
-                if existing_loc_item and (item_default_props.get("stackable") or item_default_props.get("value") is not None): existing_loc_item["quantity"] = existing_loc_item.get("quantity", 0) + drop_quantity
-                else: location_items.append({"name": item_name_to_drop, "quantity": drop_quantity})
-                self._print_color(f"You drop the {item_name_to_drop}.", Colors.GREEN); self.last_significant_event_summary = f"dropped the {item_name_to_drop}."
+                    if loc_item["name"] == item_name_to_drop:
+                        existing_loc_item = loc_item
+                        break
+                if existing_loc_item and (
+                    item_default_props.get("stackable")
+                    or item_default_props.get("value") is not None
+                ):
+                    existing_loc_item["quantity"] = (
+                        existing_loc_item.get("quantity", 0) + drop_quantity
+                    )
+                else:
+                    location_items.append(
+                        {"name": item_name_to_drop, "quantity": drop_quantity}
+                    )
+                self._print_color(f"You drop the {item_name_to_drop}.", Colors.GREEN)
+                self.last_significant_event_summary = (
+                    f"dropped the {item_name_to_drop}."
+                )
                 for npc in self.npcs_in_current_location:
                     if npc.name != self.player_character.name:
-                        npc.add_player_memory(memory_type="player_action_observed", turn=self.game_time, content={"action": "dropped_item", "item_name": item_name_to_drop, "quantity": drop_quantity, "location": self.current_location_name}, sentiment_impact=0)
+                        npc.add_player_memory(
+                            memory_type="player_action_observed",
+                            turn=self.game_time,
+                            content={
+                                "action": "dropped_item",
+                                "item_name": item_name_to_drop,
+                                "quantity": drop_quantity,
+                                "location": self.current_location_name,
+                            },
+                            sentiment_impact=0,
+                        )
                 return True, False
-            else: self._print_color(f"You try to drop {item_name_to_drop}, but something is wrong.", Colors.RED); return False, False
-        else: self._print_color(f"You don't have '{item_to_drop_name_input}' to drop.", Colors.RED); return False, False
+            else:
+                self._print_color(
+                    f"You try to drop {item_name_to_drop}, but something is wrong.",
+                    Colors.RED,
+                )
+                return False, False
+        else:
+            self._print_color(
+                f"You don't have '{item_to_drop_name_input}' to drop.", Colors.RED
+            )
+            return False, False
 
     def _handle_use_command(self, argument):
-        if not self.player_character: self._print_color("Cannot use items: Player character not available.", Colors.RED); return False
-        if isinstance(argument, tuple): item_name_input, target_name_input, interaction_mode = argument; return self.handle_use_item(item_name_input, target_name_input, interaction_mode)
-        elif argument: return self.handle_use_item(argument, None, "use_self_implicit")
-        else: self._print_color("What do you want to use or read?", Colors.RED); return False
+        if not self.player_character:
+            self._print_color(
+                "Cannot use items: Player character not available.", Colors.RED
+            )
+            return False
+        if isinstance(argument, tuple):
+            item_name_input, target_name_input, interaction_mode = argument
+            return self.handle_use_item(
+                item_name_input, target_name_input, interaction_mode
+            )
+        elif argument:
+            return self.handle_use_item(argument, None, "use_self_implicit")
+        else:
+            self._print_color("What do you want to use or read?", Colors.RED)
+            return False
 
     def _handle_read_item(self, item_to_use_name, item_props, item_obj_in_inventory):
         if not self.player_character:
-            self._print_color("Cannot read items: Player character not available.", Colors.RED)
+            self._print_color(
+                "Cannot read items: Player character not available.", Colors.RED
+            )
             return False
         player_character = self.player_character
         current_location_name = self.current_location_name or "Unknown Location"
-        if not item_props.get("readable"): self._print_color(f"You can't read the {item_to_use_name}.", Colors.YELLOW); return False
-        effect_key = item_props.get("use_effect_player")
+        if not item_props.get("readable"):
+            self._print_color(f"You can't read the {item_to_use_name}.", Colors.YELLOW)
+            return False
         if item_to_use_name == "old newspaper" or item_to_use_name == "fresh newspaper":
-            self._print_color(f"You smooth out the creases of the {item_to_use_name} and scan the faded print.", Colors.WHITE)
+            self._print_color(
+                f"You smooth out the creases of the {item_to_use_name} and scan the faded print.",
+                Colors.WHITE,
+            )
             article_snippet = None
             ai_generated = False
             if not self.low_ai_data_mode and self.gemini_api.model:
-                article_snippet = self.gemini_api.get_newspaper_article_snippet(self.current_day, self._get_recent_events_summary(), self._get_objectives_summary(player_character), player_character.apparent_state)
+                article_snippet = self.gemini_api.get_newspaper_article_snippet(
+                    self.current_day,
+                    self._get_recent_events_summary(),
+                    self._get_objectives_summary(player_character),
+                    player_character.apparent_state,
+                )
 
-            if article_snippet is None or (isinstance(article_snippet, str) and article_snippet.startswith("(OOC:")) or self.low_ai_data_mode:
+            if (
+                article_snippet is None
+                or (
+                    isinstance(article_snippet, str)
+                    and article_snippet.startswith("(OOC:")
+                )
+                or self.low_ai_data_mode
+            ):
                 if STATIC_NEWSPAPER_SNIPPETS:
                     article_snippet = random.choice(STATIC_NEWSPAPER_SNIPPETS)
                 else:
-                    article_snippet = "The newsprint is smudged and uninteresting." # Ultimate fallback
+                    article_snippet = "The newsprint is smudged and uninteresting."  # Ultimate fallback
 
-                if article_snippet : # Make sure we have something to print/log
+                if article_snippet:  # Make sure we have something to print/log
                     article_snippet = self._apply_verbosity(article_snippet)
-                    self._print_color(f"An article catches your eye: \"{article_snippet}\"", Colors.CYAN) # Static in Cyan
-                    player_character.add_journal_entry("News (Static)", article_snippet, self._get_current_game_time_period_str()) # Optionally log differently
-            elif article_snippet: # AI success and not OOC
+                    self._print_color(
+                        f'An article catches your eye: "{article_snippet}"', Colors.CYAN
+                    )  # Static in Cyan
+                    player_character.add_journal_entry(
+                        "News (Static)",
+                        article_snippet,
+                        self._get_current_game_time_period_str(),
+                    )  # Optionally log differently
+            elif article_snippet:  # AI success and not OOC
                 article_snippet = self._apply_verbosity(article_snippet)
-                self._print_color(f"An article catches your eye: \"{article_snippet}\"", Colors.YELLOW)
-                player_character.add_journal_entry("News (AI)", article_snippet, self._get_current_game_time_period_str()) # Optionally log differently
+                self._print_color(
+                    f'An article catches your eye: "{article_snippet}"', Colors.YELLOW
+                )
+                player_character.add_journal_entry(
+                    "News (AI)",
+                    article_snippet,
+                    self._get_current_game_time_period_str(),
+                )  # Optionally log differently
                 ai_generated = True
 
-            if not article_snippet: # Final fallback if all else fails
-                 self._print_color("The print is too faded or the news too mundane to hold your interest.", Colors.DIM)
+            if not article_snippet:  # Final fallback if all else fails
+                self._print_color(
+                    "The print is too faded or the news too mundane to hold your interest.",
+                    Colors.DIM,
+                )
 
             # Common logic for both AI and static snippets if they are valid
             if article_snippet:
-                if "crime" in article_snippet.lower() or "investigation" in article_snippet.lower() or "murder" in article_snippet.lower():
+                if (
+                    "crime" in article_snippet.lower()
+                    or "investigation" in article_snippet.lower()
+                    or "murder" in article_snippet.lower()
+                ):
                     player_character.apparent_state = "thoughtful"
                     if player_character.name == "Rodion Raskolnikov":
-                        player_character.add_player_memory(memory_type="read_news_crime", turn=self.game_time, content={"summary": "Read unsettling news about the recent crime."}, sentiment_impact=0)
-                        self.player_notoriety_level = min(self.player_notoriety_level + 0.1, 3)
+                        player_character.add_player_memory(
+                            memory_type="read_news_crime",
+                            turn=self.game_time,
+                            content={
+                                "summary": "Read unsettling news about the recent crime."
+                            },
+                            sentiment_impact=0,
+                        )
+                        self.player_notoriety_level = min(
+                            self.player_notoriety_level + 0.1, 3
+                        )
                 self.last_significant_event_summary = f"read an {item_to_use_name}."
                 if ai_generated:
                     self._remember_ai_output(article_snippet, "news_article")
             return True
         elif item_to_use_name == "mother's letter":
-            self._print_color(f"You re-read your mother's letter. Her words of love and anxiety, Dunya's predicament... it all weighs heavily on you.", Colors.YELLOW)
+            self._print_color(
+                "You re-read your mother's letter. Her words of love and anxiety, Dunya's predicament... it all weighs heavily on you.",
+                Colors.YELLOW,
+            )
             reflection = None
             prompt_context = "re-reading mother's letter about Dunya and Luzhin, feeling guilt and responsibility"
             if not self.low_ai_data_mode and self.gemini_api.model:
-                reflection = self.gemini_api.get_player_reflection(player_character, current_location_name, self.world_manager.get_current_time_period(), prompt_context)
+                reflection = self.gemini_api.get_player_reflection(
+                    player_character,
+                    current_location_name,
+                    self.world_manager.get_current_time_period(),
+                    prompt_context,
+                )
 
-            if reflection is None or (isinstance(reflection, str) and reflection.startswith("(OOC:")) or self.low_ai_data_mode:
+            if (
+                reflection is None
+                or (isinstance(reflection, str) and reflection.startswith("(OOC:"))
+                or self.low_ai_data_mode
+            ):
                 if STATIC_PLAYER_REFLECTIONS:
                     reflection = random.choice(STATIC_PLAYER_REFLECTIONS)
                 else:
-                    reflection = "The letter stirs a whirlwind of emotions and responsibilities." # Ultimate fallback
-                self._print_color(f"\"{self._apply_verbosity(reflection)}\"", Colors.DIM) # Static reflection in DIM
-            else: # AI success
+                    reflection = "The letter stirs a whirlwind of emotions and responsibilities."  # Ultimate fallback
+                self._print_color(
+                    f'"{self._apply_verbosity(reflection)}"', Colors.DIM
+                )  # Static reflection in DIM
+            else:  # AI success
                 reflection = self._apply_verbosity(reflection)
-                self._print_color(f"\"{reflection}\"", Colors.CYAN)
+                self._print_color(f'"{reflection}"', Colors.CYAN)
                 self._remember_ai_output(reflection, "read_letter")
 
-            player_character.apparent_state = random.choice(["burdened", "agitated", "resolved"])
-            if player_character.name == "Rodion Raskolnikov": player_character.add_player_memory(memory_type="reread_mother_letter", turn=self.game_time, content={"summary": "Re-reading mother's letter intensified feelings of duty and distress."}, sentiment_impact=-1)
-            self.last_significant_event_summary = f"re-read the {item_to_use_name}."; return True
+            player_character.apparent_state = random.choice(
+                ["burdened", "agitated", "resolved"]
+            )
+            if player_character.name == "Rodion Raskolnikov":
+                player_character.add_player_memory(
+                    memory_type="reread_mother_letter",
+                    turn=self.game_time,
+                    content={
+                        "summary": "Re-reading mother's letter intensified feelings of duty and distress."
+                    },
+                    sentiment_impact=-1,
+                )
+            self.last_significant_event_summary = f"re-read the {item_to_use_name}."
+            return True
         elif item_to_use_name == "sonya's new testament":
-            self._print_color(f"You open {item_to_use_name}. The familiar words of the Gospels seem to both accuse and offer a sliver of hope.", Colors.GREEN)
+            self._print_color(
+                f"You open {item_to_use_name}. The familiar words of the Gospels seem to both accuse and offer a sliver of hope.",
+                Colors.GREEN,
+            )
             reflection = None
             prompt_context = f"reading from {item_to_use_name}, pondering Lazarus, guilt, and salvation"
             if not self.low_ai_data_mode and self.gemini_api.model:
-                reflection = self.gemini_api.get_player_reflection(player_character, current_location_name, self.get_current_time_period(), prompt_context)
+                reflection = self.gemini_api.get_player_reflection(
+                    player_character,
+                    current_location_name,
+                    self.get_current_time_period(),
+                    prompt_context,
+                )
 
-            if reflection is None or (isinstance(reflection, str) and reflection.startswith("(OOC:")) or self.low_ai_data_mode:
+            if (
+                reflection is None
+                or (isinstance(reflection, str) and reflection.startswith("(OOC:"))
+                or self.low_ai_data_mode
+            ):
                 if STATIC_PLAYER_REFLECTIONS:
                     reflection = random.choice(STATIC_PLAYER_REFLECTIONS)
                 else:
-                    reflection = "The words offer a strange mix of judgment and hope." # Ultimate fallback
-                self._print_color(f"\"{self._apply_verbosity(reflection)}\"", Colors.DIM) # Static reflection in DIM
-            else: # AI success
+                    reflection = "The words offer a strange mix of judgment and hope."  # Ultimate fallback
+                self._print_color(
+                    f'"{self._apply_verbosity(reflection)}"', Colors.DIM
+                )  # Static reflection in DIM
+            else:  # AI success
                 reflection = self._apply_verbosity(reflection)
-                self._print_color(f"\"{reflection}\"", Colors.CYAN)
+                self._print_color(f'"{reflection}"', Colors.CYAN)
                 self._remember_ai_output(reflection, "read_testament")
 
             if player_character.name == "Rodion Raskolnikov":
-                player_character.apparent_state = random.choice(["contemplative", "remorseful", "thoughtful", "hopeful"])
-                player_character.add_player_memory(memory_type="read_testament_sonya", turn=self.game_time, content={"summary": "Read from the New Testament, stirring deep thoughts of salvation and suffering."}, sentiment_impact=0)
-            self.last_significant_event_summary = f"read from {item_to_use_name}."; return True
+                player_character.apparent_state = random.choice(
+                    ["contemplative", "remorseful", "thoughtful", "hopeful"]
+                )
+                player_character.add_player_memory(
+                    memory_type="read_testament_sonya",
+                    turn=self.game_time,
+                    content={
+                        "summary": "Read from the New Testament, stirring deep thoughts of salvation and suffering."
+                    },
+                    sentiment_impact=0,
+                )
+            self.last_significant_event_summary = f"read from {item_to_use_name}."
+            return True
         elif item_to_use_name == "anonymous note":
             if item_obj_in_inventory and "generated_content" in item_obj_in_inventory:
-                self._print_color(f"You read the {item_to_use_name}:", Colors.WHITE); self._print_color(f"\"{item_obj_in_inventory['generated_content']}\"", Colors.CYAN)
-                player_character.add_journal_entry("Note", item_obj_in_inventory['generated_content'], self._get_current_game_time_period_str()); self.last_significant_event_summary = f"read an {item_to_use_name}."
-                if "watch" in item_obj_in_inventory['generated_content'].lower() or "know" in item_obj_in_inventory['generated_content'].lower(): player_character.apparent_state = "paranoid"
+                self._print_color(f"You read the {item_to_use_name}:", Colors.WHITE)
+                self._print_color(
+                    f"\"{item_obj_in_inventory['generated_content']}\"", Colors.CYAN
+                )
+                player_character.add_journal_entry(
+                    "Note",
+                    item_obj_in_inventory["generated_content"],
+                    self._get_current_game_time_period_str(),
+                )
+                self.last_significant_event_summary = f"read an {item_to_use_name}."
+                if (
+                    "watch" in item_obj_in_inventory["generated_content"].lower()
+                    or "know" in item_obj_in_inventory["generated_content"].lower()
+                ):
+                    player_character.apparent_state = "paranoid"
                 return True
-            else: self._print_color(f"The {item_to_use_name} seems to be blank or unreadable.", Colors.RED); return False
+            else:
+                self._print_color(
+                    f"The {item_to_use_name} seems to be blank or unreadable.",
+                    Colors.RED,
+                )
+                return False
         elif item_to_use_name == "IOU Slip":
-            if item_obj_in_inventory and item_obj_in_inventory.get("content"): self._print_color(f"You examine the {item_to_use_name}: \"{item_obj_in_inventory['content']}\"", Colors.YELLOW)
-            else: self._print_color(f"You look at the {item_to_use_name}. It's a formal-looking slip of paper.", Colors.YELLOW)
-            self.last_significant_event_summary = f"read an {item_to_use_name}."; return True
+            if item_obj_in_inventory and item_obj_in_inventory.get("content"):
+                self._print_color(
+                    f"You examine the {item_to_use_name}: \"{item_obj_in_inventory['content']}\"",
+                    Colors.YELLOW,
+                )
+            else:
+                self._print_color(
+                    f"You look at the {item_to_use_name}. It's a formal-looking slip of paper.",
+                    Colors.YELLOW,
+                )
+            self.last_significant_event_summary = f"read an {item_to_use_name}."
+            return True
         elif item_to_use_name == "Student's Dog-eared Book":
             book_reflection = None
             if not self.low_ai_data_mode and self.gemini_api.model:
-                book_reflection = self.gemini_api.get_item_interaction_description(player_character, item_to_use_name, item_props, "read", current_location_name, self.get_current_time_period())
+                book_reflection = self.gemini_api.get_item_interaction_description(
+                    player_character,
+                    item_to_use_name,
+                    item_props,
+                    "read",
+                    current_location_name,
+                    self.get_current_time_period(),
+                )
 
-            if book_reflection is None or (isinstance(book_reflection, str) and book_reflection.startswith("(OOC:")) or self.low_ai_data_mode:
-                book_reflection = generate_static_item_interaction_description(item_to_use_name, "read")
-                self._print_color(f"You open the {item_to_use_name}. {book_reflection}", Colors.CYAN) # Static in Cyan
-            else: # AI success
-                self._print_color(f"You open the {item_to_use_name}. {book_reflection}", Colors.YELLOW)
+            if (
+                book_reflection is None
+                or (
+                    isinstance(book_reflection, str)
+                    and book_reflection.startswith("(OOC:")
+                )
+                or self.low_ai_data_mode
+            ):
+                book_reflection = generate_static_item_interaction_description(
+                    item_to_use_name, "read"
+                )
+                self._print_color(
+                    f"You open the {item_to_use_name}. {book_reflection}", Colors.CYAN
+                )  # Static in Cyan
+            else:  # AI success
+                self._print_color(
+                    f"You open the {item_to_use_name}. {book_reflection}", Colors.YELLOW
+                )
 
-            self.last_significant_event_summary = f"read from a {item_to_use_name}."; used_successfully = True; return True # Keep used_successfully variable, though it's always true here
+            self.last_significant_event_summary = f"read from a {item_to_use_name}."
+            return True
 
         read_reflection = None
         if not self.low_ai_data_mode and self.gemini_api.model:
-            read_reflection = self.gemini_api.get_item_interaction_description(player_character, item_to_use_name, item_props, "read", current_location_name, self.get_current_time_period())
+            read_reflection = self.gemini_api.get_item_interaction_description(
+                player_character,
+                item_to_use_name,
+                item_props,
+                "read",
+                current_location_name,
+                self.get_current_time_period(),
+            )
 
-        if read_reflection is None or (isinstance(read_reflection, str) and read_reflection.startswith("(OOC:")) or self.low_ai_data_mode:
-            read_reflection = generate_static_item_interaction_description(item_to_use_name, "read")
-            self._print_color(f"You read the {item_to_use_name}. {read_reflection}", Colors.CYAN) # Static in Cyan
-        else: # AI success
-            self._print_color(f"You read the {item_to_use_name}. {read_reflection}", Colors.YELLOW)
+        if (
+            read_reflection is None
+            or (
+                isinstance(read_reflection, str) and read_reflection.startswith("(OOC:")
+            )
+            or self.low_ai_data_mode
+        ):
+            read_reflection = generate_static_item_interaction_description(
+                item_to_use_name, "read"
+            )
+            self._print_color(
+                f"You read the {item_to_use_name}. {read_reflection}", Colors.CYAN
+            )  # Static in Cyan
+        else:  # AI success
+            self._print_color(
+                f"You read the {item_to_use_name}. {read_reflection}", Colors.YELLOW
+            )
 
-        self.last_significant_event_summary = f"read the {item_to_use_name}."; return True
+        self.last_significant_event_summary = f"read the {item_to_use_name}."
+        return True
 
     def _handle_self_use_item(self, item_to_use_name, item_props, effect_key):
         if not self.player_character:
-            self._print_color("Cannot use items: Player character not available.", Colors.RED)
+            self._print_color(
+                "Cannot use items: Player character not available.", Colors.RED
+            )
             return False
         player_character = self.player_character
         current_location_name = self.current_location_name or "Unknown Location"
         used_successfully = False
-        if effect_key == "comfort_self_if_ill" and item_to_use_name == "tattered handkerchief":
-            if player_character.apparent_state in ["feverish", "coughing", "ill", "haunted by dreams"]:
-                self._print_color(f"You press the {item_to_use_name} to your brow. It offers little physical comfort, but it's something to cling to.", Colors.YELLOW)
-                if player_character.apparent_state == "feverish" and random.random() < 0.2: player_character.apparent_state = "less feverish"; self._print_color("The coolness, imagined or real, seems to lessen the fever's grip for a moment.", Colors.CYAN)
-                self.last_significant_event_summary = f"used a {item_to_use_name} while feeling unwell."; used_successfully = True
-            else: self._print_color(f"You look at the {item_to_use_name}. It seems rather pointless to use it now.", Colors.YELLOW)
-        elif effect_key == "examine_bottle_for_residue" and item_to_use_name == "dusty bottle":
-            self._print_color(f"You peer into the {item_to_use_name}. A faint, stale smell of cheap spirits lingers. It's long empty.", Colors.YELLOW)
-            self.last_significant_event_summary = f"examined a {item_to_use_name}."; used_successfully = True
-        elif effect_key == "grip_axe_and_reminisce_horror" and item_to_use_name == "raskolnikov's axe":
+        if (
+            effect_key == "comfort_self_if_ill"
+            and item_to_use_name == "tattered handkerchief"
+        ):
+            if player_character.apparent_state in [
+                "feverish",
+                "coughing",
+                "ill",
+                "haunted by dreams",
+            ]:
+                self._print_color(
+                    f"You press the {item_to_use_name} to your brow. It offers little physical comfort, but it's something to cling to.",
+                    Colors.YELLOW,
+                )
+                if (
+                    player_character.apparent_state == "feverish"
+                    and random.random() < 0.2
+                ):
+                    player_character.apparent_state = "less feverish"
+                    self._print_color(
+                        "The coolness, imagined or real, seems to lessen the fever's grip for a moment.",
+                        Colors.CYAN,
+                    )
+                self.last_significant_event_summary = (
+                    f"used a {item_to_use_name} while feeling unwell."
+                )
+                used_successfully = True
+            else:
+                self._print_color(
+                    f"You look at the {item_to_use_name}. It seems rather pointless to use it now.",
+                    Colors.YELLOW,
+                )
+        elif (
+            effect_key == "examine_bottle_for_residue"
+            and item_to_use_name == "dusty bottle"
+        ):
+            self._print_color(
+                f"You peer into the {item_to_use_name}. A faint, stale smell of cheap spirits lingers. It's long empty.",
+                Colors.YELLOW,
+            )
+            self.last_significant_event_summary = f"examined a {item_to_use_name}."
+            used_successfully = True
+        elif (
+            effect_key == "grip_axe_and_reminisce_horror"
+            and item_to_use_name == "raskolnikov's axe"
+        ):
             if player_character.name == "Rodion Raskolnikov":
-                self._print_color(f"You grip the {item_to_use_name}. Its cold weight is a familiar dread. The memories, sharp and bloody, flood your mind. You feel a wave of nausea, then a chilling resolve, then utter despair.", Colors.RED + Colors.BOLD)
-                player_character.apparent_state = random.choice(["dangerously agitated", "remorseful", "paranoid"]); self.last_significant_event_summary = f"held the axe, tormented by memories."; used_successfully = True
-            else: self._print_color(f"You look at the {item_to_use_name}. It's a grim object, heavy and unsettling. Best left alone.", Colors.YELLOW); used_successfully = True
-        elif effect_key == "reflect_on_faith_and_redemption" and item_to_use_name == "sonya's cypress cross":
+                self._print_color(
+                    f"You grip the {item_to_use_name}. Its cold weight is a familiar dread. The memories, sharp and bloody, flood your mind. You feel a wave of nausea, then a chilling resolve, then utter despair.",
+                    Colors.RED + Colors.BOLD,
+                )
+                player_character.apparent_state = random.choice(
+                    ["dangerously agitated", "remorseful", "paranoid"]
+                )
+                self.last_significant_event_summary = (
+                    "held the axe, tormented by memories."
+                )
+                used_successfully = True
+            else:
+                self._print_color(
+                    f"You look at the {item_to_use_name}. It's a grim object, heavy and unsettling. Best left alone.",
+                    Colors.YELLOW,
+                )
+                used_successfully = True
+        elif (
+            effect_key == "reflect_on_faith_and_redemption"
+            and item_to_use_name == "sonya's cypress cross"
+        ):
             if player_character.name == "Rodion Raskolnikov":
-                self._print_color("You clutch the small cypress cross. It feels strangely significant in your hand, a stark contrast to the turmoil within you.", Colors.GREEN)
-                player_character.apparent_state = random.choice(["remorseful", "contemplative", "hopeful"]); self.last_significant_event_summary = f"held Sonya's cross, feeling its weight and Sonya's sacrifice."
+                self._print_color(
+                    "You clutch the small cypress cross. It feels strangely significant in your hand, a stark contrast to the turmoil within you.",
+                    Colors.GREEN,
+                )
+                player_character.apparent_state = random.choice(
+                    ["remorseful", "contemplative", "hopeful"]
+                )
+                self.last_significant_event_summary = (
+                    "held Sonya's cross, feeling its weight and Sonya's sacrifice."
+                )
                 reflection = None
                 if not self.low_ai_data_mode and self.gemini_api.model:
-                    reflection = self.gemini_api.get_player_reflection(player_character, current_location_name, self.get_current_time_period(), "Holding Sonya's cross, new thoughts about suffering and sacrifice surface.")
-                if reflection is None or (isinstance(reflection, str) and reflection.startswith("(OOC:")) or self.low_ai_data_mode:
+                    reflection = self.gemini_api.get_player_reflection(
+                        player_character,
+                        current_location_name,
+                        self.get_current_time_period(),
+                        "Holding Sonya's cross, new thoughts about suffering and sacrifice surface.",
+                    )
+                if (
+                    reflection is None
+                    or (isinstance(reflection, str) and reflection.startswith("(OOC:"))
+                    or self.low_ai_data_mode
+                ):
                     if STATIC_PLAYER_REFLECTIONS:
                         reflection = random.choice(STATIC_PLAYER_REFLECTIONS)
                     else:
-                        reflection = "The cross feels warm in your hand, a quiet comfort."
-                    self._print_color(f"\"{reflection}\"", Colors.CYAN); used_successfully = True
-            else: self._print_color(f"You examine {item_to_use_name}. It seems to be a simple wooden cross, yet it emanates a certain potent feeling.", Colors.YELLOW); used_successfully = True
-        elif effect_key == "examine_rag_and_spiral_into_paranoia" and item_to_use_name == "bloodied rag":
-            self._print_color(f"You stare at the {item_to_use_name}. The dark stains seem to shift and spread before your eyes. Every sound, every shadow, feels like an accusation.", Colors.RED)
+                        reflection = (
+                            "The cross feels warm in your hand, a quiet comfort."
+                        )
+                    self._print_color(f'"{reflection}"', Colors.CYAN)
+                    used_successfully = True
+            else:
+                self._print_color(
+                    f"You examine {item_to_use_name}. It seems to be a simple wooden cross, yet it emanates a certain potent feeling.",
+                    Colors.YELLOW,
+                )
+                used_successfully = True
+        elif (
+            effect_key == "examine_rag_and_spiral_into_paranoia"
+            and item_to_use_name == "bloodied rag"
+        ):
+            self._print_color(
+                f"You stare at the {item_to_use_name}. The dark stains seem to shift and spread before your eyes. Every sound, every shadow, feels like an accusation.",
+                Colors.RED,
+            )
             player_character.apparent_state = "paranoid"
-            if player_character.name == "Rodion Raskolnikov": player_character.add_player_memory(memory_type="observed_bloodied_rag", turn=self.game_time, content={"summary": "The sight of the bloodied rag brought a fresh wave of paranoia."}, sentiment_impact=-1); self.player_notoriety_level = min(self.player_notoriety_level + 0.5, 3)
-            self.last_significant_event_summary = f"was deeply disturbed by a {item_to_use_name}."; used_successfully = True
-        elif effect_key == "drink_vodka_for_oblivion" and item_to_use_name == "cheap vodka":
-            original_state_feverish = (player_character.apparent_state == "feverish")
-            self._print_color(f"You take a long swig of the harsh vodka. It burns on the way down, offering a brief, false warmth and a dulling of the senses.", Colors.MAGENTA)
+            if player_character.name == "Rodion Raskolnikov":
+                player_character.add_player_memory(
+                    memory_type="observed_bloodied_rag",
+                    turn=self.game_time,
+                    content={
+                        "summary": "The sight of the bloodied rag brought a fresh wave of paranoia."
+                    },
+                    sentiment_impact=-1,
+                )
+                self.player_notoriety_level = min(self.player_notoriety_level + 0.5, 3)
+            self.last_significant_event_summary = (
+                f"was deeply disturbed by a {item_to_use_name}."
+            )
+            used_successfully = True
+        elif (
+            effect_key == "drink_vodka_for_oblivion"
+            and item_to_use_name == "cheap vodka"
+        ):
+            original_state_feverish = player_character.apparent_state == "feverish"
+            self._print_color(
+                "You take a long swig of the harsh vodka. It burns on the way down, offering a brief, false warmth and a dulling of the senses.",
+                Colors.MAGENTA,
+            )
 
             # Default effect of vodka
             player_character.apparent_state = "slightly drunk"
 
-            if player_character.has_item("cheap vodka"): player_character.remove_from_inventory("cheap vodka", 1)
-            else: self._print_color("Odd, the bottle seems to have vanished before you could drink it all.", Colors.DIM)
-            self.last_significant_event_summary = "drank some cheap vodka to numb the thoughts."
+            if player_character.has_item("cheap vodka"):
+                player_character.remove_from_inventory("cheap vodka", 1)
+            else:
+                self._print_color(
+                    "Odd, the bottle seems to have vanished before you could drink it all.",
+                    Colors.DIM,
+                )
+            self.last_significant_event_summary = (
+                "drank some cheap vodka to numb the thoughts."
+            )
 
             # Override if originally feverish
             if original_state_feverish:
                 player_character.apparent_state = "agitated"
-                self._print_color("The vodka clashes terribly with your fever, making you feel worse.", Colors.RED)
+                self._print_color(
+                    "The vodka clashes terribly with your fever, making you feel worse.",
+                    Colors.RED,
+                )
             used_successfully = True
-        elif effect_key == "examine_bundle_and_face_guilt_for_Lizaveta" and item_to_use_name == "lizaveta's bundle":
-            self._print_color(f"You hesitantly open {item_to_use_name}. Inside are a few pitiful belongings: a worn shawl, a child's small wooden toy, a copper coin... The sight is a fresh stab of guilt for the gentle Lizaveta.", Colors.YELLOW)
-            if player_character.name == "Rodion Raskolnikov": player_character.apparent_state = "remorseful"; player_character.add_player_memory(memory_type="examined_lizavetas_bundle", turn=self.game_time, content={"summary": "Examined lizaveta's bundle; the innocence of the items was a heavy burden."}, sentiment_impact=-1)
-            self.last_significant_event_summary = f"examined lizaveta's bundle, increasing the weight of guilt."; used_successfully = True
-        elif effect_key == "eat_bread_for_sustenance" and item_to_use_name == "Loaf of Black Bread":
-            self._print_color(f"You tear off a piece of the dense {item_to_use_name}. It's coarse, but fills your stomach somewhat.", Colors.YELLOW)
-            if player_character.apparent_state in ["burdened", "feverish", "despondent"]: player_character.apparent_state = "normal"; self._print_color("The bread provides a moment of simple relief.", Colors.CYAN)
-            self.last_significant_event_summary = f"ate some {item_to_use_name}."; used_successfully = True
-        elif effect_key == "contemplate_icon" and item_to_use_name == "Small, Tarnished Icon":
+        elif (
+            effect_key == "examine_bundle_and_face_guilt_for_Lizaveta"
+            and item_to_use_name == "lizaveta's bundle"
+        ):
+            self._print_color(
+                f"You hesitantly open {item_to_use_name}. Inside are a few pitiful belongings: a worn shawl, a child's small wooden toy, a copper coin... The sight is a fresh stab of guilt for the gentle Lizaveta.",
+                Colors.YELLOW,
+            )
+            if player_character.name == "Rodion Raskolnikov":
+                player_character.apparent_state = "remorseful"
+                player_character.add_player_memory(
+                    memory_type="examined_lizavetas_bundle",
+                    turn=self.game_time,
+                    content={
+                        "summary": "Examined lizaveta's bundle; the innocence of the items was a heavy burden."
+                    },
+                    sentiment_impact=-1,
+                )
+            self.last_significant_event_summary = (
+                "examined lizaveta's bundle, increasing the weight of guilt."
+            )
+            used_successfully = True
+        elif (
+            effect_key == "eat_bread_for_sustenance"
+            and item_to_use_name == "Loaf of Black Bread"
+        ):
+            self._print_color(
+                f"You tear off a piece of the dense {item_to_use_name}. It's coarse, but fills your stomach somewhat.",
+                Colors.YELLOW,
+            )
+            if player_character.apparent_state in [
+                "burdened",
+                "feverish",
+                "despondent",
+            ]:
+                player_character.apparent_state = "normal"
+                self._print_color(
+                    "The bread provides a moment of simple relief.", Colors.CYAN
+                )
+            self.last_significant_event_summary = f"ate some {item_to_use_name}."
+            used_successfully = True
+        elif (
+            effect_key == "contemplate_icon"
+            and item_to_use_name == "Small, Tarnished Icon"
+        ):
             icon_reflection = None
             if not self.low_ai_data_mode and self.gemini_api.model:
-                icon_reflection = self.gemini_api.get_item_interaction_description(player_character, item_to_use_name, item_props, "contemplate", current_location_name, self.get_current_time_period())
+                icon_reflection = self.gemini_api.get_item_interaction_description(
+                    player_character,
+                    item_to_use_name,
+                    item_props,
+                    "contemplate",
+                    current_location_name,
+                    self.get_current_time_period(),
+                )
 
-            if icon_reflection is None or (isinstance(icon_reflection, str) and icon_reflection.startswith("(OOC:")) or self.low_ai_data_mode:
-                icon_reflection = generate_static_item_interaction_description(item_to_use_name, "contemplate")
-                self._print_color(f"You gaze at the {item_to_use_name}. {icon_reflection}", Colors.CYAN) # Static in Cyan
-            else: # AI success
-                self._print_color(f"You gaze at the {item_to_use_name}. {icon_reflection}", Colors.YELLOW)
-            self.last_significant_event_summary = f"contemplated a {item_to_use_name}."; used_successfully = True
-        if not used_successfully: self._print_color(f"You contemplate the {item_to_use_name}, but don't find a specific use for it right now.", Colors.YELLOW); return False
+            if (
+                icon_reflection is None
+                or (
+                    isinstance(icon_reflection, str)
+                    and icon_reflection.startswith("(OOC:")
+                )
+                or self.low_ai_data_mode
+            ):
+                icon_reflection = generate_static_item_interaction_description(
+                    item_to_use_name, "contemplate"
+                )
+                self._print_color(
+                    f"You gaze at the {item_to_use_name}. {icon_reflection}",
+                    Colors.CYAN,
+                )  # Static in Cyan
+            else:  # AI success
+                self._print_color(
+                    f"You gaze at the {item_to_use_name}. {icon_reflection}",
+                    Colors.YELLOW,
+                )
+            self.last_significant_event_summary = f"contemplated a {item_to_use_name}."
+            used_successfully = True
+        if not used_successfully:
+            self._print_color(
+                f"You contemplate the {item_to_use_name}, but don't find a specific use for it right now.",
+                Colors.YELLOW,
+            )
+            return False
         return used_successfully
 
     def _handle_give_item(self, item_to_use_name, item_props, target_name_input):
         if not self.player_character:
-            self._print_color("Cannot give items: Player character not available.", Colors.RED)
+            self._print_color(
+                "Cannot give items: Player character not available.", Colors.RED
+            )
             return False
         player_character = self.player_character
         current_location_name = self.current_location_name or "Unknown Location"
-        target_npc = next((npc for npc in self.npcs_in_current_location if npc.name.lower().startswith(target_name_input.lower())), None)
+        target_npc = next(
+            (
+                npc
+                for npc in self.npcs_in_current_location
+                if npc.name.lower().startswith(target_name_input.lower())
+            ),
+            None,
+        )
 
         if not target_npc:
-            self._print_color(f"You don't see '{target_name_input}' here to give anything to.", Colors.RED)
+            self._print_color(
+                f"You don't see '{target_name_input}' here to give anything to.",
+                Colors.RED,
+            )
             return False
 
         # Check if player has the item (using a generic quantity of 1 for now)
@@ -604,76 +1326,170 @@ class ItemInteractionHandler:
         # Attempt to remove the item from player's inventory
         if player_character.remove_from_inventory(item_to_use_name, 1):
             # Add item to NPC's inventory
-            target_npc.add_to_inventory(item_to_use_name, 1) # Assuming quantity 1 for now
+            target_npc.add_to_inventory(
+                item_to_use_name, 1
+            )  # Assuming quantity 1 for now
 
-            self._print_color(f"You give the {item_to_use_name} to {target_npc.name}.", Colors.WHITE)
+            self._print_color(
+                f"You give the {item_to_use_name} to {target_npc.name}.", Colors.WHITE
+            )
 
             # Generate NPC reaction using Gemini API
-            relationship_text = self.get_relationship_text(target_npc.relationship_with_player)
-            dialogue_prompt = f"(Player gives {item_to_use_name} to NPC. Player expects a reaction.)"
+            relationship_text = self.get_relationship_text(
+                target_npc.relationship_with_player
+            )
+            dialogue_prompt = (
+                f"(Player gives {item_to_use_name} to NPC. Player expects a reaction.)"
+            )
 
             reaction = None
             if not self.low_ai_data_mode and self.gemini_api.model:
                 reaction = self.gemini_api.get_npc_dialogue(
-                    target_npc, player_character, dialogue_prompt,
-                    current_location_name, self.get_current_time_period(), relationship_text,
-                    target_npc.get_player_memory_summary(self.game_time), player_character.apparent_state,
-                    player_character.get_notable_carried_items_summary(), self._get_recent_events_summary(),
-                    self._get_objectives_summary(target_npc), self._get_objectives_summary(player_character)
+                    target_npc,
+                    player_character,
+                    dialogue_prompt,
+                    current_location_name,
+                    self.get_current_time_period(),
+                    relationship_text,
+                    target_npc.get_player_memory_summary(self.game_time),
+                    player_character.apparent_state,
+                    player_character.get_notable_carried_items_summary(),
+                    self._get_recent_events_summary(),
+                    self._get_objectives_summary(target_npc),
+                    self._get_objectives_summary(player_character),
                 )
 
-            if reaction is None or (isinstance(reaction, str) and reaction.startswith("(OOC:")) or self.low_ai_data_mode :
+            if (
+                reaction is None
+                or (isinstance(reaction, str) and reaction.startswith("(OOC:"))
+                or self.low_ai_data_mode
+            ):
                 # Fallback static reaction if AI fails or low_ai_mode
                 static_reactions = [
                     f"Oh, for me? Thank you for the {item_to_use_name}.",
                     f"A {item_to_use_name}? How thoughtful of you.",
                     f"I appreciate you giving me this {item_to_use_name}.",
-                    f"Thank you, this {item_to_use_name} is noted."
+                    f"Thank you, this {item_to_use_name} is noted.",
                 ]
                 reaction = random.choice(static_reactions)
-                self._print_color(f"{target_npc.name}: \"{reaction}\" {Colors.DIM}(Static reaction){Colors.RESET}", Colors.YELLOW)
-            else: # AI Success
-                 self._print_color(f"{target_npc.name}: \"{reaction}\"", Colors.YELLOW)
-
+                self._print_color(
+                    f'{target_npc.name}: "{reaction}" {Colors.DIM}(Static reaction){Colors.RESET}',
+                    Colors.YELLOW,
+                )
+            else:  # AI Success
+                self._print_color(f'{target_npc.name}: "{reaction}"', Colors.YELLOW)
 
             # Update NPC's relationship with the player (e.g., a slight increase)
-            target_npc.relationship_with_player += 1 # Simple increment, can be more nuanced
+            target_npc.relationship_with_player += (
+                1  # Simple increment, can be more nuanced
+            )
 
             # Add a memory to the NPC about receiving the item
             target_npc.add_player_memory(
                 memory_type="received_item",
                 turn=self.game_time,
-                content={"item_name": item_to_use_name, "quantity": 1, "from_player": True, "context": "player_gave_item"},
-                sentiment_impact=1 # Generally positive for receiving an item
+                content={
+                    "item_name": item_to_use_name,
+                    "quantity": 1,
+                    "from_player": True,
+                    "context": "player_gave_item",
+                },
+                sentiment_impact=1,  # Generally positive for receiving an item
             )
 
-            self.last_significant_event_summary = f"gave {item_to_use_name} to {target_npc.name}."
+            self.last_significant_event_summary = (
+                f"gave {item_to_use_name} to {target_npc.name}."
+            )
             return True
         else:
             # This case should ideally be caught by has_item, but as a fallback
-            self._print_color(f"You find you don't actually have {item_to_use_name} to give after all.", Colors.RED)
+            self._print_color(
+                f"You find you don't actually have {item_to_use_name} to give after all.",
+                Colors.RED,
+            )
             return False
 
-    def handle_use_item(self, item_name_input, target_name_input=None, interaction_type="use_self_implicit"):
+    def handle_use_item(
+        self,
+        item_name_input,
+        target_name_input=None,
+        interaction_type="use_self_implicit",
+    ):
         # This wrapper supports "give" and "use_on" routing too
-        if not self.player_character: self._print_color("Cannot use items: Player character not set.", Colors.RED); return False
-        item_to_use_name = None; item_obj_in_inventory = None
+        if not self.player_character:
+            self._print_color("Cannot use items: Player character not set.", Colors.RED)
+            return False
+        item_to_use_name = None
+        item_obj_in_inventory = None
         if item_name_input:
             for inv_item_obj_loop in self.player_character.inventory:
-                if inv_item_obj_loop["name"].lower().startswith(item_name_input.lower()): item_to_use_name = inv_item_obj_loop["name"]; item_obj_in_inventory = inv_item_obj_loop; break
+                if (
+                    inv_item_obj_loop["name"]
+                    .lower()
+                    .startswith(item_name_input.lower())
+                ):
+                    item_to_use_name = inv_item_obj_loop["name"]
+                    item_obj_in_inventory = inv_item_obj_loop
+                    break
             if not item_to_use_name:
-                if self.player_character.has_item(item_name_input): item_to_use_name = item_name_input; item_obj_in_inventory = next((item for item in self.player_character.inventory if item["name"] == item_to_use_name), None)
-                else: self._print_color(f"You don't have '{item_name_input}' to {interaction_type.replace('_', ' ')}.", Colors.RED); return False
-        elif interaction_type != "use_self_implicit": self._print_color(f"What do you want to {interaction_type.replace('_', ' ')}{(' on ' + target_name_input) if target_name_input else ''}?", Colors.RED); return False
-        if not item_to_use_name : self._print_color("You need to specify an item to use or read.", Colors.RED); return False
-        item_props = DEFAULT_ITEMS.get(item_to_use_name, {}); used_successfully = False
-        if interaction_type == "read": used_successfully = self._handle_read_item(item_to_use_name, item_props, item_obj_in_inventory)
-        elif interaction_type == "give" and target_name_input: used_successfully = self._handle_give_item(item_to_use_name, item_props, target_name_input)
-        elif interaction_type == "use_on" and target_name_input: self._print_color(f"You try to use the {item_to_use_name} on {target_name_input}, but nothing specific happens.", Colors.YELLOW); used_successfully = False
+                if self.player_character.has_item(item_name_input):
+                    item_to_use_name = item_name_input
+                    item_obj_in_inventory = next(
+                        (
+                            item
+                            for item in self.player_character.inventory
+                            if item["name"] == item_to_use_name
+                        ),
+                        None,
+                    )
+                else:
+                    self._print_color(
+                        f"You don't have '{item_name_input}' to {interaction_type.replace('_', ' ')}.",
+                        Colors.RED,
+                    )
+                    return False
+        elif interaction_type != "use_self_implicit":
+            self._print_color(
+                f"What do you want to {interaction_type.replace('_', ' ')}{(' on ' + target_name_input) if target_name_input else ''}?",
+                Colors.RED,
+            )
+            return False
+        if not item_to_use_name:
+            self._print_color("You need to specify an item to use or read.", Colors.RED)
+            return False
+        item_props = DEFAULT_ITEMS.get(item_to_use_name, {})
+        used_successfully = False
+        if interaction_type == "read":
+            used_successfully = self._handle_read_item(
+                item_to_use_name, item_props, item_obj_in_inventory
+            )
+        elif interaction_type == "give" and target_name_input:
+            used_successfully = self._handle_give_item(
+                item_to_use_name, item_props, target_name_input
+            )
+        elif interaction_type == "use_on" and target_name_input:
+            self._print_color(
+                f"You try to use the {item_to_use_name} on {target_name_input}, but nothing specific happens.",
+                Colors.YELLOW,
+            )
+            used_successfully = False
         else:
             effect_key = item_props.get("use_effect_player")
-            if effect_key: used_successfully = self._handle_self_use_item(item_to_use_name, item_props, effect_key)
-            else: self._print_color(f"You contemplate the {item_to_use_name}, but don't find a specific use for it right now.", Colors.YELLOW); used_successfully = False
-        if used_successfully and item_props.get("consumable", False) and item_to_use_name != "cheap vodka":
-            if self.player_character.remove_from_inventory(item_to_use_name, 1): self._print_color(f"The {item_to_use_name} is used up.", Colors.MAGENTA)
+            if effect_key:
+                used_successfully = self._handle_self_use_item(
+                    item_to_use_name, item_props, effect_key
+                )
+            else:
+                self._print_color(
+                    f"You contemplate the {item_to_use_name}, but don't find a specific use for it right now.",
+                    Colors.YELLOW,
+                )
+                used_successfully = False
+        if (
+            used_successfully
+            and item_props.get("consumable", False)
+            and item_to_use_name != "cheap vodka"
+        ):
+            if self.player_character.remove_from_inventory(item_to_use_name, 1):
+                self._print_color(f"The {item_to_use_name} is used up.", Colors.MAGENTA)
         return used_successfully

--- a/game_engine/location_module.py
+++ b/game_engine/location_module.py
@@ -1,21 +1,25 @@
 # location_module.py
 import json
-import logging # It's good practice to log errors
-from .game_config import DEFAULT_ITEMS
+import logging  # It's good practice to log errors
+
 
 def load_locations_data(data_path=None):
     from .game_config import get_data_path
+
     if data_path is None:
-        data_path = get_data_path('data/locations.json')
+        data_path = get_data_path("data/locations.json")
     """Loads location data from a JSON file."""
     try:
-        with open(data_path, 'r', encoding='utf-8') as f:
+        with open(data_path, "r", encoding="utf-8") as f:
             return json.load(f)
     except FileNotFoundError:
         logging.error(f"Error: The locations data file was not found at {data_path}")
         return {}
     except json.JSONDecodeError:
-        logging.error(f"Error: The locations data file at {data_path} is not a valid JSON.")
+        logging.error(
+            f"Error: The locations data file at {data_path} is not a valid JSON."
+        )
         return {}
+
 
 LOCATIONS_DATA = load_locations_data()

--- a/game_engine/npc_interaction_handler.py
+++ b/game_engine/npc_interaction_handler.py
@@ -1,115 +1,355 @@
 import random
 import re
-from .game_config import (Colors, CONCLUDING_PHRASES, POSITIVE_KEYWORDS, NEGATIVE_KEYWORDS,
-                         TIME_UNITS_PER_PLAYER_ACTION, HIGHLY_NOTABLE_ITEMS_FOR_MEMORY)
+from .game_config import (
+    Colors,
+    CONCLUDING_PHRASES,
+    POSITIVE_KEYWORDS,
+    NEGATIVE_KEYWORDS,
+    TIME_UNITS_PER_PLAYER_ACTION,
+    HIGHLY_NOTABLE_ITEMS_FOR_MEMORY,
+)
+
 
 class NPCInteractionHandler:
     def check_conversation_conclusion(self, text):
         for phrase_regex in CONCLUDING_PHRASES:
-            if re.search(phrase_regex, text, re.IGNORECASE): return True
+            if re.search(phrase_regex, text, re.IGNORECASE):
+                return True
         return False
 
     def _record_npc_post_interaction_memories(self, target_npc, context_str):
         """Records NPC memories of the player's unusual state and notable inventory items after an interaction."""
-        unusual_states = ["feverish", "slightly drunk", "paranoid", "agitated", "dangerously agitated", "remorseful", "haunted by dreams", "injured"]
+        unusual_states = [
+            "feverish",
+            "slightly drunk",
+            "paranoid",
+            "agitated",
+            "dangerously agitated",
+            "remorseful",
+            "haunted by dreams",
+            "injured",
+        ]
         current_player_state = self.player_character.apparent_state
         if current_player_state in unusual_states:
-            sentiment = -1 if current_player_state in ["dangerously agitated", "paranoid"] else 0
-            target_npc.add_player_memory(memory_type="observed_player_state", turn=self.game_time, content={"state": current_player_state, "context": context_str}, sentiment_impact=sentiment)
+            sentiment = (
+                -1
+                if current_player_state in ["dangerously agitated", "paranoid"]
+                else 0
+            )
+            target_npc.add_player_memory(
+                memory_type="observed_player_state",
+                turn=self.game_time,
+                content={"state": current_player_state, "context": context_str},
+                sentiment_impact=sentiment,
+            )
         for item_in_inventory in self.player_character.inventory:
             item_name = item_in_inventory.get("name")
             if item_name in HIGHLY_NOTABLE_ITEMS_FOR_MEMORY:
                 sentiment = 0
-                if item_name in ["raskolnikov's axe", "bloodied rag"]: sentiment = -1
-                elif item_name == "sonya's cypress cross" and target_npc.name != "Sonya Marmeladova":
-                    if target_npc.name == "Porfiry Petrovich" and self.player_character.name == "Rodion Raskolnikov": sentiment = -1
-                target_npc.add_player_memory(memory_type="observed_player_inventory", turn=self.game_time, content={"item_name": item_name, "context": f"player was carrying {context_str}"}, sentiment_impact=sentiment)
+                if item_name in ["raskolnikov's axe", "bloodied rag"]:
+                    sentiment = -1
+                elif (
+                    item_name == "sonya's cypress cross"
+                    and target_npc.name != "Sonya Marmeladova"
+                ):
+                    if (
+                        target_npc.name == "Porfiry Petrovich"
+                        and self.player_character.name == "Rodion Raskolnikov"
+                    ):
+                        sentiment = -1
+                target_npc.add_player_memory(
+                    memory_type="observed_player_inventory",
+                    turn=self.game_time,
+                    content={
+                        "item_name": item_name,
+                        "context": f"player was carrying {context_str}",
+                    },
+                    sentiment_impact=sentiment,
+                )
 
     def _handle_talk_to_command(self, argument):
         """Handles the 'talk to [npc]' command."""
-        if not argument: self._print_color("Who do you want to talk to?", Colors.RED); return False, False
-        if not self.npcs_in_current_location: self._print_color("There's no one here to talk to.", Colors.DIM); return False, False
-        if not self.player_character: self._print_color("Cannot talk: Player character not available.", Colors.RED); return False, False
+        if not argument:
+            self._print_color("Who do you want to talk to?", Colors.RED)
+            return False, False
+        if not self.npcs_in_current_location:
+            self._print_color("There's no one here to talk to.", Colors.DIM)
+            return False, False
+        if not self.player_character:
+            self._print_color(
+                "Cannot talk: Player character not available.", Colors.RED
+            )
+            return False, False
         target_name_input = argument.lower()
-        target_npc, ambiguous = self.command_handler._get_matching_npc(target_name_input)
+        target_npc, ambiguous = self.command_handler._get_matching_npc(
+            target_name_input
+        )
         if ambiguous:
             return False, False
         if target_npc:
             if target_npc.name == "Porfiry Petrovich":
                 solve_murders_obj = target_npc.get_objective_by_id("solve_murders")
                 if solve_murders_obj and solve_murders_obj.get("active"):
-                    current_stage_obj = target_npc.get_current_stage_for_objective("solve_murders")
-                    if current_stage_obj and current_stage_obj.get("stage_id") == "encourage_confession":
+                    current_stage_obj = target_npc.get_current_stage_for_objective(
+                        "solve_murders"
+                    )
+                    if (
+                        current_stage_obj
+                        and current_stage_obj.get("stage_id") == "encourage_confession"
+                    ):
                         new_state = "intensely persuasive"
-                        if target_npc.apparent_state != new_state: target_npc.apparent_state = new_state; self._print_color(f"({target_npc.name} seems to adopt a new demeanor, his gaze sharpening. He now appears {target_npc.apparent_state}.)", Colors.MAGENTA + Colors.DIM)
-            self.current_conversation_log = []; MAX_CONVERSATION_LOG_LINES = 20
-            self._print_color(f"\nYou approach {Colors.YELLOW}{target_npc.name}{Colors.RESET} (appears {target_npc.apparent_state}).", Colors.WHITE)
+                        if target_npc.apparent_state != new_state:
+                            target_npc.apparent_state = new_state
+                            self._print_color(
+                                f"({target_npc.name} seems to adopt a new demeanor, his gaze sharpening. He now appears {target_npc.apparent_state}.)",
+                                Colors.MAGENTA + Colors.DIM,
+                            )
+            self.current_conversation_log = []
+            MAX_CONVERSATION_LOG_LINES = 20
+            self._print_color(
+                f"\nYou approach {Colors.YELLOW}{target_npc.name}{Colors.RESET} (appears {target_npc.apparent_state}).",
+                Colors.WHITE,
+            )
             should_print_static_greeting = True
             # Removed specific condition for Raskolnikov and Razumikhin
-            if should_print_static_greeting and hasattr(target_npc, 'greeting') and target_npc.greeting:
-                 initial_greeting_text = f"{target_npc.name}: \"{target_npc.greeting}\""; self._print_color(f"{target_npc.name}: ", Colors.YELLOW, end=""); print(f"\"{target_npc.greeting}\"")
-                 self.current_conversation_log.append(initial_greeting_text)
-                 if len(self.current_conversation_log) > MAX_CONVERSATION_LOG_LINES: self.current_conversation_log.pop(0)
+            if (
+                should_print_static_greeting
+                and hasattr(target_npc, "greeting")
+                and target_npc.greeting
+            ):
+                initial_greeting_text = f'{target_npc.name}: "{target_npc.greeting}"'
+                self._print_color(f"{target_npc.name}: ", Colors.YELLOW, end="")
+                print(f'"{target_npc.greeting}"')
+                self.current_conversation_log.append(initial_greeting_text)
+                if len(self.current_conversation_log) > MAX_CONVERSATION_LOG_LINES:
+                    self.current_conversation_log.pop(0)
             conversation_active = True
             while conversation_active:
-                player_dialogue = self._input_color(f"You ({Colors.GREEN}{self.player_character.name}{Colors.RESET}): {self._prompt_arrow()}", Colors.GREEN).strip()
-                if player_dialogue.lower() in ['history', 'review', 'log']:
-                    self._print_color("\n--- Recent Conversation History ---", Colors.CYAN + Colors.BOLD)
-                    if not self.current_conversation_log: self._print_color("No history recorded yet for this conversation.", Colors.DIM)
+                player_dialogue = self._input_color(
+                    f"You ({Colors.GREEN}{self.player_character.name}{Colors.RESET}): {self._prompt_arrow()}",
+                    Colors.GREEN,
+                ).strip()
+                if player_dialogue.lower() in ["history", "review", "log"]:
+                    self._print_color(
+                        "\n--- Recent Conversation History ---",
+                        Colors.CYAN + Colors.BOLD,
+                    )
+                    if not self.current_conversation_log:
+                        self._print_color(
+                            "No history recorded yet for this conversation.", Colors.DIM
+                        )
                     else:
                         history_to_show = self.current_conversation_log[-10:]
                         for line in history_to_show:
-                            if line.startswith("You:"): self._print_color(line, Colors.GREEN)
-                            elif ":" in line: speaker, rest_of_line = line.split(":", 1); self._print_color(f"{speaker}:", Colors.YELLOW, end=""); print(rest_of_line)
-                            else: self._print_color(line, Colors.DIM)
-                    self._print_color("--- End of History ---", Colors.CYAN + Colors.BOLD); continue
-                logged_player_dialogue = f"You: {player_dialogue}"; self.current_conversation_log.append(logged_player_dialogue)
-                if len(self.current_conversation_log) > MAX_CONVERSATION_LOG_LINES: self.current_conversation_log.pop(0)
-                if self.check_conversation_conclusion(player_dialogue): self._print_color(f"You end the conversation with {Colors.YELLOW}{target_npc.name}{Colors.RESET}.", Colors.WHITE); conversation_active = False; break
-                if not player_dialogue: self._print_color("You remain silent for a moment.", Colors.DIM); pass
+                            if line.startswith("You:"):
+                                self._print_color(line, Colors.GREEN)
+                            elif ":" in line:
+                                speaker, rest_of_line = line.split(":", 1)
+                                self._print_color(f"{speaker}:", Colors.YELLOW, end="")
+                                print(rest_of_line)
+                            else:
+                                self._print_color(line, Colors.DIM)
+                    self._print_color(
+                        "--- End of History ---", Colors.CYAN + Colors.BOLD
+                    )
+                    continue
+                logged_player_dialogue = f"You: {player_dialogue}"
+                self.current_conversation_log.append(logged_player_dialogue)
+                if len(self.current_conversation_log) > MAX_CONVERSATION_LOG_LINES:
+                    self.current_conversation_log.pop(0)
+                if self.check_conversation_conclusion(player_dialogue):
+                    self._print_color(
+                        f"You end the conversation with {Colors.YELLOW}{target_npc.name}{Colors.RESET}.",
+                        Colors.WHITE,
+                    )
+                    conversation_active = False
+                    break
+                if not player_dialogue:
+                    self._print_color("You remain silent for a moment.", Colors.DIM)
+                    pass
                 used_ai_dialogue = False
                 if self.gemini_api.model:
-                    ai_response = self.gemini_api.get_npc_dialogue(target_npc, self.player_character, player_dialogue, self.current_location_name, self.get_current_time_period(), self.get_relationship_text(target_npc.relationship_with_player), target_npc.get_player_memory_summary(self.game_time), self.player_character.apparent_state, self.player_character.get_notable_carried_items_summary(), self._get_recent_events_summary(), self._get_objectives_summary(target_npc), self._get_objectives_summary(self.player_character))
+                    ai_response = self.gemini_api.get_npc_dialogue(
+                        target_npc,
+                        self.player_character,
+                        player_dialogue,
+                        self.current_location_name,
+                        self.get_current_time_period(),
+                        self.get_relationship_text(target_npc.relationship_with_player),
+                        target_npc.get_player_memory_summary(self.game_time),
+                        self.player_character.apparent_state,
+                        self.player_character.get_notable_carried_items_summary(),
+                        self._get_recent_events_summary(),
+                        self._get_objectives_summary(target_npc),
+                        self._get_objectives_summary(self.player_character),
+                    )
                     used_ai_dialogue = True
-                else: ai_response = random.choice(["Yes?", "Hmm.", "What is it?", "I am busy.", f"{target_npc.greeting if hasattr(target_npc, 'greeting') else '...'}"]); self._print_color(f"{Colors.DIM}(Using placeholder dialogue){Colors.RESET}", Colors.DIM)
+                else:
+                    ai_response = random.choice(
+                        [
+                            "Yes?",
+                            "Hmm.",
+                            "What is it?",
+                            "I am busy.",
+                            f"{target_npc.greeting if hasattr(target_npc, 'greeting') else '...'}",
+                        ]
+                    )
+                    self._print_color(
+                        f"{Colors.DIM}(Using placeholder dialogue){Colors.RESET}",
+                        Colors.DIM,
+                    )
                 ai_response = self._apply_verbosity(ai_response)
-                target_npc.update_relationship(player_dialogue, POSITIVE_KEYWORDS, NEGATIVE_KEYWORDS, self.game_time); self._print_color(f"{target_npc.name}: ", Colors.YELLOW, end=""); print(f"\"{ai_response}\"")
-                logged_ai_response = f"{target_npc.name}: \"{ai_response}\""; self.current_conversation_log.append(logged_ai_response)
-                if used_ai_dialogue and not (isinstance(ai_response, str) and ai_response.startswith("(OOC:")):
+                target_npc.update_relationship(
+                    player_dialogue,
+                    POSITIVE_KEYWORDS,
+                    NEGATIVE_KEYWORDS,
+                    self.game_time,
+                )
+                self._print_color(f"{target_npc.name}: ", Colors.YELLOW, end="")
+                print(f'"{ai_response}"')
+                logged_ai_response = f'{target_npc.name}: "{ai_response}"'
+                self.current_conversation_log.append(logged_ai_response)
+                if used_ai_dialogue and not (
+                    isinstance(ai_response, str) and ai_response.startswith("(OOC:")
+                ):
                     self._remember_ai_output(ai_response, "npc_dialogue")
-                if len(self.current_conversation_log) > MAX_CONVERSATION_LOG_LINES: self.current_conversation_log.pop(0)
-                self.last_significant_event_summary = f"spoke with {target_npc.name} who said: \"{ai_response[:50]}...\""
-                if self.check_conversation_conclusion(ai_response): self._print_color(f"\nThe conversation with {Colors.YELLOW}{target_npc.name}{Colors.RESET} seems to have concluded.", Colors.MAGENTA); conversation_active = False
+                if len(self.current_conversation_log) > MAX_CONVERSATION_LOG_LINES:
+                    self.current_conversation_log.pop(0)
+                self.last_significant_event_summary = (
+                    f'spoke with {target_npc.name} who said: "{ai_response[:50]}..."'
+                )
+                if self.check_conversation_conclusion(ai_response):
+                    self._print_color(
+                        f"\nThe conversation with {Colors.YELLOW}{target_npc.name}{Colors.RESET} seems to have concluded.",
+                        Colors.MAGENTA,
+                    )
+                    conversation_active = False
                 self.world_manager.advance_time(TIME_UNITS_PER_PLAYER_ACTION)
-                if self.event_manager.check_and_trigger_events(): self.last_significant_event_summary = "an event occurred during conversation."
-            self._record_npc_post_interaction_memories(target_npc, "during conversation")
-            if self.player_character.name == "Rodion Raskolnikov" and target_npc and target_npc.name == "Porfiry Petrovich":
-                self.player_notoriety_level = min(3, max(0, self.player_notoriety_level + 0.15)); self._print_color("(Your conversation with Porfiry seems to have drawn some attention...)", Colors.YELLOW + Colors.DIM)
+                if self.event_manager.check_and_trigger_events():
+                    self.last_significant_event_summary = (
+                        "an event occurred during conversation."
+                    )
+            self._record_npc_post_interaction_memories(
+                target_npc, "during conversation"
+            )
+            if (
+                self.player_character.name == "Rodion Raskolnikov"
+                and target_npc
+                and target_npc.name == "Porfiry Petrovich"
+            ):
+                self.player_notoriety_level = min(
+                    3, max(0, self.player_notoriety_level + 0.15)
+                )
+                self._print_color(
+                    "(Your conversation with Porfiry seems to have drawn some attention...)",
+                    Colors.YELLOW + Colors.DIM,
+                )
             return True, True
-        else: self._print_color(f"You don't see anyone named '{target_name_input}' here.", Colors.RED); return False, False
+        else:
+            self._print_color(
+                f"You don't see anyone named '{target_name_input}' here.", Colors.RED
+            )
+            return False, False
 
     def _handle_persuade_command(self, argument):
-        if not argument or not isinstance(argument, tuple) or len(argument) != 2: self._print_color("How do you want to persuade them? Use: persuade [person] that/to [your argument]", Colors.RED); return False, False
+        if not argument or not isinstance(argument, tuple) or len(argument) != 2:
+            self._print_color(
+                "How do you want to persuade them? Use: persuade [person] that/to [your argument]",
+                Colors.RED,
+            )
+            return False, False
         target_npc_name, statement_text = argument
-        if not self.player_character: self._print_color("Cannot persuade: Player character not available.", Colors.RED); return False, False
-        target_npc = next((npc for npc in self.npcs_in_current_location if npc.name.lower().startswith(target_npc_name.lower())), None)
-        if not target_npc: self._print_color(f"You don't see anyone named '{target_npc_name}' here to persuade.", Colors.RED); return False, False
-        self._print_color(f"\nYou attempt to persuade {Colors.YELLOW}{target_npc.name}{Colors.RESET} that \"{statement_text}\"...", Colors.WHITE)
-        difficulty = 2; success = self.player_character.check_skill("Persuasion", difficulty)
-        persuasion_skill_check_result_text = "SUCCESS due to their skillful argument" if success else "FAILURE despite their efforts"
+        if not self.player_character:
+            self._print_color(
+                "Cannot persuade: Player character not available.", Colors.RED
+            )
+            return False, False
+        target_npc = next(
+            (
+                npc
+                for npc in self.npcs_in_current_location
+                if npc.name.lower().startswith(target_npc_name.lower())
+            ),
+            None,
+        )
+        if not target_npc:
+            self._print_color(
+                f"You don't see anyone named '{target_npc_name}' here to persuade.",
+                Colors.RED,
+            )
+            return False, False
+        self._print_color(
+            f'\nYou attempt to persuade {Colors.YELLOW}{target_npc.name}{Colors.RESET} that "{statement_text}"...',
+            Colors.WHITE,
+        )
+        difficulty = 2
+        success = self.player_character.check_skill("Persuasion", difficulty)
+        persuasion_skill_check_result_text = (
+            "SUCCESS due to their skillful argument"
+            if success
+            else "FAILURE despite their efforts"
+        )
         used_ai_dialogue = False
         if self.gemini_api.model:
-            ai_response = self.gemini_api.get_npc_dialogue_persuasion_attempt(target_npc, self.player_character, player_persuasive_statement=statement_text, current_location_name=self.current_location_name, current_time_period=self.get_current_time_period(), relationship_status_text=self.get_relationship_text(target_npc.relationship_with_player), npc_memory_summary=target_npc.get_player_memory_summary(self.game_time), player_apparent_state=self.player_character.apparent_state, player_notable_items_summary=self.player_character.get_notable_carried_items_summary(), recent_game_events_summary=self._get_recent_events_summary(), npc_objectives_summary=self._get_objectives_summary(target_npc), player_objectives_summary=self._get_objectives_summary(self.player_character), persuasion_skill_check_result_text=persuasion_skill_check_result_text)
+            ai_response = self.gemini_api.get_npc_dialogue_persuasion_attempt(
+                target_npc,
+                self.player_character,
+                player_persuasive_statement=statement_text,
+                current_location_name=self.current_location_name,
+                current_time_period=self.get_current_time_period(),
+                relationship_status_text=self.get_relationship_text(
+                    target_npc.relationship_with_player
+                ),
+                npc_memory_summary=target_npc.get_player_memory_summary(self.game_time),
+                player_apparent_state=self.player_character.apparent_state,
+                player_notable_items_summary=self.player_character.get_notable_carried_items_summary(),
+                recent_game_events_summary=self._get_recent_events_summary(),
+                npc_objectives_summary=self._get_objectives_summary(target_npc),
+                player_objectives_summary=self._get_objectives_summary(
+                    self.player_character
+                ),
+                persuasion_skill_check_result_text=persuasion_skill_check_result_text,
+            )
             used_ai_dialogue = True
-        else: ai_response = f"Hmm, '{statement_text}', you say? That's... something to consider. (Skill: {persuasion_skill_check_result_text})"; self._print_color(f"{Colors.DIM}(Using placeholder dialogue for persuasion){Colors.RESET}", Colors.DIM)
+        else:
+            ai_response = f"Hmm, '{statement_text}', you say? That's... something to consider. (Skill: {persuasion_skill_check_result_text})"
+            self._print_color(
+                f"{Colors.DIM}(Using placeholder dialogue for persuasion){Colors.RESET}",
+                Colors.DIM,
+            )
         ai_response = self._apply_verbosity(ai_response)
-        self._print_color(f"{target_npc.name}: ", Colors.YELLOW, end=""); print(f"\"{ai_response}\"")
-        if used_ai_dialogue and not (isinstance(ai_response, str) and ai_response.startswith("(OOC:")):
+        self._print_color(f"{target_npc.name}: ", Colors.YELLOW, end="")
+        print(f'"{ai_response}"')
+        if used_ai_dialogue and not (
+            isinstance(ai_response, str) and ai_response.startswith("(OOC:")
+        ):
             self._remember_ai_output(ai_response, "persuasion_dialogue")
         sentiment_impact_base = 0
-        if success: self._print_color(f"Your argument seems to have had an effect!", Colors.GREEN); sentiment_impact_base = 1; target_npc.relationship_with_player += 1
-        else: self._print_color(f"Your words don't seem to convince {target_npc.name}.", Colors.RED); sentiment_impact_base = -1; target_npc.relationship_with_player -= 1
-        target_npc.add_player_memory(memory_type="persuasion_attempt", turn=self.game_time, content={"statement": statement_text[:100], "outcome": "success" if success else "failure", "npc_response_snippet": ai_response[:70]}, sentiment_impact=sentiment_impact_base)
+        if success:
+            self._print_color(
+                "Your argument seems to have had an effect!", Colors.GREEN
+            )
+            sentiment_impact_base = 1
+            target_npc.relationship_with_player += 1
+        else:
+            self._print_color(
+                f"Your words don't seem to convince {target_npc.name}.", Colors.RED
+            )
+            sentiment_impact_base = -1
+            target_npc.relationship_with_player -= 1
+        target_npc.add_player_memory(
+            memory_type="persuasion_attempt",
+            turn=self.game_time,
+            content={
+                "statement": statement_text[:100],
+                "outcome": "success" if success else "failure",
+                "npc_response_snippet": ai_response[:70],
+            },
+            sentiment_impact=sentiment_impact_base,
+        )
         self.last_significant_event_summary = f"attempted to persuade {target_npc.name} regarding '{statement_text[:30]}...'."
-        self._record_npc_post_interaction_memories(target_npc, "during persuasion attempt")
-        self.world_manager.advance_time(TIME_UNITS_PER_PLAYER_ACTION); return True, True
+        self._record_npc_post_interaction_memories(
+            target_npc, "during persuasion attempt"
+        )
+        self.world_manager.advance_time(TIME_UNITS_PER_PLAYER_ACTION)
+        return True, True

--- a/game_engine/world_manager.py
+++ b/game_engine/world_manager.py
@@ -1,210 +1,404 @@
 import random
 import copy
-import re
-import os
-from .game_config import (Colors, TIME_UNITS_PER_PLAYER_ACTION, MAX_TIME_UNITS_PER_DAY, TIME_PERIODS,
-                         TIME_UNITS_FOR_NPC_SCHEDULE_UPDATE, NPC_MOVE_CHANCE,
-                         DEFAULT_ITEMS, AMBIENT_RUMOR_CHANCE_PUBLIC_PLACE,
-                         STATIC_DREAM_SEQUENCES, STATIC_RUMORS,
-                         DREAM_CHANCE_TROUBLED_STATE, DREAM_CHANCE_NORMAL_STATE,
-                         NPC_INTERACTION_CHANCE, TIME_UNITS_FOR_NPC_INTERACTION_CHANCE,
-                         HIGHLY_NOTABLE_ITEMS_FOR_MEMORY, SAVE_GAME_FILE, DEBUG_LOGS)
+from .game_config import (
+    Colors,
+    TIME_UNITS_PER_PLAYER_ACTION,
+    MAX_TIME_UNITS_PER_DAY,
+    TIME_PERIODS,
+    TIME_UNITS_FOR_NPC_SCHEDULE_UPDATE,
+    NPC_MOVE_CHANCE,
+    DEFAULT_ITEMS,
+    AMBIENT_RUMOR_CHANCE_PUBLIC_PLACE,
+    STATIC_DREAM_SEQUENCES,
+    STATIC_RUMORS,
+    DREAM_CHANCE_TROUBLED_STATE,
+    DREAM_CHANCE_NORMAL_STATE,
+    NPC_INTERACTION_CHANCE,
+    TIME_UNITS_FOR_NPC_INTERACTION_CHANCE,
+    HIGHLY_NOTABLE_ITEMS_FOR_MEMORY,
+    DEBUG_LOGS,
+)
 from .location_module import LOCATIONS_DATA
 from .character_module import Character, CHARACTERS_DATA
+
 
 class WorldManager:
     def __init__(self, game_state):
         self.game_state = game_state
+
     def get_current_time_period(self):
         time_in_day = self.game_state.game_time % MAX_TIME_UNITS_PER_DAY
         for period, (start, end) in TIME_PERIODS.items():
             if start <= time_in_day <= end:
                 return period
-        self.game_state._print_color(f"Warning: Could not determine time period for game_time {self.game_state.game_time % MAX_TIME_UNITS_PER_DAY}", Colors.RED)
+        self.game_state._print_color(
+            f"Warning: Could not determine time period for game_time {self.game_state.game_time % MAX_TIME_UNITS_PER_DAY}",
+            Colors.RED,
+        )
         return "Unknown"
 
     def advance_time(self, units=TIME_UNITS_PER_PLAYER_ACTION):
         previous_day = self.game_state.current_day
         self.game_state.game_time += units
-        new_day_begins = (self.game_state.game_time // MAX_TIME_UNITS_PER_DAY) + 1 > previous_day
+        new_day_begins = (
+            self.game_state.game_time // MAX_TIME_UNITS_PER_DAY
+        ) + 1 > previous_day
 
         if new_day_begins:
-            self.game_state.current_day = (self.game_state.game_time // MAX_TIME_UNITS_PER_DAY) + 1
-            self.game_state._print_color(f"\n{Colors.DIM}--- A new day dawns. It is Day {self.game_state.current_day}. ---{Colors.RESET}", Colors.CYAN + Colors.BOLD)
-            self.game_state.key_events_occurred.append(f"Day {self.game_state.current_day} began.")
-            self.game_state.last_significant_event_summary = f"a new day (Day {self.game_state.current_day}) began."
-            if self.game_state.player_character and self.game_state.player_character.name == "Rodion Raskolnikov":
-                troubled_states = ["feverish", "dangerously agitated", "remorseful", "paranoid", "haunted by dreams", "agitated"]
-                dream_chance = DREAM_CHANCE_TROUBLED_STATE if self.game_state.player_character.apparent_state in troubled_states else DREAM_CHANCE_NORMAL_STATE
+            self.game_state.current_day = (
+                self.game_state.game_time // MAX_TIME_UNITS_PER_DAY
+            ) + 1
+            self.game_state._print_color(
+                f"\n{Colors.DIM}--- A new day dawns. It is Day {self.game_state.current_day}. ---{Colors.RESET}",
+                Colors.CYAN + Colors.BOLD,
+            )
+            self.game_state.key_events_occurred.append(
+                f"Day {self.game_state.current_day} began."
+            )
+            self.game_state.last_significant_event_summary = (
+                f"a new day (Day {self.game_state.current_day}) began."
+            )
+            if (
+                self.game_state.player_character
+                and self.game_state.player_character.name == "Rodion Raskolnikov"
+            ):
+                troubled_states = [
+                    "feverish",
+                    "dangerously agitated",
+                    "remorseful",
+                    "paranoid",
+                    "haunted by dreams",
+                    "agitated",
+                ]
+                dream_chance = (
+                    DREAM_CHANCE_TROUBLED_STATE
+                    if self.game_state.player_character.apparent_state
+                    in troubled_states
+                    else DREAM_CHANCE_NORMAL_STATE
+                )
                 if random.random() < dream_chance:
-                    self.game_state._print_color(f"\n{Colors.MAGENTA}As morning struggles to break, unsettling images from the night still cling to your mind...{Colors.RESET}", Colors.MAGENTA)
+                    self.game_state._print_color(
+                        f"\n{Colors.MAGENTA}As morning struggles to break, unsettling images from the night still cling to your mind...{Colors.RESET}",
+                        Colors.MAGENTA,
+                    )
                     relationships_summary = "Relationships are complex."
                     if self.game_state.all_character_objects.get("Sonya Marmeladova"):
-                        sonya_npc = self.game_state.all_character_objects["Sonya Marmeladova"]
+                        sonya_npc = self.game_state.all_character_objects[
+                            "Sonya Marmeladova"
+                        ]
                         relationships_summary = f"Sonya: {self.game_state.get_relationship_text(sonya_npc.relationship_with_player if hasattr(sonya_npc, 'relationship_with_player') else 0)}"
 
                     dream_text = None
-                    if not self.game_state.low_ai_data_mode and self.game_state.gemini_api.model:
+                    if (
+                        not self.game_state.low_ai_data_mode
+                        and self.game_state.gemini_api.model
+                    ):
                         dream_text = self.game_state.gemini_api.get_dream_sequence(
-                            self.game_state.player_character, self.game_state._get_recent_events_summary(),
-                            self.game_state._get_objectives_summary(self.game_state.player_character), relationships_summary)
+                            self.game_state.player_character,
+                            self.game_state._get_recent_events_summary(),
+                            self.game_state._get_objectives_summary(
+                                self.game_state.player_character
+                            ),
+                            relationships_summary,
+                        )
 
-                    if dream_text is None or (isinstance(dream_text, str) and dream_text.startswith("(OOC:")) or self.game_state.low_ai_data_mode:
+                    if (
+                        dream_text is None
+                        or (
+                            isinstance(dream_text, str)
+                            and dream_text.startswith("(OOC:")
+                        )
+                        or self.game_state.low_ai_data_mode
+                    ):
                         if STATIC_DREAM_SEQUENCES:
                             dream_text = random.choice(STATIC_DREAM_SEQUENCES)
                         else:
-                            dream_text = "You had a restless night filled with strange, fleeting images." # Ultimate fallback
+                            dream_text = "You had a restless night filled with strange, fleeting images."  # Ultimate fallback
 
-                    self.game_state._print_color(f"{Colors.CYAN}Dream: \"{dream_text}\"{Colors.RESET}", Colors.CYAN)
-                    self.game_state.player_character.add_journal_entry("Dream", dream_text, self.game_state._get_current_game_time_period_str())
+                    self.game_state._print_color(
+                        f'{Colors.CYAN}Dream: "{dream_text}"{Colors.RESET}', Colors.CYAN
+                    )
+                    self.game_state.player_character.add_journal_entry(
+                        "Dream",
+                        dream_text,
+                        self.game_state._get_current_game_time_period_str(),
+                    )
                     self.game_state.player_character.add_player_memory(
                         memory_type="dream",
                         turn=self.game_state.game_time,
-                        content={"summary": f"Had a disturbing dream: {(dream_text if dream_text else '')[:50]}..."},
-                        sentiment_impact=-1
+                        content={
+                            "summary": f"Had a disturbing dream: {(dream_text if dream_text else '')[:50]}..."
+                        },
+                        sentiment_impact=-1,
                     )
-                    if "terror" in dream_text.lower() or "blood" in dream_text.lower() or "axe" in dream_text.lower():
-                        self.game_state.player_character.apparent_state = random.choice(["paranoid", "agitated", "haunted by dreams"])
-                    elif "sonya" in dream_text.lower() or "hope" in dream_text.lower() or "cross" in dream_text.lower():
-                        self.game_state.player_character.apparent_state = random.choice(["thoughtful", "remorseful", "hopeful"])
+                    if (
+                        "terror" in dream_text.lower()
+                        or "blood" in dream_text.lower()
+                        or "axe" in dream_text.lower()
+                    ):
+                        self.game_state.player_character.apparent_state = random.choice(
+                            ["paranoid", "agitated", "haunted by dreams"]
+                        )
+                    elif (
+                        "sonya" in dream_text.lower()
+                        or "hope" in dream_text.lower()
+                        or "cross" in dream_text.lower()
+                    ):
+                        self.game_state.player_character.apparent_state = random.choice(
+                            ["thoughtful", "remorseful", "hopeful"]
+                        )
                     else:
-                        self.game_state.player_character.apparent_state = "haunted by dreams"
-                    self.game_state._print_color(f"(The dream leaves you feeling {self.game_state.player_character.apparent_state}.)", Colors.YELLOW)
-                    self.game_state.last_significant_event_summary = "awoke troubled by a vivid dream."
+                        self.game_state.player_character.apparent_state = (
+                            "haunted by dreams"
+                        )
+                    self.game_state._print_color(
+                        f"(The dream leaves you feeling {self.game_state.player_character.apparent_state}.)",
+                        Colors.YELLOW,
+                    )
+                    self.game_state.last_significant_event_summary = (
+                        "awoke troubled by a vivid dream."
+                    )
                     self.game_state._print_color("", Colors.RESET)
 
         self.game_state.time_since_last_npc_interaction += units
         self.game_state.time_since_last_npc_schedule_update += units
-        if self.game_state.time_since_last_npc_schedule_update >= TIME_UNITS_FOR_NPC_SCHEDULE_UPDATE:
+        if (
+            self.game_state.time_since_last_npc_schedule_update
+            >= TIME_UNITS_FOR_NPC_SCHEDULE_UPDATE
+        ):
             self.update_npc_locations_by_schedule()
             self.game_state.time_since_last_npc_schedule_update = 0
 
     def initialize_dynamic_location_items(self):
         self.game_state.dynamic_location_items = {}
         for loc_name, loc_data in LOCATIONS_DATA.items():
-            self.game_state.dynamic_location_items[loc_name] = copy.deepcopy(loc_data.get("items_present", []))
+            self.game_state.dynamic_location_items[loc_name] = copy.deepcopy(
+                loc_data.get("items_present", [])
+            )
         for item_name, item_props in DEFAULT_ITEMS.items():
             if "hidden_in_location" in item_props:
                 hidden_loc = item_props["hidden_in_location"]
                 if hidden_loc in self.game_state.dynamic_location_items:
                     location_items = self.game_state.dynamic_location_items[hidden_loc]
-                    if not any(loc_item["name"] == item_name for loc_item in location_items):
-                        qty_to_add = item_props.get("quantity", 1) if item_props.get("stackable", False) or item_props.get("value") is not None else 1
-                        location_items.append({"name": item_name, "quantity": qty_to_add})
+                    if not any(
+                        loc_item["name"] == item_name for loc_item in location_items
+                    ):
+                        qty_to_add = (
+                            item_props.get("quantity", 1)
+                            if item_props.get("stackable", False)
+                            or item_props.get("value") is not None
+                            else 1
+                        )
+                        location_items.append(
+                            {"name": item_name, "quantity": qty_to_add}
+                        )
 
     def load_all_characters(self, from_save=False):
-        if from_save: return
+        if from_save:
+            return
         self.game_state.all_character_objects = {}
         for name, data in CHARACTERS_DATA.items():
             static_data_copy = copy.deepcopy(data)
             if "accessible_locations" not in static_data_copy:
                 static_data_copy["accessible_locations"] = []
-            if static_data_copy.get("default_location") not in static_data_copy["accessible_locations"]:
-                static_data_copy["accessible_locations"].append(static_data_copy["default_location"])
+            if (
+                static_data_copy.get("default_location")
+                not in static_data_copy["accessible_locations"]
+            ):
+                static_data_copy["accessible_locations"].append(
+                    static_data_copy["default_location"]
+                )
             self.game_state.all_character_objects[name] = Character(
-                name, static_data_copy.get("persona","A resident of St. Petersburg."),
+                name,
+                static_data_copy.get("persona", "A resident of St. Petersburg."),
                 static_data_copy.get("greeting", "Yes?"),
                 static_data_copy.get("default_location", "Haymarket Square"),
                 static_data_copy.get("accessible_locations", ["Haymarket Square"]),
                 static_data_copy.get("objectives", []),
                 static_data_copy.get("inventory_items", []),
-                static_data_copy.get("schedule", {}))
+                static_data_copy.get("schedule", {}),
+            )
         self.initialize_dynamic_location_items()
 
     def select_player_character(self, non_interactive=False):
-        self.game_state._print_color("\n--- Choose Your Character ---", Colors.CYAN + Colors.BOLD)
-        playable_character_names = [name for name, data in CHARACTERS_DATA.items() if not data.get("non_playable", False)]
+        self.game_state._print_color(
+            "\n--- Choose Your Character ---", Colors.CYAN + Colors.BOLD
+        )
+        playable_character_names = [
+            name
+            for name, data in CHARACTERS_DATA.items()
+            if not data.get("non_playable", False)
+        ]
         if not playable_character_names:
-            self.game_state._print_color("Error: No playable characters defined!", Colors.RED)
+            self.game_state._print_color(
+                "Error: No playable characters defined!", Colors.RED
+            )
             return False
 
         if non_interactive:
             chosen_name = playable_character_names[0]
-            self.game_state._print_color(f"Automatically selecting character: {chosen_name}", Colors.YELLOW)
+            self.game_state._print_color(
+                f"Automatically selecting character: {chosen_name}", Colors.YELLOW
+            )
         else:
             for i, name in enumerate(playable_character_names):
                 print(f"{Colors.MAGENTA}{i + 1}. {Colors.WHITE}{name}{Colors.RESET}")
             while True:
                 try:
-                    choice_str = self.game_state._input_color("Enter the number of your choice: ", Colors.MAGENTA)
-                    if not choice_str: continue
+                    choice_str = self.game_state._input_color(
+                        "Enter the number of your choice: ", Colors.MAGENTA
+                    )
+                    if not choice_str:
+                        continue
                     choice = int(choice_str) - 1
                     if 0 <= choice < len(playable_character_names):
                         chosen_name = playable_character_names[choice]
                         break
                     else:
-                        self.game_state._print_color("Invalid choice. Please enter a number from the list.", Colors.RED)
+                        self.game_state._print_color(
+                            "Invalid choice. Please enter a number from the list.",
+                            Colors.RED,
+                        )
                 except ValueError:
-                    self.game_state._print_color("Invalid input. Please enter a number.", Colors.RED)
+                    self.game_state._print_color(
+                        "Invalid input. Please enter a number.", Colors.RED
+                    )
 
         if chosen_name in self.game_state.all_character_objects:
-            self.game_state.player_character = self.game_state.all_character_objects[chosen_name]
+            self.game_state.player_character = self.game_state.all_character_objects[
+                chosen_name
+            ]
             self.game_state.player_character.is_player = True
-            self.game_state.current_location_name = self.game_state.player_character.default_location
-            self.game_state.player_character.current_location = self.game_state.current_location_name
+            self.game_state.current_location_name = (
+                self.game_state.player_character.default_location
+            )
+            self.game_state.player_character.current_location = (
+                self.game_state.current_location_name
+            )
             self.game_state.current_location_description_shown_this_visit = False
-            self.game_state._print_color(f"\nYou are playing as {Colors.GREEN}{self.game_state.player_character.name}{Colors.RESET}.", Colors.WHITE)
-            self.game_state._print_color(f"You start in: {Colors.CYAN}{self.game_state.current_location_name}{Colors.RESET}", Colors.WHITE)
-            self.game_state._print_color(f"Your current state appears: {Colors.YELLOW}{self.game_state.player_character.apparent_state}{Colors.RESET}.", Colors.WHITE)
+            self.game_state._print_color(
+                f"\nYou are playing as {Colors.GREEN}{self.game_state.player_character.name}{Colors.RESET}.",
+                Colors.WHITE,
+            )
+            self.game_state._print_color(
+                f"You start in: {Colors.CYAN}{self.game_state.current_location_name}{Colors.RESET}",
+                Colors.WHITE,
+            )
+            self.game_state._print_color(
+                f"Your current state appears: {Colors.YELLOW}{self.game_state.player_character.apparent_state}{Colors.RESET}.",
+                Colors.WHITE,
+            )
             return True
         else:
-            self.game_state._print_color(f"Error: Character '{chosen_name}' not found in loaded objects.", Colors.RED)
+            self.game_state._print_color(
+                f"Error: Character '{chosen_name}' not found in loaded objects.",
+                Colors.RED,
+            )
             return False
 
     def update_npc_locations_by_schedule(self):
         current_time_period = self.get_current_time_period()
-        if current_time_period == "Unknown": return
+        if current_time_period == "Unknown":
+            return
         moved_npcs_info = []
         for npc_name, npc_obj in self.game_state.all_character_objects.items():
-            if npc_obj.is_player or not npc_obj.schedule: continue
+            if npc_obj.is_player or not npc_obj.schedule:
+                continue
             scheduled_location = npc_obj.schedule.get(current_time_period)
             if scheduled_location and scheduled_location != npc_obj.current_location:
-                if scheduled_location in LOCATIONS_DATA and scheduled_location in npc_obj.accessible_locations:
+                if (
+                    scheduled_location in LOCATIONS_DATA
+                    and scheduled_location in npc_obj.accessible_locations
+                ):
                     if random.random() < NPC_MOVE_CHANCE:
                         old_location = npc_obj.current_location
                         npc_obj.current_location = scheduled_location
-                        if old_location == self.game_state.current_location_name and scheduled_location != self.game_state.current_location_name:
+                        if (
+                            old_location == self.game_state.current_location_name
+                            and scheduled_location
+                            != self.game_state.current_location_name
+                        ):
                             moved_npcs_info.append(f"{npc_obj.name} has left.")
-                        elif scheduled_location == self.game_state.current_location_name and old_location != self.game_state.current_location_name:
-                             moved_npcs_info.append(f"{npc_obj.name} has arrived.")
+                        elif (
+                            scheduled_location == self.game_state.current_location_name
+                            and old_location != self.game_state.current_location_name
+                        ):
+                            moved_npcs_info.append(f"{npc_obj.name} has arrived.")
         if moved_npcs_info:
             self.game_state._print_color("\n(As time passes...)", Colors.MAGENTA)
-            for info in moved_npcs_info: self.game_state._print_color(info, Colors.MAGENTA)
+            for info in moved_npcs_info:
+                self.game_state._print_color(info, Colors.MAGENTA)
             self.game_state._print_color("", Colors.RESET)
         self.update_npcs_in_current_location()
 
     def update_current_location_details(self, from_explicit_look_cmd=False):
         if not self.game_state.current_location_name:
             self.game_state._print_color("Error: Current location not set.", Colors.RED)
-            if self.game_state.player_character and self.game_state.player_character.current_location: self.game_state.current_location_name = self.game_state.player_character.current_location
-            else: self.game_state._print_color("Critical Error: Cannot determine current location.", Colors.RED); return
+            if (
+                self.game_state.player_character
+                and self.game_state.player_character.current_location
+            ):
+                self.game_state.current_location_name = (
+                    self.game_state.player_character.current_location
+                )
+            else:
+                self.game_state._print_color(
+                    "Critical Error: Cannot determine current location.", Colors.RED
+                )
+                return
         location_data = LOCATIONS_DATA.get(self.game_state.current_location_name)
-        if not location_data: self.game_state._print_color(f"Error: Unknown location: {self.game_state.current_location_name}. Data missing.", Colors.RED); return
+        if not location_data:
+            self.game_state._print_color(
+                f"Error: Unknown location: {self.game_state.current_location_name}. Data missing.",
+                Colors.RED,
+            )
+            return
         time_str = f"({self.game_state._get_current_game_time_period_str()})"
-        self.game_state._print_color(f"\n--- {self.game_state.current_location_name} {time_str} ---", Colors.CYAN + Colors.BOLD)
-        if from_explicit_look_cmd or not self.game_state.current_location_description_shown_this_visit:
-            is_first_visit = self.game_state.current_location_name not in self.game_state.visited_locations
-            recently_visited = getattr(self, 'last_visited_location', None) == self.game_state.current_location_name
+        self.game_state._print_color(
+            f"\n--- {self.game_state.current_location_name} {time_str} ---",
+            Colors.CYAN + Colors.BOLD,
+        )
+        if (
+            from_explicit_look_cmd
+            or not self.game_state.current_location_description_shown_this_visit
+        ):
+            is_first_visit = (
+                self.game_state.current_location_name
+                not in self.game_state.visited_locations
+            )
+            recently_visited = (
+                getattr(self, "last_visited_location", None)
+                == self.game_state.current_location_name
+            )
             base_description = location_data.get("description", "A non-descript place.")
-            time_effect_desc = location_data.get("time_effects", {}).get(self.get_current_time_period(), "")
+            time_effect_desc = location_data.get("time_effects", {}).get(
+                self.get_current_time_period(), ""
+            )
             if is_first_visit or from_explicit_look_cmd:
                 print(base_description + " " + time_effect_desc)
-                self.game_state.visited_locations.add(self.game_state.current_location_name)
+                self.game_state.visited_locations.add(
+                    self.game_state.current_location_name
+                )
             elif recently_visited:
                 # Extremely brief, just the location name and time basically
                 self.game_state._print_color("(You have returned here.)", Colors.DIM)
             else:
-                brief_desc = base_description.split('.')[0] + "."
+                brief_desc = base_description.split(".")[0] + "."
                 print(brief_desc + " " + time_effect_desc)
             self.game_state.current_location_description_shown_this_visit = True
         self.update_npcs_in_current_location()
 
     def update_npcs_in_current_location(self):
         self.game_state.npcs_in_current_location = []
-        if not self.game_state.current_location_name: return
+        if not self.game_state.current_location_name:
+            return
         for char_name, char_obj in self.game_state.all_character_objects.items():
-            if not char_obj.is_player and char_obj.current_location == self.game_state.current_location_name:
-                if char_obj not in self.game_state.npcs_in_current_location: self.game_state.npcs_in_current_location.append(char_obj)
+            if (
+                not char_obj.is_player
+                and char_obj.current_location == self.game_state.current_location_name
+            ):
+                if char_obj not in self.game_state.npcs_in_current_location:
+                    self.game_state.npcs_in_current_location.append(char_obj)
 
     def _validate_item_data(self):
         missing_items = set()
@@ -212,114 +406,254 @@ class WorldManager:
             for item_info in location_data.get("items_present", []):
                 item_name = item_info.get("name")
                 if item_name and item_name not in DEFAULT_ITEMS:
-                    missing_items.add(f"Location '{location_name}' references unknown item '{item_name}'.")
+                    missing_items.add(
+                        f"Location '{location_name}' references unknown item '{item_name}'."
+                    )
 
         for character_name, character_data in CHARACTERS_DATA.items():
             for item_info in character_data.get("inventory_items", []):
                 item_name = item_info.get("name")
                 if item_name and item_name not in DEFAULT_ITEMS:
-                    missing_items.add(f"Character '{character_name}' references unknown item '{item_name}'.")
+                    missing_items.add(
+                        f"Character '{character_name}' references unknown item '{item_name}'."
+                    )
 
         for item_name in HIGHLY_NOTABLE_ITEMS_FOR_MEMORY:
             if item_name not in DEFAULT_ITEMS:
-                missing_items.add(f"Notable items list references unknown item '{item_name}'.")
+                missing_items.add(
+                    f"Notable items list references unknown item '{item_name}'."
+                )
 
         for item_name, item_data in DEFAULT_ITEMS.items():
             hidden_location = item_data.get("hidden_in_location")
             if hidden_location and hidden_location not in LOCATIONS_DATA:
-                missing_items.add(f"Item '{item_name}' references unknown hidden location '{hidden_location}'.")
+                missing_items.add(
+                    f"Item '{item_name}' references unknown hidden location '{hidden_location}'."
+                )
 
         if missing_items:
-            self.game_state._print_color("Warning: Item data inconsistencies detected:", Colors.YELLOW)
+            self.game_state._print_color(
+                "Warning: Item data inconsistencies detected:", Colors.YELLOW
+            )
             for message in sorted(missing_items):
                 self.game_state._print_color(f"- {message}", Colors.YELLOW)
             self.game_state._print_color("", Colors.RESET)
 
     def _handle_ambient_rumors(self):
-        if self.game_state.current_location_name in ["Haymarket Square", "Tavern", "Squalid St. Petersburg Street"] and \
-           random.random() < AMBIENT_RUMOR_CHANCE_PUBLIC_PLACE:
-            source_npc = random.choice(self.game_state.npcs_in_current_location) if self.game_state.npcs_in_current_location \
-                         else Character("A Passerby", "A typical St. Petersburg citizen.", "", self.game_state.current_location_name, [])
+        if (
+            self.game_state.current_location_name
+            in ["Haymarket Square", "Tavern", "Squalid St. Petersburg Street"]
+            and random.random() < AMBIENT_RUMOR_CHANCE_PUBLIC_PLACE
+        ):
+            source_npc = (
+                random.choice(self.game_state.npcs_in_current_location)
+                if self.game_state.npcs_in_current_location
+                else Character(
+                    "A Passerby",
+                    "A typical St. Petersburg citizen.",
+                    "",
+                    self.game_state.current_location_name,
+                    [],
+                )
+            )
             relationship_score_for_rumor = 0
-            if source_npc.name != "A Passerby" and hasattr(source_npc, 'relationship_with_player'):
+            if source_npc.name != "A Passerby" and hasattr(
+                source_npc, "relationship_with_player"
+            ):
                 relationship_score_for_rumor = source_npc.relationship_with_player
 
             rumor_text = None
-            if not self.game_state.low_ai_data_mode and self.game_state.gemini_api.model:
+            if (
+                not self.game_state.low_ai_data_mode
+                and self.game_state.gemini_api.model
+            ):
                 rumor_text = self.game_state.gemini_api.get_rumor_or_gossip(
-                    source_npc, self.game_state.current_location_name, self.get_current_time_period(),
-                    self.game_state._get_known_facts_summary(), self.game_state.player_notoriety_level,
-                    self.game_state.get_relationship_text(relationship_score_for_rumor), self.game_state._get_objectives_summary(source_npc))
+                    source_npc,
+                    self.game_state.current_location_name,
+                    self.get_current_time_period(),
+                    self.game_state._get_known_facts_summary(),
+                    self.game_state.player_notoriety_level,
+                    self.game_state.get_relationship_text(relationship_score_for_rumor),
+                    self.game_state._get_objectives_summary(source_npc),
+                )
 
-            if rumor_text is None or (isinstance(rumor_text, str) and rumor_text.startswith("(OOC:")) or self.game_state.low_ai_data_mode:
+            if (
+                rumor_text is None
+                or (isinstance(rumor_text, str) and rumor_text.startswith("(OOC:"))
+                or self.game_state.low_ai_data_mode
+            ):
                 if STATIC_RUMORS:
                     rumor_text = random.choice(STATIC_RUMORS)
                 else:
-                    rumor_text = "The air buzzes with indistinct chatter." # Ultimate fallback
+                    rumor_text = (
+                        "The air buzzes with indistinct chatter."  # Ultimate fallback
+                    )
                 rumor_text = self.game_state._apply_verbosity(rumor_text)
                 # Print static rumor with a different color or note if desired
-                self.game_state._print_color(f"\n{Colors.DIM}(You overhear some chatter nearby: \"{rumor_text}\"){Colors.RESET}", Colors.DIM); self.game_state._print_color("", Colors.RESET)
-                if self.game_state.player_character and rumor_text: # Check rumor_text is not None
-                     self.game_state.player_character.add_journal_entry("Overheard Rumor (Static)", rumor_text, self.game_state._get_current_game_time_period_str())
-            elif rumor_text: # AI success and not OOC
+                self.game_state._print_color(
+                    f'\n{Colors.DIM}(You overhear some chatter nearby: "{rumor_text}"){Colors.RESET}',
+                    Colors.DIM,
+                )
+                self.game_state._print_color("", Colors.RESET)
+                if (
+                    self.game_state.player_character and rumor_text
+                ):  # Check rumor_text is not None
+                    self.game_state.player_character.add_journal_entry(
+                        "Overheard Rumor (Static)",
+                        rumor_text,
+                        self.game_state._get_current_game_time_period_str(),
+                    )
+            elif rumor_text:  # AI success and not OOC
                 rumor_text = self.game_state._apply_verbosity(rumor_text)
-                self.game_state._print_color(f"\n{Colors.DIM}(You overhear some chatter nearby: \"{rumor_text}\"){Colors.RESET}", Colors.DIM); self.game_state._print_color("", Colors.RESET)
+                self.game_state._print_color(
+                    f'\n{Colors.DIM}(You overhear some chatter nearby: "{rumor_text}"){Colors.RESET}',
+                    Colors.DIM,
+                )
+                self.game_state._print_color("", Colors.RESET)
                 if self.game_state.player_character:
-                     self.game_state.player_character.add_journal_entry("Overheard Rumor (AI)", rumor_text, self.game_state._get_current_game_time_period_str())
+                    self.game_state.player_character.add_journal_entry(
+                        "Overheard Rumor (AI)",
+                        rumor_text,
+                        self.game_state._get_current_game_time_period_str(),
+                    )
                 self.game_state._remember_ai_output(rumor_text, "ambient_rumor")
 
             # Common logic for Raskolnikov if any rumor was processed (AI or static)
-            if rumor_text and self.game_state.player_character and self.game_state.player_character.name == "Rodion Raskolnikov" and \
-               any(kw in rumor_text.lower() for kw in ["student", "axe", "pawnbroker", "murder", "police"]):
-                self.game_state.player_character.apparent_state = "paranoid"; self.game_state.player_notoriety_level = min(self.game_state.player_notoriety_level + 0.2, 3)
+            if (
+                rumor_text
+                and self.game_state.player_character
+                and self.game_state.player_character.name == "Rodion Raskolnikov"
+                and any(
+                    kw in rumor_text.lower()
+                    for kw in ["student", "axe", "pawnbroker", "murder", "police"]
+                )
+            ):
+                self.game_state.player_character.apparent_state = "paranoid"
+                self.game_state.player_notoriety_level = min(
+                    self.game_state.player_notoriety_level + 0.2, 3
+                )
 
-    def _update_world_state_after_action(self, command, action_taken_this_turn, time_to_advance):
+    def _update_world_state_after_action(
+        self, command, action_taken_this_turn, time_to_advance
+    ):
         if action_taken_this_turn:
             self.game_state.player_action_count += 1
-            if command != "talk to": self.advance_time(time_to_advance)
+            if command != "talk to":
+                self.advance_time(time_to_advance)
             self.game_state.actions_since_last_autosave += 1
-            if self.game_state.actions_since_last_autosave >= self.game_state.autosave_interval_actions and command not in ["save", "load", "quit"]:
+            if (
+                self.game_state.actions_since_last_autosave
+                >= self.game_state.autosave_interval_actions
+                and command not in ["save", "load", "quit"]
+            ):
                 self.game_state.save_game("autosave", is_autosave=True)
                 self.game_state.actions_since_last_autosave = 0
             event_triggered = self.game_state.event_manager.check_and_trigger_events()
-            if event_triggered and self.game_state.last_significant_event_summary and \
-               self.game_state.last_significant_event_summary not in self.game_state.key_events_occurred[-3:]:
-                self.game_state.key_events_occurred.append(self.game_state.last_significant_event_summary)
-                if len(self.game_state.key_events_occurred) > 10: self.game_state.key_events_occurred.pop(0)
-            if self.game_state.gemini_api.model and command != "talk to" and \
-               self.game_state.time_since_last_npc_interaction >= TIME_UNITS_FOR_NPC_INTERACTION_CHANCE:
-                if len(self.game_state.npcs_in_current_location) >= 2 and random.random() < NPC_INTERACTION_CHANCE:
-                    if self.game_state.event_manager.attempt_npc_npc_interaction(): self.game_state.last_significant_event_summary = "overheard an exchange between NPCs."
+            if (
+                event_triggered
+                and self.game_state.last_significant_event_summary
+                and self.game_state.last_significant_event_summary
+                not in self.game_state.key_events_occurred[-3:]
+            ):
+                self.game_state.key_events_occurred.append(
+                    self.game_state.last_significant_event_summary
+                )
+                if len(self.game_state.key_events_occurred) > 10:
+                    self.game_state.key_events_occurred.pop(0)
+            if (
+                self.game_state.gemini_api.model
+                and command != "talk to"
+                and self.game_state.time_since_last_npc_interaction
+                >= TIME_UNITS_FOR_NPC_INTERACTION_CHANCE
+            ):
+                if (
+                    len(self.game_state.npcs_in_current_location) >= 2
+                    and random.random() < NPC_INTERACTION_CHANCE
+                ):
+                    if self.game_state.event_manager.attempt_npc_npc_interaction():
+                        self.game_state.last_significant_event_summary = (
+                            "overheard an exchange between NPCs."
+                        )
                 self.game_state.time_since_last_npc_interaction = 0
 
     def _check_game_ending_conditions(self):
-        if self.game_state.player_character and self.game_state.player_character.name == "Rodion Raskolnikov":
-            obj_grapple = self.game_state.player_character.get_objective_by_id("grapple_with_crime")
+        if (
+            self.game_state.player_character
+            and self.game_state.player_character.name == "Rodion Raskolnikov"
+        ):
+            obj_grapple = self.game_state.player_character.get_objective_by_id(
+                "grapple_with_crime"
+            )
             if obj_grapple and obj_grapple.get("completed", False):
-                current_stage = self.game_state.player_character.get_current_stage_for_objective("grapple_with_crime")
+                current_stage = (
+                    self.game_state.player_character.get_current_stage_for_objective(
+                        "grapple_with_crime"
+                    )
+                )
                 if current_stage and current_stage.get("is_ending_stage"):
-                    self.game_state._print_color(f"\n--- The story of {self.game_state.player_character.name} has reached a conclusion ({current_stage.get('description', 'an end')}) ---", Colors.CYAN + Colors.BOLD)
+                    self.game_state._print_color(
+                        f"\n--- The story of {self.game_state.player_character.name} has reached a conclusion ({current_stage.get('description', 'an end')}) ---",
+                        Colors.CYAN + Colors.BOLD,
+                    )
                     return True
         return False
 
     def _handle_move_to_command(self, argument):
-        if not argument: self.game_state._print_color("Where do you want to move to?", Colors.RED); return False, False
-        if not self.game_state.player_character: self.game_state._print_color("Cannot move: Player character not available.", Colors.RED); return False, False
-        target_exit_input = argument.lower(); moved = False; potential_target_loc_name = None
-        current_location_data = LOCATIONS_DATA.get(self.game_state.current_location_name)
-        if not current_location_data: self.game_state._print_color(f"Error: Data for current location '{self.game_state.current_location_name}' is missing.", Colors.RED); return False, False
+        if not argument:
+            self.game_state._print_color("Where do you want to move to?", Colors.RED)
+            return False, False
+        if not self.game_state.player_character:
+            self.game_state._print_color(
+                "Cannot move: Player character not available.", Colors.RED
+            )
+            return False, False
+        target_exit_input = argument.lower()
+        potential_target_loc_name = None
+        current_location_data = LOCATIONS_DATA.get(
+            self.game_state.current_location_name
+        )
+        if not current_location_data:
+            self.game_state._print_color(
+                f"Error: Data for current location '{self.game_state.current_location_name}' is missing.",
+                Colors.RED,
+            )
+            return False, False
         location_exits = current_location_data.get("exits", {})
-        potential_target_loc_name, ambiguous = self.game_state._get_matching_exit(target_exit_input, location_exits)
+        potential_target_loc_name, ambiguous = self.game_state._get_matching_exit(
+            target_exit_input, location_exits
+        )
         if ambiguous:
             return False, False
         if potential_target_loc_name:
-            old_location = self.game_state.current_location_name; self.game_state.current_location_name = potential_target_loc_name
-            self.game_state.player_character.current_location = potential_target_loc_name; self.game_state.current_location_description_shown_this_visit = False
-            self.game_state.last_significant_event_summary = f"moved from {old_location} to {self.game_state.current_location_name}."
-            if self.game_state.player_character.name == "Rodion Raskolnikov" and potential_target_loc_name in ["Pawnbroker's Apartment", "Pawnbroker's Apartment Building"]:
-                self.game_state.player_notoriety_level = min(3, max(0, self.game_state.player_notoriety_level + 0.25)); self.game_state._print_color("(Your presence in this place feels heavy with unseen eyes...)", Colors.YELLOW + Colors.DIM)
+            old_location = self.game_state.current_location_name
+            self.game_state.current_location_name = potential_target_loc_name
+            self.game_state.player_character.current_location = (
+                potential_target_loc_name
+            )
+            self.game_state.current_location_description_shown_this_visit = False
+            self.game_state.last_significant_event_summary = (
+                f"moved from {old_location} to {self.game_state.current_location_name}."
+            )
+            if (
+                self.game_state.player_character.name == "Rodion Raskolnikov"
+                and potential_target_loc_name
+                in ["Pawnbroker's Apartment", "Pawnbroker's Apartment Building"]
+            ):
+                self.game_state.player_notoriety_level = min(
+                    3, max(0, self.game_state.player_notoriety_level + 0.25)
+                )
+                self.game_state._print_color(
+                    "(Your presence in this place feels heavy with unseen eyes...)",
+                    Colors.YELLOW + Colors.DIM,
+                )
                 if DEBUG_LOGS:
-                    print(f"[DEBUG] Notoriety changed to: {self.game_state.player_notoriety_level}")
-            self.update_current_location_details(from_explicit_look_cmd=False); moved = True
+                    print(
+                        f"[DEBUG] Notoriety changed to: {self.game_state.player_notoriety_level}"
+                    )
+            self.update_current_location_details(from_explicit_look_cmd=False)
             return True, True
-        else: self.game_state._print_color(f"You can't find a way to '{target_exit_input}' from here.", Colors.RED); return False, False
+        else:
+            self.game_state._print_color(
+                f"You can't find a way to '{target_exit_input}' from here.", Colors.RED
+            )
+            return False, False

--- a/main.py
+++ b/main.py
@@ -1,13 +1,13 @@
 # main.py
-import logging
-import traceback
+import importlib.util
+
 from game_engine.game_state import Game
 
-try:
-    import google.genai
-except ImportError:
+if importlib.util.find_spec("google.genai") is None:
     print("\n[WARNING] 'google-genai' package is not installed.")
-    print("[WARNING] The game will run in fallback deterministic mode without AI features.\n")
+    print(
+        "[WARNING] The game will run in fallback deterministic mode without AI features.\n"
+    )
 
 if __name__ == "__main__":
     game_instance = Game()

--- a/tests/blessed_test.py
+++ b/tests/blessed_test.py
@@ -1,5 +1,4 @@
 import blessed
-import time
 
 term = blessed.Terminal()
 
@@ -8,13 +7,13 @@ print("Line 1: Standard output before blessed.")
 # Try to print at the bottom of the terminal
 # (or top, if height is small, to ensure visibility)
 status_line_y = term.height - 1
-if status_line_y < 0: # term.height might be None or 0 if not a full terminal
+if status_line_y < 0:  # term.height might be None or 0 if not a full terminal
     status_line_y = 0
 
 # Ensure x-coordinate is within width if possible, else 0
 status_line_x = 0
 if term.width is not None and 0 >= term.width:
-    status_line_x = term.width -1 if term.width > 0 else 0
+    status_line_x = term.width - 1 if term.width > 0 else 0
 
 
 try:

--- a/tests/test_character_module.py
+++ b/tests/test_character_module.py
@@ -3,11 +3,12 @@ from unittest.mock import patch
 import os
 import sys
 
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from game_engine.character_module import Character
+from game_engine.character_module import Character  # noqa: E402
+
 
 class TestCharacterModule(unittest.TestCase):
     def setUp(self):
@@ -19,7 +20,7 @@ class TestCharacterModule(unittest.TestCase):
             accessible_locations=["test_room", "another_room"],
             objectives=[],
             inventory_items=[],
-            schedule={}
+            schedule={},
         )
         self.character.skills = {"Observation": 2}
 
@@ -48,47 +49,47 @@ class TestCharacterModule(unittest.TestCase):
         char_dict = self.character.to_dict()
 
         self.assertEqual(
-            char_dict["psychology"],
-            {"suspicion": 35, "fear": 10, "respect": 65}
+            char_dict["psychology"], {"suspicion": 35, "fear": 10, "respect": 65}
         )
 
     def test_from_dict(self):
         char_data = {
-            'name': 'Loaded Character',
-            'persona': 'Loaded persona.',
-            'greeting': 'Loaded greeting.',
-            'default_location': 'loaded_location',
-            'accessible_locations': ['loaded_location'],
-            'objectives': [],
-            'inventory': [],
-            'schedule': {},
-            'skills': {'Persuasion': 3},
-            'is_player': True,
-            'current_location': 'loaded_location',
-            'apparent_state': 'happy',
-            'relationship_with_player': 5,
-            'conversation_histories': {},
-            'memory_about_player': [],
-            'journal_entries': []
+            "name": "Loaded Character",
+            "persona": "Loaded persona.",
+            "greeting": "Loaded greeting.",
+            "default_location": "loaded_location",
+            "accessible_locations": ["loaded_location"],
+            "objectives": [],
+            "inventory": [],
+            "schedule": {},
+            "skills": {"Persuasion": 3},
+            "is_player": True,
+            "current_location": "loaded_location",
+            "apparent_state": "happy",
+            "relationship_with_player": 5,
+            "conversation_histories": {},
+            "memory_about_player": [],
+            "journal_entries": [],
         }
         static_data = {
             "persona": "Original persona.",
             "greeting": "Original greeting.",
             "default_location": "original_location",
-            "accessible_locations": ["original_location"]
+            "accessible_locations": ["original_location"],
         }
         loaded_char = Character.from_dict(char_data, static_data)
-        self.assertEqual(loaded_char.name, 'Loaded Character')
-        self.assertEqual(loaded_char.skills['Persuasion'], 3)
+        self.assertEqual(loaded_char.name, "Loaded Character")
+        self.assertEqual(loaded_char.skills["Persuasion"], 3)
         self.assertTrue(loaded_char.is_player)
 
     def test_check_skill_success(self):
-        with patch('game_engine.character_module.random.randint', return_value=4):
+        with patch("game_engine.character_module.random.randint", return_value=4):
             self.assertTrue(self.character.check_skill("Observation", 2))
 
     def test_check_skill_failure(self):
-        with patch('game_engine.character_module.random.randint', return_value=1):
+        with patch("game_engine.character_module.random.randint", return_value=1):
             self.assertFalse(self.character.check_skill("Observation", 2))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_event_manager.py
+++ b/tests/test_event_manager.py
@@ -1,13 +1,14 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 import os
 import sys
 
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from game_engine.event_manager import EventManager
+from game_engine.event_manager import EventManager  # noqa: E402
+
 
 class TestEventManager(unittest.TestCase):
     def setUp(self):
@@ -31,14 +32,14 @@ class TestEventManager(unittest.TestCase):
             "id": "test_event_1",
             "trigger": lambda: True,
             "action": mock_action,
-            "one_time": True
+            "one_time": True,
         }
         self.event_manager.story_events.append(test_event)
 
         result = self.event_manager.check_and_trigger_events()
 
         self.assertTrue(result)
-        mock_action.assert_called_once_with() # The action is called with no arguments
+        mock_action.assert_called_once_with()  # The action is called with no arguments
         self.assertIn("test_event_1", self.event_manager.triggered_events)
 
     def test_event_not_triggered_if_condition_false(self):
@@ -47,7 +48,7 @@ class TestEventManager(unittest.TestCase):
             "id": "test_event_2",
             "trigger": lambda: False,
             "action": mock_action,
-            "one_time": True
+            "one_time": True,
         }
         self.event_manager.story_events.append(test_event)
 
@@ -62,14 +63,16 @@ class TestEventManager(unittest.TestCase):
             "id": "one_time_event",
             "trigger": lambda: True,
             "action": mock_action,
-            "one_time": True
+            "one_time": True,
         }
         self.event_manager.story_events.append(test_event)
-        self.event_manager.triggered_events.add("one_time_event") # Pretend it has already run
+        self.event_manager.triggered_events.add(
+            "one_time_event"
+        )  # Pretend it has already run
 
         result = self.event_manager.check_and_trigger_events()
 
-        self.assertFalse(result) # Should return False as no new event was triggered
+        self.assertFalse(result)  # Should return False as no new event was triggered
         mock_action.assert_not_called()
 
     def test_repeatable_event_can_trigger_again(self):
@@ -78,7 +81,7 @@ class TestEventManager(unittest.TestCase):
             "id": "repeatable_event",
             "trigger": lambda: True,
             "action": mock_action,
-            "one_time": False
+            "one_time": False,
         }
         self.event_manager.story_events.append(test_event)
         # Even if it was "triggered" before, as long as the "_recent" flag is not set, it should run.
@@ -96,15 +99,18 @@ class TestEventManager(unittest.TestCase):
             "id": "repeatable_event_recent",
             "trigger": lambda: True,
             "action": mock_action,
-            "one_time": False
+            "one_time": False,
         }
         self.event_manager.story_events.append(test_event)
-        self.event_manager.triggered_events.add("repeatable_event_recent_recent") # Set the recent flag
+        self.event_manager.triggered_events.add(
+            "repeatable_event_recent_recent"
+        )  # Set the recent flag
 
         result = self.event_manager.check_and_trigger_events()
 
         self.assertFalse(result)
         mock_action.assert_not_called()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_game_logic.py
+++ b/tests/test_game_logic.py
@@ -1,22 +1,27 @@
 import unittest
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock
 import sys
 import os
-import random # For TestItemEffects
-import copy # For TestCharacterObjectives
+import copy  # For TestCharacterObjectives
 
 # Add project root to sys.path to allow imports from game_engine
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from game_engine.character_module import Character
-from game_engine.gemini_interactions import GeminiAPI, DEFAULT_GEMINI_MODEL_NAME
-from game_engine.game_state import Game
-from game_engine.command_handler import CommandHandler
-from game_engine.world_manager import WorldManager
-from game_engine.event_manager import EventManager
-from game_engine.game_config import Colors, TIME_UNITS_PER_PLAYER_ACTION, TIME_UNITS_FOR_NPC_SCHEDULE_UPDATE, MAX_TIME_UNITS_PER_DAY, NPC_MOVE_CHANCE, TIME_PERIODS
+from game_engine.character_module import Character  # noqa: E402
+from game_engine.gemini_interactions import (  # noqa: E402
+    GeminiAPI,
+    DEFAULT_GEMINI_MODEL_NAME,
+)
+from game_engine.game_state import Game  # noqa: E402
+from game_engine.world_manager import WorldManager  # noqa: E402
+from game_engine.event_manager import EventManager  # noqa: E402
+from game_engine.game_config import (  # noqa: E402
+    Colors,
+    TIME_UNITS_PER_PLAYER_ACTION,
+    STATIC_ANONYMOUS_NOTE_CONTENT,
+)
 
 # Test data for DEFAULT_ITEMS
 DEFAULT_ITEMS_TEST_DATA = {
@@ -24,48 +29,85 @@ DEFAULT_ITEMS_TEST_DATA = {
     "sword": {"description": "A sharp sword."},
     "coin": {"description": "A gold coin.", "value": 1},
     "potion": {"description": "A healing potion.", "stackable": True},
-    "scroll": {"description": "An old scroll."}
+    "scroll": {"description": "An old scroll."},
 }
 
 TEST_ITEMS_FOR_LOOK = {
-    "test_apple": {"description": "A juicy red apple, looking crisp.", "stackable": True, "takeable": True},
-    "test_sword": {"description": "A long, sharp sword, gleaming slightly.", "takeable": True},
+    "test_apple": {
+        "description": "A juicy red apple, looking crisp.",
+        "stackable": True,
+        "takeable": True,
+    },
+    "test_sword": {
+        "description": "A long, sharp sword, gleaming slightly.",
+        "takeable": True,
+    },
     "test_coin": {"description": "A single gold coin.", "value": 1, "takeable": True},
-    "test_scroll": {"description": "An ancient scroll.", "readable": True, "takeable": True},
-    "test_potion": {"description": "A bubbling potion.", "use_effect_player": "drink_potion", "takeable": True}
+    "test_scroll": {
+        "description": "An ancient scroll.",
+        "readable": True,
+        "takeable": True,
+    },
+    "test_potion": {
+        "description": "A bubbling potion.",
+        "use_effect_player": "drink_potion",
+        "takeable": True,
+    },
 }
 
-TEST_GAME_ITEMS = { # For TestItemEffects
-    "tattered handkerchief": {"description": "A worn piece of cloth.", "use_effect_player": "comfort_self_if_ill"},
-    "raskolnikov's axe": {"description": "A weighty axe.", "use_effect_player": "grip_axe_and_reminisce_horror"},
-    "cheap vodka": {"description": "A bottle of cheap spirits.", "use_effect_player": "drink_vodka_for_oblivion", "consumable": True, "stackable": True},
-    "fresh newspaper": {"description": "Today's news.", "readable": True, "use_effect_player": "read_evolving_news_article"},
-    "mother's letter": {"description": "A letter from Pulcheria.", "readable": True, "use_effect_player": "reread_letter_and_feel_familial_pressure"},
+TEST_GAME_ITEMS = {  # For TestItemEffects
+    "tattered handkerchief": {
+        "description": "A worn piece of cloth.",
+        "use_effect_player": "comfort_self_if_ill",
+    },
+    "raskolnikov's axe": {
+        "description": "A weighty axe.",
+        "use_effect_player": "grip_axe_and_reminisce_horror",
+    },
+    "cheap vodka": {
+        "description": "A bottle of cheap spirits.",
+        "use_effect_player": "drink_vodka_for_oblivion",
+        "consumable": True,
+        "stackable": True,
+    },
+    "fresh newspaper": {
+        "description": "Today's news.",
+        "readable": True,
+        "use_effect_player": "read_evolving_news_article",
+    },
+    "mother's letter": {
+        "description": "A letter from Pulcheria.",
+        "readable": True,
+        "use_effect_player": "reread_letter_and_feel_familial_pressure",
+    },
 }
 
 TEST_SCHEDULE_LOCATIONS_DATA = {
     "LocationA": {"description": "A quiet place.", "exits": {}},
     "LocationB": {"description": "A busy place.", "exits": {}},
-    "LocationC": {"description": "An inaccessible place.", "exits": {}}
+    "LocationC": {"description": "An inaccessible place.", "exits": {}},
 }
 TEST_SCHEDULED_NPC_DATA = {
     "ScheduledNPC": {
-        "persona": "An NPC with a schedule", "greeting": "Hmph.",
+        "persona": "An NPC with a schedule",
+        "greeting": "Hmph.",
         "default_location": "LocationA",
         "accessible_locations": ["LocationA", "LocationB"],
         "schedule": {
             "Morning": "LocationA",
             "Afternoon": "LocationB",
-            "Evening": "LocationA"
-        }
+            "Evening": "LocationA",
+        },
     },
     "StaticNPC": {
-        "persona": "Stays put.", "greeting": "...",
+        "persona": "Stays put.",
+        "greeting": "...",
         "default_location": "LocationA",
         "accessible_locations": ["LocationA"],
-        "schedule": {}
-    }
+        "schedule": {},
+    },
 }
+
 
 class TestInventoryDescription(unittest.TestCase):
     def setUp(self):
@@ -74,69 +116,101 @@ class TestInventoryDescription(unittest.TestCase):
             persona="A test persona",
             greeting="Hello",
             default_location="TestLocation",
-            accessible_locations=["TestLocation"]
+            accessible_locations=["TestLocation"],
         )
         self.char.inventory = []
 
-    @patch.dict('game_engine.game_config.DEFAULT_ITEMS', DEFAULT_ITEMS_TEST_DATA, clear=True)
+    @patch.dict(
+        "game_engine.game_config.DEFAULT_ITEMS", DEFAULT_ITEMS_TEST_DATA, clear=True
+    )
     def test_empty_inventory(self):
-        self.assertEqual(self.char.get_inventory_description(), "You are carrying nothing.")
+        self.assertEqual(
+            self.char.get_inventory_description(), "You are carrying nothing."
+        )
 
-    @patch.dict('game_engine.game_config.DEFAULT_ITEMS', DEFAULT_ITEMS_TEST_DATA, clear=True)
+    @patch.dict(
+        "game_engine.game_config.DEFAULT_ITEMS", DEFAULT_ITEMS_TEST_DATA, clear=True
+    )
     def test_single_non_stackable_item(self):
         self.char.inventory = [{"name": "sword"}]
-        self.assertEqual(self.char.get_inventory_description(), "You are carrying: sword.")
+        self.assertEqual(
+            self.char.get_inventory_description(), "You are carrying: sword."
+        )
 
-    @patch.dict('game_engine.game_config.DEFAULT_ITEMS', DEFAULT_ITEMS_TEST_DATA, clear=True)
+    @patch.dict(
+        "game_engine.game_config.DEFAULT_ITEMS", DEFAULT_ITEMS_TEST_DATA, clear=True
+    )
     def test_single_stackable_item_quantity_one(self):
         self.char.inventory = [{"name": "apple", "quantity": 1}]
-        self.assertEqual(self.char.get_inventory_description(), "You are carrying: apple.")
+        self.assertEqual(
+            self.char.get_inventory_description(), "You are carrying: apple."
+        )
 
-    @patch.dict('game_engine.game_config.DEFAULT_ITEMS', DEFAULT_ITEMS_TEST_DATA, clear=True)
+    @patch.dict(
+        "game_engine.game_config.DEFAULT_ITEMS", DEFAULT_ITEMS_TEST_DATA, clear=True
+    )
     def test_single_stackable_item_quantity_many(self):
         self.char.inventory = [{"name": "apple", "quantity": 3}]
-        self.assertEqual(self.char.get_inventory_description(), "You are carrying: apple (x3).")
+        self.assertEqual(
+            self.char.get_inventory_description(), "You are carrying: apple (x3)."
+        )
 
-    @patch.dict('game_engine.game_config.DEFAULT_ITEMS', DEFAULT_ITEMS_TEST_DATA, clear=True)
+    @patch.dict(
+        "game_engine.game_config.DEFAULT_ITEMS", DEFAULT_ITEMS_TEST_DATA, clear=True
+    )
     def test_multiple_items(self):
         self.char.inventory = [
             {"name": "sword"},
             {"name": "apple", "quantity": 2},
-            {"name": "coin", "quantity": 10}
+            {"name": "coin", "quantity": 10},
         ]
         desc = self.char.get_inventory_description()
         self.assertTrue(desc.startswith("You are carrying: "))
         expected_items = sorted(["sword", "apple (x2)", "coin (x10)"])
         actual_items_str = desc.replace("You are carrying: ", "").split(", ")
-        actual_items = sorted([item.strip('.') for item in actual_items_str])
+        actual_items = sorted([item.strip(".") for item in actual_items_str])
         self.assertEqual(actual_items, expected_items)
 
-    @patch('game_engine.game_config.DEFAULT_ITEMS', DEFAULT_ITEMS_TEST_DATA)
+    @patch("game_engine.game_config.DEFAULT_ITEMS", DEFAULT_ITEMS_TEST_DATA)
     def test_item_with_command_suffix_displayed_cleanly(self):
         self.char.inventory = [{"name": "potion use_effect_player:drink"}]
-        self.assertEqual(self.char.get_inventory_description(), "You are carrying: potion.")
+        self.assertEqual(
+            self.char.get_inventory_description(), "You are carrying: potion."
+        )
 
-    @patch('game_engine.game_config.DEFAULT_ITEMS', DEFAULT_ITEMS_TEST_DATA)
+    @patch("game_engine.game_config.DEFAULT_ITEMS", DEFAULT_ITEMS_TEST_DATA)
     def test_item_with_command_suffix_stackable(self):
-        self.char.inventory = [{"name": "potion use_effect_player:drink", "quantity": 3}]
-        self.assertEqual(self.char.get_inventory_description(), "You are carrying: potion (x3).")
+        self.char.inventory = [
+            {"name": "potion use_effect_player:drink", "quantity": 3}
+        ]
+        self.assertEqual(
+            self.char.get_inventory_description(), "You are carrying: potion (x3)."
+        )
 
-    @patch('game_engine.game_config.DEFAULT_ITEMS', DEFAULT_ITEMS_TEST_DATA)
+    @patch("game_engine.game_config.DEFAULT_ITEMS", DEFAULT_ITEMS_TEST_DATA)
     def test_item_with_value_and_suffix_stackable(self):
         self.char.inventory = [{"name": "coin use_effect_player:spend", "quantity": 5}]
-        self.assertEqual(self.char.get_inventory_description(), "You are carrying: coin (x5).")
+        self.assertEqual(
+            self.char.get_inventory_description(), "You are carrying: coin (x5)."
+        )
 
-    @patch('game_engine.game_config.DEFAULT_ITEMS', DEFAULT_ITEMS_TEST_DATA)
+    @patch("game_engine.game_config.DEFAULT_ITEMS", DEFAULT_ITEMS_TEST_DATA)
     def test_mangled_name_not_in_default_items_but_base_is(self):
         self.char.inventory = [{"name": "scroll use_effect_player:read", "quantity": 1}]
-        self.assertEqual(self.char.get_inventory_description(), "You are carrying: scroll.")
+        self.assertEqual(
+            self.char.get_inventory_description(), "You are carrying: scroll."
+        )
 
-    @patch('game_engine.game_config.DEFAULT_ITEMS', DEFAULT_ITEMS_TEST_DATA)
+    @patch("game_engine.game_config.DEFAULT_ITEMS", DEFAULT_ITEMS_TEST_DATA)
     def test_mangled_name_where_base_not_in_default_items(self):
         self.char.inventory = [{"name": "ghost_item use_effect_player:vanish"}]
         # This test reflects that if the "cleaned" base name is not in DEFAULT_ITEMS,
         # the original (mangled) name is displayed.
-        self.assertEqual(self.char.get_inventory_description(), "You are carrying: ghost_item use_effect_player:vanish.")
+        self.assertEqual(
+            self.char.get_inventory_description(),
+            "You are carrying: ghost_item use_effect_player:vanish.",
+        )
+
 
 class TestGeminiDialogueQuotes(unittest.TestCase):
     def setUp(self):
@@ -146,8 +220,20 @@ class TestGeminiDialogueQuotes(unittest.TestCase):
         self.api = GeminiAPI()
         self.api.model = MagicMock()
 
-        self.player = Character(name="Player", persona="P", greeting="G", default_location="L", accessible_locations=["L"])
-        self.npc = Character(name="NPC", persona="N", greeting="G", default_location="L", accessible_locations=["L"])
+        self.player = Character(
+            name="Player",
+            persona="P",
+            greeting="G",
+            default_location="L",
+            accessible_locations=["L"],
+        )
+        self.npc = Character(
+            name="NPC",
+            persona="N",
+            greeting="G",
+            default_location="L",
+            accessible_locations=["L"],
+        )
 
         self.player.conversation_histories = {}
         self.npc.conversation_histories = {}
@@ -155,65 +241,117 @@ class TestGeminiDialogueQuotes(unittest.TestCase):
     def tearDown(self):
         patch.stopall()
 
-    @patch.object(GeminiAPI, '_generate_content_with_fallback')
+    @patch.object(GeminiAPI, "_generate_content_with_fallback")
     def test_player_dialogue_quotes_escaped_in_prompt(self, mock_generate_content):
         mock_generate_content.return_value = "AI response"
         player_dialogue = 'He said "Hello!" to me.'
-        self.api.get_npc_dialogue(self.npc, self.player, player_dialogue, "Loc", "Time", "Rel", "Mem", "State", "Items", "Events", "Obj", "PlayerObj")
+        self.api.get_npc_dialogue(
+            self.npc,
+            self.player,
+            player_dialogue,
+            "Loc",
+            "Time",
+            "Rel",
+            "Mem",
+            "State",
+            "Items",
+            "Events",
+            "Obj",
+            "PlayerObj",
+        )
         self.assertTrue(mock_generate_content.called)
         prompt_arg = mock_generate_content.call_args[0][0]
         self.assertIn('He said \\"Hello!\\" to me.', prompt_arg)
 
-    @patch.object(GeminiAPI, '_generate_content_with_fallback')
+    @patch.object(GeminiAPI, "_generate_content_with_fallback")
     def test_ai_response_with_escaped_quotes_normalized(self, mock_generate_content):
         mock_generate_content.return_value = 'NPC says: \\"Greetings!\\"'
-        response = self.api.get_npc_dialogue(self.npc, self.player, "Hi", "L", "T", "R", "M", "S", "I", "E", "O", "PO")
+        response = self.api.get_npc_dialogue(
+            self.npc, self.player, "Hi", "L", "T", "R", "M", "S", "I", "E", "O", "PO"
+        )
         self.assertEqual(response, 'NPC says: "Greetings!"')
 
-    @patch.object(GeminiAPI, '_generate_content_with_fallback')
+    @patch.object(GeminiAPI, "_generate_content_with_fallback")
     def test_ai_response_with_surrounding_quotes_stripped(self, mock_generate_content):
         mock_generate_content.return_value = '"This is the actual response."'
-        response = self.api.get_npc_dialogue(self.npc, self.player, "Hello", "L", "T", "R", "M", "S", "I", "E", "O", "PO")
-        self.assertEqual(response, 'This is the actual response.')
+        response = self.api.get_npc_dialogue(
+            self.npc, self.player, "Hello", "L", "T", "R", "M", "S", "I", "E", "O", "PO"
+        )
+        self.assertEqual(response, "This is the actual response.")
 
-    @patch.object(GeminiAPI, '_generate_content_with_fallback')
-    def test_ai_response_with_both_escaped_and_surrounding_quotes(self, mock_generate_content):
+    @patch.object(GeminiAPI, "_generate_content_with_fallback")
+    def test_ai_response_with_both_escaped_and_surrounding_quotes(
+        self, mock_generate_content
+    ):
         mock_generate_content.return_value = '"NPC says: \\"Okay!\\""'
-        response = self.api.get_npc_dialogue(self.npc, self.player, "Tell me.", "L", "T", "R", "M", "S", "I", "E", "O", "PO")
+        response = self.api.get_npc_dialogue(
+            self.npc,
+            self.player,
+            "Tell me.",
+            "L",
+            "T",
+            "R",
+            "M",
+            "S",
+            "I",
+            "E",
+            "O",
+            "PO",
+        )
         self.assertEqual(response, 'NPC says: "Okay!"')
 
-    @patch.object(GeminiAPI, '_generate_content_with_fallback')
+    @patch.object(GeminiAPI, "_generate_content_with_fallback")
     def test_ooc_message_passthrough_and_history(self, mock_generate_content):
-        mock_generate_content.return_value = '(OOC: Cannot respond.)'
+        mock_generate_content.return_value = "(OOC: Cannot respond.)"
         self.npc.conversation_histories[self.player.name] = []
         initial_npc_history_len = len(self.npc.conversation_histories[self.player.name])
-        response = self.api.get_npc_dialogue(self.npc, self.player, "What?", "L", "T", "R", "M", "S", "I", "E", "O", "PO")
-        self.assertEqual(response, '(OOC: Cannot respond.)')
+        response = self.api.get_npc_dialogue(
+            self.npc, self.player, "What?", "L", "T", "R", "M", "S", "I", "E", "O", "PO"
+        )
+        self.assertEqual(response, "(OOC: Cannot respond.)")
         npc_hist_for_player = self.npc.conversation_histories[self.player.name]
         self.assertEqual(len(npc_hist_for_player), initial_npc_history_len + 1)
         self.assertEqual(npc_hist_for_player[-1], f"{self.player.name}: What?")
 
-    @patch.object(GeminiAPI, '_generate_content_with_fallback')
+    @patch.object(GeminiAPI, "_generate_content_with_fallback")
     def test_history_player_dialogue_is_original(self, mock_generate_content):
-        mock_generate_content.return_value = 'AI response'
+        mock_generate_content.return_value = "AI response"
         player_dialogue_with_quotes = 'My input has "quotes".'
-        self.api.get_npc_dialogue(self.npc, self.player, player_dialogue_with_quotes, "L", "T", "R", "M", "S", "I", "E", "O", "PO")
+        self.api.get_npc_dialogue(
+            self.npc,
+            self.player,
+            player_dialogue_with_quotes,
+            "L",
+            "T",
+            "R",
+            "M",
+            "S",
+            "I",
+            "E",
+            "O",
+            "PO",
+        )
         npc_history_for_player = self.npc.conversation_histories[self.player.name]
         expected_player_entry = f"{self.player.name}: {player_dialogue_with_quotes}"
         self.assertIn(expected_player_entry, npc_history_for_player)
 
-@patch('game_engine.item_interaction_handler.DEFAULT_ITEMS', TEST_ITEMS_FOR_LOOK)
+
+@patch("game_engine.item_interaction_handler.DEFAULT_ITEMS", TEST_ITEMS_FOR_LOOK)
 class TestGameStateCommands(unittest.TestCase):
     def setUp(self):
         self.game = Game()
         self.game.player_character = MagicMock(spec=Character)
-        self.game.player_character.name = "TestPlayer" # Fix for AttributeError
+        self.game.player_character.name = "TestPlayer"  # Fix for AttributeError
         self.game.player_character.inventory = []
         # Add defaults for attributes/methods needed in get_npc_dialogue context
         self.game.player_character.apparent_state = "normal"
-        self.game.player_character.get_notable_carried_items_summary = MagicMock(return_value="nothing notable.")
-        self.game.player_character.get_objectives_summary = MagicMock(return_value="No specific objectives.")
-        self.game.player_character.conversation_histories = {} # Ensure this exists
+        self.game.player_character.get_notable_carried_items_summary = MagicMock(
+            return_value="nothing notable."
+        )
+        self.game.player_character.get_objectives_summary = MagicMock(
+            return_value="No specific objectives."
+        )
+        self.game.player_character.conversation_histories = {}  # Ensure this exists
 
         self.game.current_location_name = "Test Chamber"
         self.game.dynamic_location_items = {
@@ -222,7 +360,7 @@ class TestGameStateCommands(unittest.TestCase):
                 {"name": "test_sword"},
                 {"name": "test_coin"},
                 {"name": "test_scroll"},
-                {"name": "test_potion"}
+                {"name": "test_potion"},
             ]
         }
         self.game.all_character_objects = {}
@@ -230,90 +368,127 @@ class TestGameStateCommands(unittest.TestCase):
         self.game.numbered_actions_context = []
         self.game.TIME_UNITS_PER_PLAYER_ACTION = TIME_UNITS_PER_PLAYER_ACTION
 
-        self.mock_locations_data_patch = patch('game_engine.game_state.LOCATIONS_DATA', {'Test Chamber': {'description': 'A room.', 'exits': {'north': 'Corridor'}}})
+        self.mock_locations_data_patch = patch(
+            "game_engine.game_state.LOCATIONS_DATA",
+            {
+                "Test Chamber": {
+                    "description": "A room.",
+                    "exits": {"north": "Corridor"},
+                }
+            },
+        )
         self.mock_locations_data = self.mock_locations_data_patch.start()
 
-        self.mock_print = patch('builtins.print').start()
-        self.mock_print_color = patch.object(self.game, '_print_color').start()
-        self.mock_input_color = patch.object(self.game, '_input_color').start()
+        self.mock_print = patch("builtins.print").start()
+        self.mock_print_color = patch.object(self.game, "_print_color").start()
+        self.mock_input_color = patch.object(self.game, "_input_color").start()
 
     def tearDown(self):
         patch.stopall()
 
     def test_handle_look_command_item_display(self):
         self.game._handle_look_command(None, show_full_look_details=True)
-        printed_content = " ".join([str(call_obj[0][0]) for call_obj in self.mock_print_color.call_args_list if call_obj[0]])
+        printed_content = " ".join(
+            [
+                str(call_obj[0][0])
+                for call_obj in self.mock_print_color.call_args_list
+                if call_obj[0]
+            ]
+        )
 
-        self.assertIn("test_apple (x3) - A juicy red apple, looking crisp.", printed_content)
-        self.assertIn("test_sword - A long, sharp sword, gleaming slightly.", printed_content)
+        self.assertIn(
+            "test_apple (x3) - A juicy red apple, looking crisp.", printed_content
+        )
+        self.assertIn(
+            "test_sword - A long, sharp sword, gleaming slightly.", printed_content
+        )
         self.assertIn("test_coin - A single gold coin.", printed_content)
 
         expected_context_actions = [
-            {'type': 'select_item', 'target': 'test_apple', 'display': 'test_apple'},
-            {'type': 'select_item', 'target': 'test_sword', 'display': 'test_sword'},
-            {'type': 'select_item', 'target': 'test_coin', 'display': 'test_coin'}
+            {"type": "select_item", "target": "test_apple", "display": "test_apple"},
+            {"type": "select_item", "target": "test_sword", "display": "test_sword"},
+            {"type": "select_item", "target": "test_coin", "display": "test_coin"},
         ]
         for expected_action in expected_context_actions:
-            found = any(e_a['type'] == expected_action['type'] and e_a['target'] == expected_action['target'] for e_a in self.game.numbered_actions_context)
-            self.assertTrue(found, f"Expected action {expected_action} not found in numbered_actions_context: {self.game.numbered_actions_context}")
+            found = any(
+                e_a["type"] == expected_action["type"]
+                and e_a["target"] == expected_action["target"]
+                for e_a in self.game.numbered_actions_context
+            )
+            self.assertTrue(
+                found,
+                f"Expected action {expected_action} not found in numbered_actions_context: {self.game.numbered_actions_context}",
+            )
 
-
-    @patch.object(Game, '_handle_look_command')
+    @patch.object(Game, "_handle_look_command")
     def test_process_command_select_item_then_look_at(self, mock_specific_look):
         item_name = "test_apple"
         self.mock_input_color.return_value = "look at"
         # When _process_command handles 'select_item', show_full_look_details is False
-        action_taken, show_atmospherics, time_units, _ = self.game.command_handler._process_command('select_item', item_name)
+        action_taken, show_atmospherics, time_units, _ = (
+            self.game.command_handler._process_command("select_item", item_name)
+        )
         # So, _handle_look_command (mocked as mock_specific_look here) should be called with False
         mock_specific_look.assert_called_once_with(item_name, False)
         self.assertTrue(action_taken)
         self.assertTrue(show_atmospherics)
         self.assertEqual(time_units, self.game.TIME_UNITS_PER_PLAYER_ACTION)
 
-    @patch.object(Game, '_handle_take_command')
+    @patch.object(Game, "_handle_take_command")
     def test_process_command_select_item_then_take(self, mock_handle_take):
         item_name = "test_apple"
         mock_handle_take.return_value = (True, True)
         self.mock_input_color.return_value = "take"
-        action_taken, show_atmospherics, time_units, _ = self.game.command_handler._process_command('select_item', item_name)
+        action_taken, show_atmospherics, time_units, _ = (
+            self.game.command_handler._process_command("select_item", item_name)
+        )
         mock_handle_take.assert_called_once_with(item_name)
         self.assertTrue(action_taken)
         self.assertTrue(show_atmospherics)
         self.assertEqual(time_units, self.game.TIME_UNITS_PER_PLAYER_ACTION)
 
-    @patch.object(Game, 'handle_use_item')
+    @patch.object(Game, "handle_use_item")
     def test_process_command_select_item_then_read(self, mock_handle_use_item):
         self.game.player_character.inventory = [{"name": "test_scroll"}]
         item_name = "test_scroll"
         mock_handle_use_item.return_value = True
         self.mock_input_color.return_value = "read"
-        action_taken, show_atmospherics, time_units, _ = self.game.command_handler._process_command('select_item', item_name)
+        action_taken, show_atmospherics, time_units, _ = (
+            self.game.command_handler._process_command("select_item", item_name)
+        )
         mock_handle_use_item.assert_called_once_with(item_name, None, "read")
         self.assertTrue(action_taken)
         self.assertFalse(show_atmospherics)
         self.assertEqual(time_units, self.game.TIME_UNITS_PER_PLAYER_ACTION)
 
-    @patch.object(Game, 'handle_use_item')
+    @patch.object(Game, "handle_use_item")
     def test_process_command_select_item_then_use_self(self, mock_handle_use_item):
         self.game.player_character.inventory = [{"name": "test_potion"}]
         item_name = "test_potion"
         mock_handle_use_item.return_value = True
         self.mock_input_color.return_value = "use"
-        action_taken, show_atmospherics, time_units, _ = self.game.command_handler._process_command('select_item', item_name)
-        mock_handle_use_item.assert_called_once_with(item_name, None, "use_self_implicit")
+        action_taken, show_atmospherics, time_units, _ = (
+            self.game.command_handler._process_command("select_item", item_name)
+        )
+        mock_handle_use_item.assert_called_once_with(
+            item_name, None, "use_self_implicit"
+        )
         self.assertTrue(action_taken)
         self.assertFalse(show_atmospherics)
         self.assertEqual(time_units, self.game.TIME_UNITS_PER_PLAYER_ACTION)
 
-    @patch.object(Game, 'handle_use_item')
+    @patch.object(Game, "handle_use_item")
     def test_process_command_select_item_then_give_to(self, mock_handle_use_item):
         self.game.player_character.inventory = [{"name": "test_apple"}]
         item_name = "test_apple"
-        mock_npc = MagicMock(spec=Character); mock_npc.name = "TestNPC"
+        mock_npc = MagicMock(spec=Character)
+        mock_npc.name = "TestNPC"
         self.game.npcs_in_current_location = [mock_npc]
         mock_handle_use_item.return_value = True
         self.mock_input_color.return_value = "give to TestNPC"
-        action_taken, show_atmospherics, time_units, _ = self.game.command_handler._process_command('select_item', item_name)
+        action_taken, show_atmospherics, time_units, _ = (
+            self.game.command_handler._process_command("select_item", item_name)
+        )
         mock_handle_use_item.assert_called_once_with(item_name, "testnpc", "give")
         self.assertTrue(action_taken)
         self.assertFalse(show_atmospherics)
@@ -322,56 +497,102 @@ class TestGameStateCommands(unittest.TestCase):
     def test_process_command_select_item_invalid_secondary_action(self):
         item_name = "test_apple"
         self.mock_input_color.return_value = "fly"
-        action_taken, show_atmospherics, time_units, _ = self.game.command_handler._process_command('select_item', item_name)
-        self.mock_print_color.assert_any_call(f"Invalid action 'fly' for {item_name}.", Colors.RED)
+        action_taken, show_atmospherics, time_units, _ = (
+            self.game.command_handler._process_command("select_item", item_name)
+        )
+        self.mock_print_color.assert_any_call(
+            f"Invalid action 'fly' for {item_name}.", Colors.RED
+        )
         self.assertFalse(action_taken)
         self.assertFalse(show_atmospherics)
         self.assertEqual(time_units, 0)
 
     # --- Tests for _handle_take_command ---
     TEST_ITEMS_FOR_TAKE = {
-        "unique_sword": {"description": "A unique blade.", "takeable": True, "stackable": False},
-        "apple": {"description": "A simple fruit.", "takeable": True, "stackable": True},
-        "coin": {"description": "A gold piece.", "takeable": True, "value": 1}
+        "unique_sword": {
+            "description": "A unique blade.",
+            "takeable": True,
+            "stackable": False,
+        },
+        "apple": {
+            "description": "A simple fruit.",
+            "takeable": True,
+            "stackable": True,
+        },
+        "coin": {"description": "A gold piece.", "takeable": True, "value": 1},
     }
 
-    @patch.dict('game_engine.item_interaction_handler.DEFAULT_ITEMS', TEST_ITEMS_FOR_TAKE, clear=True)
+    @patch.dict(
+        "game_engine.item_interaction_handler.DEFAULT_ITEMS",
+        TEST_ITEMS_FOR_TAKE,
+        clear=True,
+    )
     def test_take_non_stackable_already_has(self):
         self.game.player_character.inventory = [{"name": "unique_sword"}]
-        self.game.dynamic_location_items[self.game.current_location_name] = [{"name": "unique_sword"}]
+        self.game.dynamic_location_items[self.game.current_location_name] = [
+            {"name": "unique_sword"}
+        ]
         self.game.player_character.add_to_inventory = MagicMock(return_value=False)
-        self.game.player_character.has_item = MagicMock(return_value=True) # Player already has it
+        self.game.player_character.has_item = MagicMock(
+            return_value=True
+        )  # Player already has it
 
         action_taken, show_atmospherics = self.game._handle_take_command("unique_sword")
 
         self.assertFalse(action_taken)
         self.assertFalse(show_atmospherics)
-        self.mock_print_color.assert_any_call("You cannot carry another 'unique_sword'.", Colors.YELLOW)
-        self.game.player_character.add_to_inventory.assert_called_once_with("unique_sword", 1)
+        self.mock_print_color.assert_any_call(
+            "You cannot carry another 'unique_sword'.", Colors.YELLOW
+        )
+        self.game.player_character.add_to_inventory.assert_called_once_with(
+            "unique_sword", 1
+        )
 
-    @patch.dict('game_engine.item_interaction_handler.DEFAULT_ITEMS', TEST_ITEMS_FOR_TAKE, clear=True)
+    @patch.dict(
+        "game_engine.item_interaction_handler.DEFAULT_ITEMS",
+        TEST_ITEMS_FOR_TAKE,
+        clear=True,
+    )
     def test_take_non_stackable_does_not_have(self):
         self.game.player_character.inventory = []
-        self.game.dynamic_location_items[self.game.current_location_name] = [{"name": "unique_sword"}]
+        self.game.dynamic_location_items[self.game.current_location_name] = [
+            {"name": "unique_sword"}
+        ]
         self.game.player_character.add_to_inventory = MagicMock(return_value=True)
-        self.game.player_character.has_item = MagicMock(return_value=False) # Player does not have it initially
+        self.game.player_character.has_item = MagicMock(
+            return_value=False
+        )  # Player does not have it initially
 
         action_taken, show_atmospherics = self.game._handle_take_command("unique_sword")
 
         self.assertTrue(action_taken)
         self.assertFalse(show_atmospherics)
-        self.mock_print_color.assert_any_call("You take the unique_sword.", Colors.GREEN)
+        self.mock_print_color.assert_any_call(
+            "You take the unique_sword.", Colors.GREEN
+        )
         # Ensure the specific "cannot carry" message was NOT printed
         for call_args in self.mock_print_color.call_args_list:
-            self.assertNotEqual(call_args[0][0], "You cannot carry another 'unique_sword'.")
-        self.game.player_character.add_to_inventory.assert_called_once_with("unique_sword", 1)
+            self.assertNotEqual(
+                call_args[0][0], "You cannot carry another 'unique_sword'."
+            )
+        self.game.player_character.add_to_inventory.assert_called_once_with(
+            "unique_sword", 1
+        )
 
-    @patch.dict('game_engine.item_interaction_handler.DEFAULT_ITEMS', TEST_ITEMS_FOR_TAKE, clear=True)
+    @patch.dict(
+        "game_engine.item_interaction_handler.DEFAULT_ITEMS",
+        TEST_ITEMS_FOR_TAKE,
+        clear=True,
+    )
     def test_take_stackable_item(self):
         self.game.player_character.inventory = [{"name": "apple", "quantity": 1}]
-        self.game.dynamic_location_items[self.game.current_location_name] = [{"name": "apple", "quantity": 1}]
+        self.game.dynamic_location_items[self.game.current_location_name] = [
+            {"name": "apple", "quantity": 1}
+        ]
         self.game.player_character.add_to_inventory = MagicMock(return_value=True)
-        self.game.player_character.has_item = MagicMock(return_value=True) # Player has some apples
+        self.game.player_character.has_item = MagicMock(
+            return_value=True
+        )  # Player has some apples
 
         action_taken, show_atmospherics = self.game._handle_take_command("apple")
 
@@ -382,10 +603,16 @@ class TestGameStateCommands(unittest.TestCase):
             self.assertNotEqual(call_args[0][0], "You cannot carry another 'apple'.")
         self.game.player_character.add_to_inventory.assert_called_once_with("apple", 1)
 
-    @patch.dict('game_engine.item_interaction_handler.DEFAULT_ITEMS', TEST_ITEMS_FOR_TAKE, clear=True)
+    @patch.dict(
+        "game_engine.item_interaction_handler.DEFAULT_ITEMS",
+        TEST_ITEMS_FOR_TAKE,
+        clear=True,
+    )
     def test_take_item_with_value_behaves_stackable(self):
         self.game.player_character.inventory = [{"name": "coin", "quantity": 1}]
-        self.game.dynamic_location_items[self.game.current_location_name] = [{"name": "coin", "quantity": 1}]
+        self.game.dynamic_location_items[self.game.current_location_name] = [
+            {"name": "coin", "quantity": 1}
+        ]
         self.game.player_character.add_to_inventory = MagicMock(return_value=True)
         # has_item mock isn't strictly necessary here as the logic branches on add_to_inventory's return primarily
 
@@ -393,24 +620,35 @@ class TestGameStateCommands(unittest.TestCase):
 
         self.assertTrue(action_taken)
         self.assertFalse(show_atmospherics)
-        self.mock_print_color.assert_any_call("You take the coin.", Colors.GREEN) # Corrected assertion
+        self.mock_print_color.assert_any_call(
+            "You take the coin.", Colors.GREEN
+        )  # Corrected assertion
         for call_args in self.mock_print_color.call_args_list:
             self.assertNotEqual(call_args[0][0], "You cannot carry another 'coin'.")
         self.game.player_character.add_to_inventory.assert_called_once_with("coin", 1)
 
-
-    @patch.dict('game_engine.item_interaction_handler.DEFAULT_ITEMS', TEST_ITEMS_FOR_TAKE, clear=True)
+    @patch.dict(
+        "game_engine.item_interaction_handler.DEFAULT_ITEMS",
+        TEST_ITEMS_FOR_TAKE,
+        clear=True,
+    )
     def test_take_add_to_inventory_fails_generic(self):
         self.game.player_character.inventory = []
-        self.game.dynamic_location_items[self.game.current_location_name] = [{"name": "apple", "quantity": 1}]
+        self.game.dynamic_location_items[self.game.current_location_name] = [
+            {"name": "apple", "quantity": 1}
+        ]
         self.game.player_character.add_to_inventory = MagicMock(return_value=False)
-        self.game.player_character.has_item = MagicMock(return_value=False) # Does not have the item
+        self.game.player_character.has_item = MagicMock(
+            return_value=False
+        )  # Does not have the item
 
         action_taken, show_atmospherics = self.game._handle_take_command("apple")
 
         self.assertFalse(action_taken)
         self.assertFalse(show_atmospherics)
-        self.mock_print_color.assert_any_call("Failed to add apple to inventory.", Colors.RED)
+        self.mock_print_color.assert_any_call(
+            "Failed to add apple to inventory.", Colors.RED
+        )
         for call_args in self.mock_print_color.call_args_list:
             self.assertNotEqual(call_args[0][0], "You cannot carry another 'apple'.")
         self.game.player_character.add_to_inventory.assert_called_once_with("apple", 1)
@@ -420,92 +658,141 @@ class TestGameStateCommands(unittest.TestCase):
         self.game.player_character.name = "Rodion Raskolnikov"
         # Mock player attributes needed for get_npc_dialogue context
         self.game.player_character.apparent_state = "brooding"
-        self.game.player_character.get_notable_carried_items_summary = MagicMock(return_value="nothing notable.")
-        self.game.player_character.get_inventory_description = MagicMock(return_value="carrying a few kopeks.")
-
+        self.game.player_character.get_notable_carried_items_summary = MagicMock(
+            return_value="nothing notable."
+        )
+        self.game.player_character.get_inventory_description = MagicMock(
+            return_value="carrying a few kopeks."
+        )
 
         # Setup NPC Dmitri Razumikhin
         mock_razumikhin = MagicMock(spec=Character)
         mock_razumikhin.name = "Dmitri Razumikhin"
         mock_razumikhin.greeting = "Ah, Rodya, old friend! What brings you here?"
         mock_razumikhin.apparent_state = "cheerful"
-        mock_razumikhin.relationship_with_player = 5 # Positive relationship
-        mock_razumikhin.conversation_histories = {} # Initialize conversation histories
+        mock_razumikhin.relationship_with_player = 5  # Positive relationship
+        mock_razumikhin.conversation_histories = {}  # Initialize conversation histories
         mock_razumikhin.update_relationship = MagicMock()
         mock_razumikhin.add_player_memory = MagicMock()
-        mock_razumikhin.get_player_memory_summary = MagicMock(return_value="Fond memories.")
+        mock_razumikhin.get_player_memory_summary = MagicMock(
+            return_value="Fond memories."
+        )
         mock_razumikhin.get_objective_by_id = MagicMock(return_value=None)
         # Mock methods needed for get_npc_dialogue context for NPC
-        mock_razumikhin.get_objectives_summary = MagicMock(return_value="Just trying to help friends.")
-
+        mock_razumikhin.get_objectives_summary = MagicMock(
+            return_value="Just trying to help friends."
+        )
 
         self.game.npcs_in_current_location = [mock_razumikhin]
         self.game.all_character_objects["Dmitri Razumikhin"] = mock_razumikhin
 
         # Mock Gemini API for subsequent dialogue
-        self.game.gemini_api.model = MagicMock() # Ensure API model is considered available
-        self.game.gemini_api.get_npc_dialogue = MagicMock(return_value="Just thinking, Razumikhin. Just thinking.")
+        self.game.gemini_api.model = (
+            MagicMock()
+        )  # Ensure API model is considered available
+        self.game.gemini_api.get_npc_dialogue = MagicMock(
+            return_value="Just thinking, Razumikhin. Just thinking."
+        )
         # Mock game methods that provide context to get_npc_dialogue
         self.game.get_relationship_text = MagicMock(return_value="positive")
-        self.game._get_recent_events_summary = MagicMock(return_value="The usual St. Petersburg gloom.")
-        self.game._get_objectives_summary = MagicMock(return_value="Survive.") # For player
+        self.game._get_recent_events_summary = MagicMock(
+            return_value="The usual St. Petersburg gloom."
+        )
+        self.game._get_objectives_summary = MagicMock(
+            return_value="Survive."
+        )  # For player
         self.game.get_current_time_period = MagicMock(return_value="Evening")
-        self.game.player_character.current_location = self.game.current_location_name # Ensure player has a location
-
+        self.game.player_character.current_location = (
+            self.game.current_location_name
+        )  # Ensure player has a location
 
         # Mock input to end conversation immediately
-        self.mock_input_color.side_effect = ["Hello there!", "Farewell"] # Allow one exchange
+        self.mock_input_color.side_effect = [
+            "Hello there!",
+            "Farewell",
+        ]  # Allow one exchange
 
         # Action
         self.game._handle_talk_to_command("Dmitri Razumikhin")
 
         # Assertions
         # Check that the NPC's name was printed with _print_color(..., end="")
-        self.mock_print_color.assert_any_call(f"{mock_razumikhin.name}: ", Colors.YELLOW, end="")
+        self.mock_print_color.assert_any_call(
+            f"{mock_razumikhin.name}: ", Colors.YELLOW, end=""
+        )
         # Check that the NPC's greeting was printed with print()
-        self.mock_print.assert_any_call(f"\"{mock_razumikhin.greeting}\"")
+        self.mock_print.assert_any_call(f'"{mock_razumikhin.greeting}"')
 
         # Assert that Gemini API was called for the conversation part
         self.game.gemini_api.get_npc_dialogue.assert_called_once()
         # Verify some key context arguments passed to get_npc_dialogue
         dialogue_args, dialogue_kwargs = self.game.gemini_api.get_npc_dialogue.call_args
-        self.assertEqual(dialogue_args[0], mock_razumikhin) # target_npc is the first positional arg
-        self.assertEqual(dialogue_args[1], self.game.player_character) # player_character is the second
-        self.assertEqual(dialogue_args[2], "Hello there!") # player_dialogue_input is the third
-
+        self.assertEqual(
+            dialogue_args[0], mock_razumikhin
+        )  # target_npc is the first positional arg
+        self.assertEqual(
+            dialogue_args[1], self.game.player_character
+        )  # player_character is the second
+        self.assertEqual(
+            dialogue_args[2], "Hello there!"
+        )  # player_dialogue_input is the third
 
     # --- Tests for _handle_give_item ---
-    @patch.dict('game_engine.game_config.DEFAULT_ITEMS', {
-        "test_apple": {"description": "A simple apple.", "stackable": True, "takeable": True, "value": 5}, # value makes it stackable
-        "test_book": {"description": "An old book.", "takeable": True} # Non-stackable by default if no value
-    })
+    @patch.dict(
+        "game_engine.game_config.DEFAULT_ITEMS",
+        {
+            "test_apple": {
+                "description": "A simple apple.",
+                "stackable": True,
+                "takeable": True,
+                "value": 5,
+            },  # value makes it stackable
+            "test_book": {
+                "description": "An old book.",
+                "takeable": True,
+            },  # Non-stackable by default if no value
+        },
+    )
     def test_give_item_successfully(self):
         # Setup player inventory
         self.game.player_character.inventory = [{"name": "test_apple", "quantity": 1}]
         # Mock remove_from_inventory to check it's called and simulate success
         self.game.player_character.remove_from_inventory = MagicMock(return_value=True)
-        self.game.player_character.has_item = MagicMock(return_value=True) # Player has the item
+        self.game.player_character.has_item = MagicMock(
+            return_value=True
+        )  # Player has the item
         # Ensure player_character has attributes needed for dialogue context
-        self.game.player_character.name = "TestPlayerGive" # Specific name for clarity if needed
+        self.game.player_character.name = (
+            "TestPlayerGive"  # Specific name for clarity if needed
+        )
         self.game.player_character.apparent_state = "generous"
-        self.game.player_character.get_notable_carried_items_summary = MagicMock(return_value="an apple")
-        self.game.player_character.get_objectives_summary = MagicMock(return_value="To give an apple.")
-
+        self.game.player_character.get_notable_carried_items_summary = MagicMock(
+            return_value="an apple"
+        )
+        self.game.player_character.get_objectives_summary = MagicMock(
+            return_value="To give an apple."
+        )
 
         # Setup NPC
         mock_npc = MagicMock(spec=Character)
         mock_npc.name = "TestNPC"
         mock_npc.inventory = []
         mock_npc.relationship_with_player = 0
-        mock_npc.add_to_inventory = MagicMock(return_value=True) # Simulate successful add to NPC inv
+        mock_npc.add_to_inventory = MagicMock(
+            return_value=True
+        )  # Simulate successful add to NPC inv
         mock_npc.add_player_memory = MagicMock()
         mock_npc.get_player_memory_summary = MagicMock(return_value="No memories.")
-        mock_npc.get_objectives_summary = MagicMock(return_value="To receive an apple.") # Corrected: get_objectives_summary
+        mock_npc.get_objectives_summary = MagicMock(
+            return_value="To receive an apple."
+        )  # Corrected: get_objectives_summary
         self.game.npcs_in_current_location = [mock_npc]
 
         # Mock Gemini API & Game context methods
-        self.game.gemini_api.get_npc_dialogue = MagicMock(return_value="Oh, thank you for the apple!")
-        self.game.gemini_api.model = MagicMock() # Ensure model is truthy
+        self.game.gemini_api.get_npc_dialogue = MagicMock(
+            return_value="Oh, thank you for the apple!"
+        )
+        self.game.gemini_api.model = MagicMock()  # Ensure model is truthy
         self.game.low_ai_data_mode = False
         self.game.get_current_time_period = MagicMock(return_value="Afternoon")
         self.game._get_recent_events_summary = MagicMock(return_value="Nothing much.")
@@ -513,84 +800,125 @@ class TestGameStateCommands(unittest.TestCase):
         # For this test, player_character.get_objectives_summary is mocked above.
         # If self.game._get_objectives_summary(self.player_character) is used, that needs mocking on game.
         # Assuming get_npc_dialogue calls self.game._get_objectives_summary(character)
-        self.game._get_objectives_summary = MagicMock(side_effect=lambda char: char.get_objectives_summary())
-
+        self.game._get_objectives_summary = MagicMock(
+            side_effect=lambda char: char.get_objectives_summary()
+        )
 
         # Action: Player gives "test_apple" to "TestNPC"
         success = self.game.handle_use_item("test_apple", "TestNPC", "give")
 
         # Assertions
         self.assertTrue(success)
-        self.game.player_character.remove_from_inventory.assert_called_once_with("test_apple", 1)
+        self.game.player_character.remove_from_inventory.assert_called_once_with(
+            "test_apple", 1
+        )
         mock_npc.add_to_inventory.assert_called_once_with("test_apple", 1)
         self.game.gemini_api.get_npc_dialogue.assert_called_once()
         dialogue_args, dialogue_kwargs = self.game.gemini_api.get_npc_dialogue.call_args
         # player_dialogue_input is the 3rd positional arg (index 2)
-        self.assertEqual(dialogue_args[2], "(Player gives test_apple to NPC. Player expects a reaction.)")
+        self.assertEqual(
+            dialogue_args[2],
+            "(Player gives test_apple to NPC. Player expects a reaction.)",
+        )
 
-        self.mock_print_color.assert_any_call(f"You give the test_apple to {mock_npc.name}.", Colors.WHITE)
-        self.mock_print_color.assert_any_call(f"{mock_npc.name}: \"Oh, thank you for the apple!\"", Colors.YELLOW)
+        self.mock_print_color.assert_any_call(
+            f"You give the test_apple to {mock_npc.name}.", Colors.WHITE
+        )
+        self.mock_print_color.assert_any_call(
+            f'{mock_npc.name}: "Oh, thank you for the apple!"', Colors.YELLOW
+        )
         self.assertEqual(mock_npc.relationship_with_player, 1)
         mock_npc.add_player_memory.assert_called_once()
         args, kwargs = mock_npc.add_player_memory.call_args
-        self.assertEqual(kwargs.get('memory_type'), "received_item")
-        self.assertEqual(kwargs.get('content', {}).get('item_name'), "test_apple")
-        self.assertEqual(kwargs.get('content', {}).get('quantity'), 1)
-        self.assertTrue(kwargs.get('content', {}).get('from_player'))
-        self.assertEqual(self.game.last_significant_event_summary, f"gave test_apple to {mock_npc.name}.")
+        self.assertEqual(kwargs.get("memory_type"), "received_item")
+        self.assertEqual(kwargs.get("content", {}).get("item_name"), "test_apple")
+        self.assertEqual(kwargs.get("content", {}).get("quantity"), 1)
+        self.assertTrue(kwargs.get("content", {}).get("from_player"))
+        self.assertEqual(
+            self.game.last_significant_event_summary,
+            f"gave test_apple to {mock_npc.name}.",
+        )
 
-    @patch.dict('game_engine.game_config.DEFAULT_ITEMS', {"test_banana": {"description": "A ripe banana."}}, clear=True)
+    @patch.dict(
+        "game_engine.game_config.DEFAULT_ITEMS",
+        {"test_banana": {"description": "A ripe banana."}},
+        clear=True,
+    )
     def test_give_item_player_does_not_have(self):
-        self.game.player_character.inventory = [] # Player has nothing
-        self.game.player_character.has_item = MagicMock(return_value=False) # Explicitly mock has_item
+        self.game.player_character.inventory = []  # Player has nothing
+        self.game.player_character.has_item = MagicMock(
+            return_value=False
+        )  # Explicitly mock has_item
 
-        mock_npc = MagicMock(spec=Character); mock_npc.name = "TestNPC"
-        mock_npc.inventory = []; mock_npc.add_player_memory = MagicMock()
+        mock_npc = MagicMock(spec=Character)
+        mock_npc.name = "TestNPC"
+        mock_npc.inventory = []
+        mock_npc.add_player_memory = MagicMock()
         self.game.npcs_in_current_location = [mock_npc]
         self.game.gemini_api.get_npc_dialogue = MagicMock()
 
         success = self.game.handle_use_item("test_banana", "TestNPC", "give")
 
         self.assertFalse(success)
-        self.mock_print_color.assert_any_call("You don't have 'test_banana' to give.", Colors.RED)
-        self.assertEqual(len(mock_npc.inventory), 0) # NPC inventory unchanged
+        self.mock_print_color.assert_any_call(
+            "You don't have 'test_banana' to give.", Colors.RED
+        )
+        self.assertEqual(len(mock_npc.inventory), 0)  # NPC inventory unchanged
         self.game.gemini_api.get_npc_dialogue.assert_not_called()
         mock_npc.add_player_memory.assert_not_called()
 
-    @patch.dict('game_engine.game_config.DEFAULT_ITEMS', {"test_orange": {"description": "A juicy orange."}}, clear=True)
+    @patch.dict(
+        "game_engine.game_config.DEFAULT_ITEMS",
+        {"test_orange": {"description": "A juicy orange."}},
+        clear=True,
+    )
     def test_give_item_npc_not_found(self):
         self.game.player_character.inventory = [{"name": "test_orange", "quantity": 1}]
         self.game.player_character.has_item = MagicMock(return_value=True)
-        self.game.npcs_in_current_location = [] # NPC not here
+        self.game.npcs_in_current_location = []  # NPC not here
 
         self.game.gemini_api.get_npc_dialogue = MagicMock()
 
         success = self.game.handle_use_item("test_orange", "MissingNPC", "give")
 
         self.assertFalse(success)
-        self.mock_print_color.assert_any_call("You don't see 'MissingNPC' here to give anything to.", Colors.RED)
-        self.assertEqual(len(self.game.player_character.inventory), 1) # Player inventory unchanged
+        self.mock_print_color.assert_any_call(
+            "You don't see 'MissingNPC' here to give anything to.", Colors.RED
+        )
+        self.assertEqual(
+            len(self.game.player_character.inventory), 1
+        )  # Player inventory unchanged
         self.game.gemini_api.get_npc_dialogue.assert_not_called()
 
-    @patch.dict('game_engine.game_config.DEFAULT_ITEMS', {
-        "test_pear": {"description": "A green pear.", "stackable": True, "takeable": True, "value": 3}
-    })
-    @patch('random.choice') # To make static fallback predictable
+    @patch.dict(
+        "game_engine.game_config.DEFAULT_ITEMS",
+        {
+            "test_pear": {
+                "description": "A green pear.",
+                "stackable": True,
+                "takeable": True,
+                "value": 3,
+            }
+        },
+    )
+    @patch("random.choice")  # To make static fallback predictable
     def test_give_item_static_fallback_low_ai_mode(self, mock_random_choice):
         self.game.player_character.inventory = [{"name": "test_pear", "quantity": 1}]
         self.game.player_character.remove_from_inventory = MagicMock(return_value=True)
         self.game.player_character.has_item = MagicMock(return_value=True)
 
-        mock_npc = MagicMock(spec=Character); mock_npc.name = "TestNPC"
-        mock_npc.inventory = []; mock_npc.relationship_with_player = 0
+        mock_npc = MagicMock(spec=Character)
+        mock_npc.name = "TestNPC"
+        mock_npc.inventory = []
+        mock_npc.relationship_with_player = 0
         mock_npc.add_to_inventory = MagicMock(return_value=True)
         mock_npc.add_player_memory = MagicMock()
         mock_npc.get_player_memory_summary = MagicMock(return_value="No memories.")
         mock_npc.get_objective_summary = MagicMock(return_value="No objectives.")
         self.game.npcs_in_current_location = [mock_npc]
 
-        self.game.low_ai_data_mode = True # Enable Low AI mode
-        self.game.gemini_api.get_npc_dialogue = MagicMock() # This should not be called
+        self.game.low_ai_data_mode = True  # Enable Low AI mode
+        self.game.gemini_api.get_npc_dialogue = MagicMock()  # This should not be called
 
         static_reaction_choice = "Oh, for me? Thank you for the test_pear."
         mock_random_choice.return_value = static_reaction_choice
@@ -598,10 +926,15 @@ class TestGameStateCommands(unittest.TestCase):
         success = self.game.handle_use_item("test_pear", "TestNPC", "give")
 
         self.assertTrue(success)
-        self.game.player_character.remove_from_inventory.assert_called_once_with("test_pear", 1)
+        self.game.player_character.remove_from_inventory.assert_called_once_with(
+            "test_pear", 1
+        )
         mock_npc.add_to_inventory.assert_called_once_with("test_pear", 1)
-        self.game.gemini_api.get_npc_dialogue.assert_not_called() # Gemini API should not be called in low AI mode
-        self.mock_print_color.assert_any_call(f"{mock_npc.name}: \"{static_reaction_choice}\" {Colors.DIM}(Static reaction){Colors.RESET}", Colors.YELLOW)
+        self.game.gemini_api.get_npc_dialogue.assert_not_called()  # Gemini API should not be called in low AI mode
+        self.mock_print_color.assert_any_call(
+            f'{mock_npc.name}: "{static_reaction_choice}" {Colors.DIM}(Static reaction){Colors.RESET}',
+            Colors.YELLOW,
+        )
         self.assertEqual(mock_npc.relationship_with_player, 1)
         mock_npc.add_player_memory.assert_called_once()
 
@@ -610,20 +943,26 @@ class TestEventManager(unittest.TestCase):
     def setUp(self):
         self.mock_game = MagicMock(spec=Game)
         self.mock_game.gemini_api = MagicMock(spec=GeminiAPI)
-        self.mock_game.gemini_api.model = MagicMock() # Add model attribute here
-        self.mock_game.gemini_api.get_player_reflection = MagicMock(return_value="A deep thought.")
+        self.mock_game.gemini_api.model = MagicMock()  # Add model attribute here
+        self.mock_game.gemini_api.get_player_reflection = MagicMock(
+            return_value="A deep thought."
+        )
         self.mock_game.player_character = MagicMock(spec=Character)
         self.mock_game.player_character.name = "Rodion Raskolnikov"
         self.mock_game.player_character.apparent_state = "thoughtful"
         self.mock_game.player_character.add_player_memory = MagicMock()
-        self.mock_game.player_character.get_objective_by_id = MagicMock(return_value=None)
+        self.mock_game.player_character.get_objective_by_id = MagicMock(
+            return_value=None
+        )
         self.mock_game.player_character.activate_objective = MagicMock()
         self.mock_game.player_character.has_item = MagicMock(return_value=False)
         self.mock_game.player_character.add_to_inventory = MagicMock()
-        self.mock_game.low_ai_data_mode = False # Add the attribute
+        self.mock_game.low_ai_data_mode = False  # Add the attribute
         self.mock_game.current_location_name = "Raskolnikov's Garret"
         self.mock_game.get_current_time_period = MagicMock(return_value="Morning")
-        self.mock_game._get_objectives_summary = MagicMock(return_value="Some objectives.")
+        self.mock_game._get_objectives_summary = MagicMock(
+            return_value="Some objectives."
+        )
         self.mock_game._print_color = MagicMock()
         self.mock_game.last_significant_event_summary = ""
         self.mock_game.key_events_occurred = []
@@ -634,23 +973,40 @@ class TestEventManager(unittest.TestCase):
         self.event_manager.action_letter_from_mother()
         self.mock_game.gemini_api.get_player_reflection.assert_called_once()
         args, kwargs = self.mock_game.gemini_api.get_player_reflection.call_args
-        self.assertEqual(kwargs.get('player_character'), self.mock_game.player_character)
-        self.assertEqual(kwargs.get('current_location_name'), self.mock_game.current_location_name)
-        self.assertEqual(kwargs.get('current_time_period'), self.mock_game.get_current_time_period.return_value)
-        self.assertIn('context_text', kwargs)
-        self.assertEqual(kwargs.get('active_objectives_summary'), self.mock_game._get_objectives_summary.return_value)
-        self.assertNotIn('player_char_obj', kwargs)
-        self.assertNotIn('context_string', kwargs)
-        self.assertNotIn('objectives_summary', kwargs)
+        self.assertEqual(
+            kwargs.get("player_character"), self.mock_game.player_character
+        )
+        self.assertEqual(
+            kwargs.get("current_location_name"), self.mock_game.current_location_name
+        )
+        self.assertEqual(
+            kwargs.get("current_time_period"),
+            self.mock_game.get_current_time_period.return_value,
+        )
+        self.assertIn("context_text", kwargs)
+        self.assertEqual(
+            kwargs.get("active_objectives_summary"),
+            self.mock_game._get_objectives_summary.return_value,
+        )
+        self.assertNotIn("player_char_obj", kwargs)
+        self.assertNotIn("context_string", kwargs)
+        self.assertNotIn("objectives_summary", kwargs)
 
-@patch.dict('game_engine.game_config.DEFAULT_ITEMS', TEST_GAME_ITEMS, clear=True)
+
+@patch.dict("game_engine.game_config.DEFAULT_ITEMS", TEST_GAME_ITEMS, clear=True)
 class TestItemEffects(unittest.TestCase):
     def setUp(self):
-        self.mock_gemini_configure = patch.object(GeminiAPI, 'configure').start()
+        self.mock_gemini_configure = patch.object(GeminiAPI, "configure").start()
         self.game = Game()
         self.game.gemini_api = MagicMock(spec=GeminiAPI)
-        self.game.gemini_api.model = MagicMock() # Add the model attribute
-        self.player = Character(name="TestPlayer", persona="P", greeting="G", default_location="TestLocation", accessible_locations=["TestLocation"])
+        self.game.gemini_api.model = MagicMock()  # Add the model attribute
+        self.player = Character(
+            name="TestPlayer",
+            persona="P",
+            greeting="G",
+            default_location="TestLocation",
+            accessible_locations=["TestLocation"],
+        )
         self.player.inventory = []
         self.player.apparent_state = "normal"
         self.player.journal_entries = []
@@ -660,7 +1016,9 @@ class TestItemEffects(unittest.TestCase):
         self.game.game_time = 100
         self.game.current_location_name = "TestLocation"
         self.game._print_color = MagicMock()
-        self.game._get_current_game_time_period_str = MagicMock(return_value="Day 1, Morning")
+        self.game._get_current_game_time_period_str = MagicMock(
+            return_value="Day 1, Morning"
+        )
 
     def tearDown(self):
         patch.stopall()
@@ -668,58 +1026,95 @@ class TestItemEffects(unittest.TestCase):
     def test_use_tattered_handkerchief_when_ill(self):
         self.player.apparent_state = "feverish"
         self.player.inventory.append({"name": "tattered handkerchief", "quantity": 1})
-        with patch('random.random', return_value=0.1):
-            self.game.handle_use_item("tattered handkerchief", None, "use_self_implicit")
+        with patch("random.random", return_value=0.1):
+            self.game.handle_use_item(
+                "tattered handkerchief", None, "use_self_implicit"
+            )
         self.assertIn(self.player.apparent_state, ["less feverish", "feverish"])
         if self.player.apparent_state == "less feverish":
-            self.game._print_color.assert_any_call("The coolness, imagined or real, seems to lessen the fever's grip for a moment.", Colors.CYAN)
-        self.assertEqual(self.game.last_significant_event_summary, "used a tattered handkerchief while feeling unwell.")
+            self.game._print_color.assert_any_call(
+                "The coolness, imagined or real, seems to lessen the fever's grip for a moment.",
+                Colors.CYAN,
+            )
+        self.assertEqual(
+            self.game.last_significant_event_summary,
+            "used a tattered handkerchief while feeling unwell.",
+        )
 
     def test_use_tattered_handkerchief_when_normal(self):
         self.player.apparent_state = "normal"
         self.player.inventory.append({"name": "tattered handkerchief", "quantity": 1})
         self.game.handle_use_item("tattered handkerchief", None, "use_self_implicit")
         self.assertEqual(self.player.apparent_state, "normal")
-        self.game._print_color.assert_any_call(f"You look at the tattered handkerchief. It seems rather pointless to use it now.", Colors.YELLOW)
+        self.game._print_color.assert_any_call(
+            "You look at the tattered handkerchief. It seems rather pointless to use it now.",
+            Colors.YELLOW,
+        )
 
     def test_use_raskolnikovs_axe_as_raskolnikov(self):
         self.player.name = "Rodion Raskolnikov"
         self.player.inventory.append({"name": "raskolnikov's axe", "quantity": 1})
         self.game.handle_use_item("raskolnikov's axe", None, "use_self_implicit")
-        self.assertIn(self.player.apparent_state, ["dangerously agitated", "remorseful", "paranoid"])
+        self.assertIn(
+            self.player.apparent_state,
+            ["dangerously agitated", "remorseful", "paranoid"],
+        )
 
     def test_use_cheap_vodka(self):
         self.player.inventory.append({"name": "cheap vodka", "quantity": 1})
         self.game.handle_use_item("cheap vodka", None, "use_self_implicit")
         self.assertEqual(self.player.apparent_state, "slightly drunk")
-        self.assertFalse(any(item["name"] == "cheap vodka" for item in self.player.inventory), "Vodka should be consumed")
-        self.assertEqual(self.game.last_significant_event_summary, "drank some cheap vodka to numb the thoughts.")
+        self.assertFalse(
+            any(item["name"] == "cheap vodka" for item in self.player.inventory),
+            "Vodka should be consumed",
+        )
+        self.assertEqual(
+            self.game.last_significant_event_summary,
+            "drank some cheap vodka to numb the thoughts.",
+        )
 
     def test_use_cheap_vodka_when_feverish(self):
         self.player.apparent_state = "feverish"
         self.player.inventory.append({"name": "cheap vodka", "quantity": 1})
         self.game.handle_use_item("cheap vodka", None, "use_self_implicit")
         self.assertEqual(self.player.apparent_state, "agitated")
-        self.game._print_color.assert_any_call("The vodka clashes terribly with your fever, making you feel worse.", Colors.RED)
+        self.game._print_color.assert_any_call(
+            "The vodka clashes terribly with your fever, making you feel worse.",
+            Colors.RED,
+        )
 
     def test_read_newspaper(self):
         self.player.inventory.append({"name": "fresh newspaper", "quantity": 1})
         self.player.add_journal_entry = MagicMock()
-        self.game.gemini_api.get_newspaper_article_snippet = MagicMock(return_value="A terrible crime was reported...")
+        self.game.gemini_api.get_newspaper_article_snippet = MagicMock(
+            return_value="A terrible crime was reported..."
+        )
         self.game.handle_use_item("fresh newspaper", None, "read")
         self.game.gemini_api.get_newspaper_article_snippet.assert_called_once()
-        self.player.add_journal_entry.assert_called_once_with("News (AI)", "A terrible crime was reported...", "Day 1, Morning") # Updated "News" to "News (AI)"
+        self.player.add_journal_entry.assert_called_once_with(
+            "News (AI)", "A terrible crime was reported...", "Day 1, Morning"
+        )  # Updated "News" to "News (AI)"
         self.assertEqual(self.player.apparent_state, "thoughtful")
 
     def test_read_mothers_letter_as_raskolnikov(self):
         self.player.name = "Rodion Raskolnikov"
         self.player.inventory.append({"name": "mother's letter", "quantity": 1})
         self.player.add_player_memory = MagicMock()
-        self.game.gemini_api.get_player_reflection = MagicMock(return_value="A reflection about family.")
+        self.game.gemini_api.get_player_reflection = MagicMock(
+            return_value="A reflection about family."
+        )
         self.game.handle_use_item("mother's letter", None, "read")
         self.game.gemini_api.get_player_reflection.assert_called_once()
-        self.player.add_player_memory.assert_called_once_with(memory_type="reread_mother_letter", turn=self.game.game_time, content={"summary": "Re-reading mother's letter intensified feelings of duty and distress."}, sentiment_impact=-1)
+        self.player.add_player_memory.assert_called_once_with(
+            memory_type="reread_mother_letter",
+            turn=self.game.game_time,
+            content={
+                "summary": "Re-reading mother's letter intensified feelings of duty and distress."
+            },
+            sentiment_impact=-1,
+        )
         self.assertIn(self.player.apparent_state, ["burdened", "agitated", "resolved"])
+
 
 class TestCharacterObjectives(unittest.TestCase):
     def setUp(self):
@@ -728,21 +1123,38 @@ class TestCharacterObjectives(unittest.TestCase):
             persona="Objective Tester",
             greeting="Hi",
             default_location="TestRoom",
-            accessible_locations=["TestRoom"]
+            accessible_locations=["TestRoom"],
         )
         self.obj_template_1 = {
-            "id": "quest1", "description": "Main Quest", "active": False, "completed": False,
+            "id": "quest1",
+            "description": "Main Quest",
+            "active": False,
+            "completed": False,
             "stages": [
                 {"stage_id": "s1", "description": "Start", "is_current_stage": False},
                 {"stage_id": "s2", "description": "Middle", "is_current_stage": False},
-                {"stage_id": "s3", "description": "End", "is_current_stage": False, "is_ending_stage": True}
+                {
+                    "stage_id": "s3",
+                    "description": "End",
+                    "is_current_stage": False,
+                    "is_ending_stage": True,
+                },
             ],
-            "current_stage_id": None
+            "current_stage_id": None,
         }
         self.obj_template_2 = {
-            "id": "quest2", "description": "Side Quest", "active": False, "completed": False,
-            "stages": [{"stage_id": "start_q2", "description": "Q2 Start", "is_current_stage": False}],
-            "current_stage_id": None
+            "id": "quest2",
+            "description": "Side Quest",
+            "active": False,
+            "completed": False,
+            "stages": [
+                {
+                    "stage_id": "start_q2",
+                    "description": "Q2 Start",
+                    "is_current_stage": False,
+                }
+            ],
+            "current_stage_id": None,
         }
         self.char.objectives = []
 
@@ -752,19 +1164,19 @@ class TestCharacterObjectives(unittest.TestCase):
 
         self.char.activate_objective("quest1")
         obj = self.char.get_objective_by_id("quest1")
-        self.assertTrue(obj['active'])
-        self.assertFalse(obj['completed'])
-        self.assertEqual(obj['current_stage_id'], "s1")
-        self.assertTrue(obj['stages'][0]['is_current_stage'])
+        self.assertTrue(obj["active"])
+        self.assertFalse(obj["completed"])
+        self.assertEqual(obj["current_stage_id"], "s1")
+        self.assertTrue(obj["stages"][0]["is_current_stage"])
 
         # Test activating with a specific stage
         obj1_copy_2 = copy.deepcopy(self.obj_template_1)
-        self.char.objectives = [obj1_copy_2] # Reset objectives
+        self.char.objectives = [obj1_copy_2]  # Reset objectives
         self.char.activate_objective("quest1", set_stage_id="s2")
         obj_2 = self.char.get_objective_by_id("quest1")
-        self.assertTrue(obj_2['active'])
-        self.assertEqual(obj_2['current_stage_id'], "s2")
-        self.assertTrue(obj_2['stages'][1]['is_current_stage'])
+        self.assertTrue(obj_2["active"])
+        self.assertEqual(obj_2["current_stage_id"], "s2")
+        self.assertTrue(obj_2["stages"][1]["is_current_stage"])
 
     def test_get_objective_by_id(self):
         obj1_copy = copy.deepcopy(self.obj_template_1)
@@ -778,7 +1190,7 @@ class TestCharacterObjectives(unittest.TestCase):
         self.char.activate_objective("quest1")
         current_stage = self.char.get_current_stage_for_objective("quest1")
         self.assertIsNotNone(current_stage)
-        self.assertEqual(current_stage['stage_id'], "s1")
+        self.assertEqual(current_stage["stage_id"], "s1")
 
     def test_advance_objective_stage(self):
         obj1_copy = copy.deepcopy(self.obj_template_1)
@@ -787,24 +1199,28 @@ class TestCharacterObjectives(unittest.TestCase):
 
         self.assertTrue(self.char.advance_objective_stage("quest1", "s2"))
         obj = self.char.get_objective_by_id("quest1")
-        self.assertEqual(obj['current_stage_id'], "s2")
-        self.assertTrue(obj['stages'][1]['is_current_stage'])
-        self.assertFalse(obj['stages'][0]['is_current_stage'])
-        self.assertTrue(obj['active'])
-        self.assertFalse(obj['completed'])
+        self.assertEqual(obj["current_stage_id"], "s2")
+        self.assertTrue(obj["stages"][1]["is_current_stage"])
+        self.assertFalse(obj["stages"][0]["is_current_stage"])
+        self.assertTrue(obj["active"])
+        self.assertFalse(obj["completed"])
 
-        self.assertFalse(self.char.advance_objective_stage("quest1", "non_existent_stage"))
+        self.assertFalse(
+            self.char.advance_objective_stage("quest1", "non_existent_stage")
+        )
 
     def test_advance_to_ending_stage_completes_objective(self):
         obj1_copy = copy.deepcopy(self.obj_template_1)
         self.char.objectives.append(obj1_copy)
         self.char.activate_objective("quest1")
 
-        self.assertTrue(self.char.advance_objective_stage("quest1", "s3")) # s3 is an ending stage
+        self.assertTrue(
+            self.char.advance_objective_stage("quest1", "s3")
+        )  # s3 is an ending stage
         obj = self.char.get_objective_by_id("quest1")
-        self.assertEqual(obj['current_stage_id'], "s3")
-        self.assertTrue(obj['completed'])
-        self.assertFalse(obj['active'])
+        self.assertEqual(obj["current_stage_id"], "s3")
+        self.assertTrue(obj["completed"])
+        self.assertFalse(obj["active"])
 
     def test_complete_objective_directly(self):
         obj1_copy = copy.deepcopy(self.obj_template_1)
@@ -813,57 +1229,66 @@ class TestCharacterObjectives(unittest.TestCase):
 
         self.assertTrue(self.char.complete_objective("quest1"))
         obj = self.char.get_objective_by_id("quest1")
-        self.assertTrue(obj['completed'])
-        self.assertFalse(obj['active'])
+        self.assertTrue(obj["completed"])
+        self.assertFalse(obj["active"])
 
     def test_objective_linking_on_completion_activates_inactive_linked_objective(self):
         obj1_linked = copy.deepcopy(self.obj_template_1)
-        obj1_linked['stages'][-1]['linked_to_objective_completion'] = "quest2"
+        obj1_linked["stages"][-1]["linked_to_objective_completion"] = "quest2"
 
         obj2_for_linking = copy.deepcopy(self.obj_template_2)
-        obj2_for_linking['active'] = False
+        obj2_for_linking["active"] = False
 
         self.char.objectives = [obj1_linked, obj2_for_linking]
         self.char.activate_objective("quest1")
 
         # Advance to the linking/ending stage of quest1
-        self.char.advance_objective_stage("quest1", obj1_linked['stages'][-1]['stage_id'])
+        self.char.advance_objective_stage(
+            "quest1", obj1_linked["stages"][-1]["stage_id"]
+        )
 
         linked_obj = self.char.get_objective_by_id("quest2")
         self.assertIsNotNone(linked_obj)
-        self.assertTrue(linked_obj['active'])
-        self.assertEqual(linked_obj['current_stage_id'], linked_obj['stages'][0]['stage_id'])
+        self.assertTrue(linked_obj["active"])
+        self.assertEqual(
+            linked_obj["current_stage_id"], linked_obj["stages"][0]["stage_id"]
+        )
 
-    def test_objective_linking_on_completion_advances_active_linked_objective_to_specific_stage(self):
+    def test_objective_linking_on_completion_advances_active_linked_objective_to_specific_stage(
+        self,
+    ):
         obj1_linked = copy.deepcopy(self.obj_template_1)
-        obj1_linked['stages'][-1]['linked_to_objective_completion'] = {"id": "quest2", "stage_to_advance_to": "q2_middle"}
+        obj1_linked["stages"][-1]["linked_to_objective_completion"] = {
+            "id": "quest2",
+            "stage_to_advance_to": "q2_middle",
+        }
 
         obj2_for_linking = copy.deepcopy(self.obj_template_2)
-        obj2_for_linking['stages'].append({"stage_id": "q2_middle", "description": "Q2 Middle", "is_current_stage": False})
+        obj2_for_linking["stages"].append(
+            {
+                "stage_id": "q2_middle",
+                "description": "Q2 Middle",
+                "is_current_stage": False,
+            }
+        )
 
         self.char.objectives = [obj1_linked, obj2_for_linking]
         self.char.activate_objective("quest1")
-        self.char.activate_objective("quest2") # Quest2 is already active, at "start_q2"
+        self.char.activate_objective(
+            "quest2"
+        )  # Quest2 is already active, at "start_q2"
 
-        self.char.advance_objective_stage("quest1", obj1_linked['stages'][-1]['stage_id'])
+        self.char.advance_objective_stage(
+            "quest1", obj1_linked["stages"][-1]["stage_id"]
+        )
 
         linked_obj = self.char.get_objective_by_id("quest2")
         self.assertIsNotNone(linked_obj)
-        self.assertTrue(linked_obj['active'])
-        self.assertEqual(linked_obj['current_stage_id'], "q2_middle")
+        self.assertTrue(linked_obj["active"])
+        self.assertEqual(linked_obj["current_stage_id"], "q2_middle")
 
 
 # --- Tests for Low AI Data Mode ---
-import io # For mocking open
-from game_engine.game_config import (
-    STATIC_ATMOSPHERIC_DETAILS, STATIC_PLAYER_REFLECTIONS,
-    generate_static_scenery_observation, STATIC_NEWSPAPER_SNIPPETS,
-    STATIC_ANONYMOUS_NOTE_CONTENT, STATIC_STREET_LIFE_EVENTS,
-    STATIC_NPC_NPC_INTERACTIONS
-)
-# Import constant for TestGeminiAPIConfiguration
-from game_engine.gemini_interactions import GEMINI_API_KEY_ENV_VAR
-
 
 # Mock CHARACTERS_DATA for TestLowAIMode setup
 TEST_CHAR_DATA_FOR_LOW_AI = {
@@ -872,84 +1297,116 @@ TEST_CHAR_DATA_FOR_LOW_AI = {
         "greeting": "Hello.",
         "default_location": "Test Chamber",
         "accessible_locations": ["Test Chamber"],
-        "non_playable": False, # Ensure it's playable
+        "non_playable": False,  # Ensure it's playable
         "objectives": [],
         "inventory_items": [],
-        "schedule": {}
+        "schedule": {},
     },
     "TestNPC1": {
-        "persona": "NPC one", "greeting": "Hi NPC1",
-        "default_location": "Test Chamber", "accessible_locations": ["Test Chamber"]
+        "persona": "NPC one",
+        "greeting": "Hi NPC1",
+        "default_location": "Test Chamber",
+        "accessible_locations": ["Test Chamber"],
     },
     "TestNPC2": {
-        "persona": "NPC two", "greeting": "Hi NPC2",
-        "default_location": "Test Chamber", "accessible_locations": ["Test Chamber"]
-    }
+        "persona": "NPC two",
+        "greeting": "Hi NPC2",
+        "default_location": "Test Chamber",
+        "accessible_locations": ["Test Chamber"],
+    },
 }
 # Mock LOCATIONS_DATA for TestLowAIMode setup
 TEST_LOC_DATA_FOR_LOW_AI = {
     "Test Chamber": {
         "description": "A plain room for testing.",
         "exits": {"north": "Another Room"},
-        "items_present": []
+        "items_present": [],
     },
-     "Raskolnikov's Garret": { # For letter event
-        "description": "A tiny garret.", "exits": {}
+    "Raskolnikov's Garret": {  # For letter event
+        "description": "A tiny garret.",
+        "exits": {},
     },
-    "Haymarket Square": { # For street life event
-        "description": "A bustling square.", "exits": {}
-    }
+    "Haymarket Square": {  # For street life event
+        "description": "A bustling square.",
+        "exits": {},
+    },
 }
 # Mock DEFAULT_ITEMS for TestLowAIMode (especially for anonymous note)
 TEST_DEFAULT_ITEMS_LOW_AI = {
-    "anonymous note": {"description": "A mysterious note.", "readable": True, "takeable": True}
+    "anonymous note": {
+        "description": "A mysterious note.",
+        "readable": True,
+        "takeable": True,
+    }
 }
 
 
-@patch.dict('game_engine.character_module.CHARACTERS_DATA', TEST_CHAR_DATA_FOR_LOW_AI, clear=True)
-@patch.dict('game_engine.location_module.LOCATIONS_DATA', TEST_LOC_DATA_FOR_LOW_AI, clear=True)
-@patch.dict('game_engine.game_config.DEFAULT_ITEMS', TEST_DEFAULT_ITEMS_LOW_AI, clear=True)
+@patch.dict(
+    "game_engine.character_module.CHARACTERS_DATA",
+    TEST_CHAR_DATA_FOR_LOW_AI,
+    clear=True,
+)
+@patch.dict(
+    "game_engine.location_module.LOCATIONS_DATA", TEST_LOC_DATA_FOR_LOW_AI, clear=True
+)
+@patch.dict(
+    "game_engine.game_config.DEFAULT_ITEMS", TEST_DEFAULT_ITEMS_LOW_AI, clear=True
+)
 class TestLowAIMode(unittest.TestCase):
     def setUp(self):
         self.game = Game()
         # Simplified setup: directly initialize player without selection process
         self.game.all_character_objects = {
-            name: Character.from_dict({"name": name, "is_player": (name == "TestPlayer")}, data)
+            name: Character.from_dict(
+                {"name": name, "is_player": (name == "TestPlayer")}, data
+            )
             for name, data in TEST_CHAR_DATA_FOR_LOW_AI.items()
         }
         self.game.player_character = self.game.all_character_objects["TestPlayer"]
         self.game.player_character.is_player = True
         self.game.current_location_name = self.game.player_character.default_location
-        self.game.world_manager.initialize_dynamic_location_items() # Ensure items are initialized
+        self.game.world_manager.initialize_dynamic_location_items()  # Ensure items are initialized
         self.game.world_manager.update_npcs_in_current_location()
 
         self.game.gemini_api = MagicMock(spec=GeminiAPI)
-        self.game.gemini_api.model = MagicMock() # Simulate that a model is available by default
-        self.game.gemini_api.chosen_model_name = "test_low_ai_model" # Add for save/load
-        self.game.event_manager = EventManager(self.game) # Re-init with mocked game
+        self.game.gemini_api.model = (
+            MagicMock()
+        )  # Simulate that a model is available by default
+        self.game.gemini_api.chosen_model_name = (
+            "test_low_ai_model"  # Add for save/load
+        )
+        self.game.event_manager = EventManager(self.game)  # Re-init with mocked game
 
         # Common mocks
-        self.mock_print_color = patch.object(self.game, '_print_color').start()
-        self.mock_input_color = patch.object(self.game, '_input_color').start() # Added this
-        self.mock_random_choice = patch('random.choice').start()
+        self.mock_print_color = patch.object(self.game, "_print_color").start()
+        self.mock_input_color = patch.object(
+            self.game, "_input_color"
+        ).start()  # Added this
+        self.mock_random_choice = patch("random.choice").start()
 
     def tearDown(self):
         patch.stopall()
 
     def test_toggle_low_ai_data_mode(self):
-        self.assertFalse(self.game.low_ai_data_mode, "Low AI mode should be False initially.")
+        self.assertFalse(
+            self.game.low_ai_data_mode, "Low AI mode should be False initially."
+        )
 
         # First toggle: ON
         self.game.command_handler._process_command("toggle_lowai", None)
         self.assertTrue(self.game.low_ai_data_mode)
-        self.mock_print_color.assert_called_with("Low AI Data Mode is now ON.", Colors.MAGENTA)
+        self.mock_print_color.assert_called_with(
+            "Low AI Data Mode is now ON.", Colors.MAGENTA
+        )
 
         # Second toggle: OFF
         self.game.command_handler._process_command("toggle_lowai", None)
         self.assertFalse(self.game.low_ai_data_mode)
-        self.mock_print_color.assert_called_with("Low AI Data Mode is now OFF.", Colors.MAGENTA)
+        self.mock_print_color.assert_called_with(
+            "Low AI Data Mode is now OFF.", Colors.MAGENTA
+        )
 
-    @patch('game_engine.game_state.SAVE_GAME_FILE', "test_savegame_low_ai.json")
+    @patch("game_engine.game_state.SAVE_GAME_FILE", "test_savegame_low_ai.json")
     def test_low_ai_data_mode_save_and_load(self):
         # Ensure file does not exist from previous failed run
         if os.path.exists("test_savegame_low_ai.json"):
@@ -964,13 +1421,17 @@ class TestLowAIMode(unittest.TestCase):
         # Create a new game instance to simulate loading from scratch
         new_game = Game()
         # Minimal setup for load_game to run without crashing
-        new_game.gemini_api = MagicMock(spec=GeminiAPI) # Mock API for new instance too
-        new_game.gemini_api.chosen_model_name = None # It would be None before load typically
-        new_game._print_color = MagicMock() # Mock print for new instance
+        new_game.gemini_api = MagicMock(spec=GeminiAPI)  # Mock API for new instance too
+        new_game.gemini_api.chosen_model_name = (
+            None  # It would be None before load typically
+        )
+        new_game._print_color = MagicMock()  # Mock print for new instance
 
         loaded_successfully = new_game.load_game()
         self.assertTrue(loaded_successfully, "Game should load successfully.")
-        self.assertTrue(new_game.low_ai_data_mode, "Low AI mode should be True after loading.")
+        self.assertTrue(
+            new_game.low_ai_data_mode, "Low AI mode should be True after loading."
+        )
 
         # Clean up the test save file
         if os.path.exists("test_savegame_low_ai.json"):
@@ -984,7 +1445,10 @@ class TestLowAIMode(unittest.TestCase):
         self.mock_random_choice.return_value = expected_detail
 
         # Ensure STATIC_ATMOSPHERIC_DETAILS is not empty for random.choice
-        with patch('game_engine.game_state.STATIC_ATMOSPHERIC_DETAILS', [expected_detail, "Another detail"]):
+        with patch(
+            "game_engine.game_state.STATIC_ATMOSPHERIC_DETAILS",
+            [expected_detail, "Another detail"],
+        ):
             self.game.display_atmospheric_details()
 
         self.mock_print_color.assert_any_call(f"\n{expected_detail}", Colors.CYAN)
@@ -997,23 +1461,33 @@ class TestLowAIMode(unittest.TestCase):
         expected_reflection = "You ponder your next move."
         self.mock_random_choice.return_value = expected_reflection
 
-        with patch('game_engine.item_interaction_handler.STATIC_PLAYER_REFLECTIONS', [expected_reflection, "Another thought"]):
+        with patch(
+            "game_engine.item_interaction_handler.STATIC_PLAYER_REFLECTIONS",
+            [expected_reflection, "Another thought"],
+        ):
             self.game._handle_think_command()
 
-        self.mock_print_color.assert_any_call(f"Inner thought: \"{expected_reflection}\"", Colors.GREEN)
+        self.mock_print_color.assert_any_call(
+            f'Inner thought: "{expected_reflection}"', Colors.GREEN
+        )
         self.game.gemini_api.get_player_reflection.assert_not_called()
 
     def test_look_at_scenery_low_ai_mode(self):
         self.game.low_ai_data_mode = True
         self.game.gemini_api.get_scenery_observation = MagicMock()
-        self.game.gemini_api.get_enhanced_observation = MagicMock() # Also mock this as it's in the same path
+        self.game.gemini_api.get_enhanced_observation = (
+            MagicMock()
+        )  # Also mock this as it's in the same path
 
         scenery_target = "window"
         # generate_static_scenery_observation returns one of a few options
         # We don't need to mock random.choice here if we check for partial static output.
         # However, to be precise, we can mock the function itself.
         expected_scenery_obs = f"You observe the {scenery_target}. It is as it seems."
-        with patch('game_engine.item_interaction_handler.generate_static_scenery_observation', return_value=expected_scenery_obs):
+        with patch(
+            "game_engine.item_interaction_handler.generate_static_scenery_observation",
+            return_value=expected_scenery_obs,
+        ):
             self.game._handle_look_command(scenery_target)
 
         # Check if the static observation was printed (color might vary based on implementation)
@@ -1027,12 +1501,15 @@ class TestLowAIMode(unittest.TestCase):
         # (This depends on how base_desc_for_skill_check is handled for static scenery)
         # For now, we just ensure the primary AI call is skipped. A more robust test would check base_desc.
 
-    @patch('game_engine.item_interaction_handler.DEFAULT_ITEMS', {
-        "fresh newspaper": {"description": "Today's news.", "readable": True}
-    })
+    @patch(
+        "game_engine.item_interaction_handler.DEFAULT_ITEMS",
+        {"fresh newspaper": {"description": "Today's news.", "readable": True}},
+    )
     def test_read_newspaper_low_ai_mode(self):
         self.game.low_ai_data_mode = True
-        self.game.player_character.inventory = [{"name": "fresh newspaper", "quantity": 1}]
+        self.game.player_character.inventory = [
+            {"name": "fresh newspaper", "quantity": 1}
+        ]
         self.game.gemini_api.get_newspaper_article_snippet = MagicMock()
 
         expected_snippet = "The headlines are dull today."
@@ -1040,12 +1517,19 @@ class TestLowAIMode(unittest.TestCase):
 
         # Ensure the item exists in player's inventory for _handle_read_item
         # The _handle_read_item is called from handle_use_item
-        with patch('game_engine.game_state.STATIC_NEWSPAPER_SNIPPETS', [expected_snippet, "Other news."]):
-             self.game.handle_use_item("fresh newspaper", None, "read") # Correct way to trigger _handle_read_item
+        with patch(
+            "game_engine.game_state.STATIC_NEWSPAPER_SNIPPETS",
+            [expected_snippet, "Other news."],
+        ):
+            self.game.handle_use_item(
+                "fresh newspaper", None, "read"
+            )  # Correct way to trigger _handle_read_item
 
         # Static newspaper snippets are printed with YELLOW in the current implementation if AI was not attempted
         # but if low_ai_data_mode is true, it's CYAN.
-        self.mock_print_color.assert_any_call(f"An article catches your eye: \"{expected_snippet}\"", Colors.CYAN)
+        self.mock_print_color.assert_any_call(
+            f'An article catches your eye: "{expected_snippet}"', Colors.CYAN
+        )
         self.game.gemini_api.get_newspaper_article_snippet.assert_not_called()
 
     # --- Tests for EventManager with Low AI Mode ---
@@ -1053,17 +1537,22 @@ class TestLowAIMode(unittest.TestCase):
         self.game.low_ai_data_mode = True
         self.game.gemini_api.get_player_reflection = MagicMock()
         # Specific setup for this event if needed, e.g., player location
-        self.game.player_character.name = "Rodion Raskolnikov" # Event is specific to him
+        self.game.player_character.name = (
+            "Rodion Raskolnikov"  # Event is specific to him
+        )
         self.game.current_location_name = "Raskolnikov's Garret"
 
         expected_reflection = "The letter brings a wave of despair."
         self.mock_random_choice.return_value = expected_reflection
 
-        with patch('game_engine.event_manager.STATIC_PLAYER_REFLECTIONS', [expected_reflection, "Other thoughts."]):
+        with patch(
+            "game_engine.event_manager.STATIC_PLAYER_REFLECTIONS",
+            [expected_reflection, "Other thoughts."],
+        ):
             self.game.event_manager.action_letter_from_mother()
 
         printed_text = " ".join(c[0][0] for c in self.mock_print_color.call_args_list)
-        self.assertIn(f"Your thoughts race: \"{expected_reflection}\"", printed_text)
+        self.assertIn(f'Your thoughts race: "{expected_reflection}"', printed_text)
         self.game.gemini_api.get_player_reflection.assert_not_called()
 
     def test_event_action_find_anonymous_note_low_ai_mode(self):
@@ -1077,12 +1566,18 @@ class TestLowAIMode(unittest.TestCase):
 
         # Check that the static content was used to create the note
         found_note = False
-        for item_data in self.game.dynamic_location_items.get(self.game.current_location_name, []):
+        for item_data in self.game.dynamic_location_items.get(
+            self.game.current_location_name, []
+        ):
             if item_data["name"] == "anonymous note":
-                self.assertEqual(item_data.get("generated_content"), STATIC_ANONYMOUS_NOTE_CONTENT)
+                self.assertEqual(
+                    item_data.get("generated_content"), STATIC_ANONYMOUS_NOTE_CONTENT
+                )
                 found_note = True
                 break
-        self.assertTrue(found_note, "anonymous note with static content should be created.")
+        self.assertTrue(
+            found_note, "anonymous note with static content should be created."
+        )
         self.game.gemini_api.get_generated_text_document.assert_not_called()
 
     def test_event_attempt_npc_npc_interaction_low_ai_mode(self):
@@ -1097,24 +1592,36 @@ class TestLowAIMode(unittest.TestCase):
         expected_interaction = "NPC1 and NPC2 nod at each other."
         self.mock_random_choice.return_value = expected_interaction
 
-        with patch('game_engine.event_manager.STATIC_NPC_NPC_INTERACTIONS', [expected_interaction, "Other interaction."]):
+        with patch(
+            "game_engine.event_manager.STATIC_NPC_NPC_INTERACTIONS",
+            [expected_interaction, "Other interaction."],
+        ):
             self.game.event_manager.attempt_npc_npc_interaction()
 
-        printed_text = " ".join(c[0][0] for c in self.mock_print_color.call_args_list if isinstance(c[0][0], str))
+        printed_text = " ".join(
+            c[0][0]
+            for c in self.mock_print_color.call_args_list
+            if isinstance(c[0][0], str)
+        )
         # The static interactions might have newlines or specific formatting
         # We'll check if the core text is present.
-        self.assertIn(expected_interaction.split(":")[0], printed_text) # Check for at least part of it
+        self.assertIn(
+            expected_interaction.split(":")[0], printed_text
+        )  # Check for at least part of it
         self.game.gemini_api.get_npc_to_npc_interaction.assert_not_called()
 
     def test_event_action_street_life_haymarket_low_ai_mode(self):
         self.game.low_ai_data_mode = True
         self.game.gemini_api.get_street_life_event_description = MagicMock()
-        self.game.current_location_name = "Haymarket Square" # Event specific location
+        self.game.current_location_name = "Haymarket Square"  # Event specific location
 
         expected_description = "A vendor shouts his wares."
         self.mock_random_choice.return_value = expected_description
 
-        with patch('game_engine.event_manager.STATIC_STREET_LIFE_EVENTS', [expected_description, "Something else happens."]):
+        with patch(
+            "game_engine.event_manager.STATIC_STREET_LIFE_EVENTS",
+            [expected_description, "Something else happens."],
+        ):
             self.game.event_manager.action_street_life_haymarket()
 
         printed_text = " ".join(c[0][0] for c in self.mock_print_color.call_args_list)
@@ -1126,7 +1633,9 @@ class TestLowAIMode(unittest.TestCase):
         self.game.low_ai_data_mode = False
 
         ai_generated_detail = "A truly unique atmospheric detail from AI."
-        self.game.gemini_api.get_atmospheric_details = MagicMock(return_value=ai_generated_detail)
+        self.game.gemini_api.get_atmospheric_details = MagicMock(
+            return_value=ai_generated_detail
+        )
 
         self.game.display_atmospheric_details()
 
@@ -1134,77 +1643,133 @@ class TestLowAIMode(unittest.TestCase):
         self.mock_print_color.assert_any_call(f"\n{ai_generated_detail}", Colors.CYAN)
 
     # --- Tests for Game._initialize_game() ---
-    @patch.object(WorldManager, 'load_all_characters') # Mock to prevent full character setup
-    @patch.object(WorldManager, 'select_player_character') # Mock to prevent interactive player selection
-    @patch.object(WorldManager, 'update_current_location_details')
-    @patch.object(Game, 'display_atmospheric_details')
-    @patch.object(Game, 'display_help')
-    def test_initialize_game_sets_low_ai_mode_from_configure_yes(self, mock_disp_help, mock_disp_atm, mock_upd_loc, mock_sel_player, mock_load_chars):
+    @patch.object(
+        WorldManager, "load_all_characters"
+    )  # Mock to prevent full character setup
+    @patch.object(
+        WorldManager, "select_player_character"
+    )  # Mock to prevent interactive player selection
+    @patch.object(WorldManager, "update_current_location_details")
+    @patch.object(Game, "display_atmospheric_details")
+    @patch.object(Game, "display_help")
+    def test_initialize_game_sets_low_ai_mode_from_configure_yes(
+        self,
+        mock_disp_help,
+        mock_disp_atm,
+        mock_upd_loc,
+        mock_sel_player,
+        mock_load_chars,
+    ):
         # Mock configure to return Low AI Mode = True
-        self.game.gemini_api.configure = MagicMock(return_value={"api_configured": True, "low_ai_preference": True})
+        self.game.gemini_api.configure = MagicMock(
+            return_value={"api_configured": True, "low_ai_preference": True}
+        )
         # Mock input for "load or new game" prompt to select new game
         self.mock_input_color.return_value = ""
-        mock_sel_player.return_value = True # Ensure select_player_character indicates success
+        mock_sel_player.return_value = (
+            True  # Ensure select_player_character indicates success
+        )
 
         self.game._initialize_game()
         self.assertTrue(self.game.low_ai_data_mode)
 
-    @patch.object(WorldManager, 'load_all_characters')
-    @patch.object(WorldManager, 'select_player_character')
-    @patch.object(WorldManager, 'update_current_location_details')
-    @patch.object(Game, 'display_atmospheric_details')
-    @patch.object(Game, 'display_help')
-    def test_initialize_game_sets_low_ai_mode_from_configure_no(self, mock_disp_help, mock_disp_atm, mock_upd_loc, mock_sel_player, mock_load_chars):
-        self.game.gemini_api.configure = MagicMock(return_value={"api_configured": True, "low_ai_preference": False})
+    @patch.object(WorldManager, "load_all_characters")
+    @patch.object(WorldManager, "select_player_character")
+    @patch.object(WorldManager, "update_current_location_details")
+    @patch.object(Game, "display_atmospheric_details")
+    @patch.object(Game, "display_help")
+    def test_initialize_game_sets_low_ai_mode_from_configure_no(
+        self,
+        mock_disp_help,
+        mock_disp_atm,
+        mock_upd_loc,
+        mock_sel_player,
+        mock_load_chars,
+    ):
+        self.game.gemini_api.configure = MagicMock(
+            return_value={"api_configured": True, "low_ai_preference": False}
+        )
         self.mock_input_color.return_value = ""
         mock_sel_player.return_value = True
 
         self.game._initialize_game()
         self.assertFalse(self.game.low_ai_data_mode)
 
-    @patch.object(WorldManager, 'load_all_characters')
-    @patch.object(WorldManager, 'select_player_character')
-    @patch.object(WorldManager, 'update_current_location_details')
-    @patch.object(Game, 'display_atmospheric_details')
-    @patch.object(Game, 'display_help')
-    def test_initialize_game_low_ai_mode_defaults_false_if_api_skipped(self, mock_disp_help, mock_disp_atm, mock_upd_loc, mock_sel_player, mock_load_chars):
-        self.game.gemini_api.configure = MagicMock(return_value={"api_configured": False, "low_ai_preference": False})
+    @patch.object(WorldManager, "load_all_characters")
+    @patch.object(WorldManager, "select_player_character")
+    @patch.object(WorldManager, "update_current_location_details")
+    @patch.object(Game, "display_atmospheric_details")
+    @patch.object(Game, "display_help")
+    def test_initialize_game_low_ai_mode_defaults_false_if_api_skipped(
+        self,
+        mock_disp_help,
+        mock_disp_atm,
+        mock_upd_loc,
+        mock_sel_player,
+        mock_load_chars,
+    ):
+        self.game.gemini_api.configure = MagicMock(
+            return_value={"api_configured": False, "low_ai_preference": False}
+        )
         self.mock_input_color.return_value = ""
         mock_sel_player.return_value = True
 
         self.game._initialize_game()
         self.assertFalse(self.game.low_ai_data_mode)
 
-    @patch('game_engine.game_state.os.getenv')
-    @patch.object(Game, 'load_game')
-    @patch.object(WorldManager, 'select_player_character') # Still need to mock this if load_game fails or is bypassed
-    @patch.object(WorldManager, 'load_all_characters')
-    @patch.object(WorldManager, 'update_current_location_details')
-    @patch.object(Game, 'display_atmospheric_details')
-    @patch.object(Game, 'display_help')
-    def test_initialize_game_load_game_overrides_configure_low_ai_pref(self, mock_disp_help, mock_disp_atm, mock_upd_loc, mock_load_chars_init, mock_sel_player, mock_load_game_method, mock_os_getenv):
+    @patch("game_engine.game_state.os.getenv")
+    @patch.object(Game, "load_game")
+    @patch.object(
+        WorldManager, "select_player_character"
+    )  # Still need to mock this if load_game fails or is bypassed
+    @patch.object(WorldManager, "load_all_characters")
+    @patch.object(WorldManager, "update_current_location_details")
+    @patch.object(Game, "display_atmospheric_details")
+    @patch.object(Game, "display_help")
+    def test_initialize_game_load_game_overrides_configure_low_ai_pref(
+        self,
+        mock_disp_help,
+        mock_disp_atm,
+        mock_upd_loc,
+        mock_load_chars_init,
+        mock_sel_player,
+        mock_load_game_method,
+        mock_os_getenv,
+    ):
         # Ensure interactive path by mocking getenv
         mock_os_getenv.return_value = None
         # Simulate that configure() suggests Low AI Mode = False
-        self.game.gemini_api.configure = MagicMock(return_value={"api_configured": True, "low_ai_preference": False})
+        self.game.gemini_api.configure = MagicMock(
+            return_value={"api_configured": True, "low_ai_preference": False}
+        )
 
         # Simulate user typing "load"
         self.mock_input_color.return_value = "load"
 
         # Configure mock for self.game.load_game()
         def side_effect_load_game():
-            self.game.low_ai_data_mode = True # Simulate that loaded game had True for low_ai
+            self.game.low_ai_data_mode = (
+                True  # Simulate that loaded game had True for low_ai
+            )
             # Simulate other necessary attributes being set by load_game for _initialize_game to proceed
-            self.game.player_character = self.game.all_character_objects["TestPlayer"] # Use player from setUp
+            self.game.player_character = self.game.all_character_objects[
+                "TestPlayer"
+            ]  # Use player from setUp
             self.game.player_character.is_player = True
             self.game.current_location_name = "Test Chamber"
-            return True # Indicate load was successful
+            return True  # Indicate load was successful
 
         mock_load_game_method.side_effect = side_effect_load_game
 
         initialization_successful = self.game._initialize_game()
-        self.assertTrue(initialization_successful, "_initialize_game should return True on successful load.")
-        self.assertTrue(self.game.low_ai_data_mode, "low_ai_data_mode should be True (from loaded game).")
+        self.assertTrue(
+            initialization_successful,
+            "_initialize_game should return True on successful load.",
+        )
+        self.assertTrue(
+            self.game.low_ai_data_mode,
+            "low_ai_data_mode should be True (from loaded game).",
+        )
         mock_load_game_method.assert_called_once()
 
 
@@ -1219,24 +1784,28 @@ class TestGeminiAPIConfiguration(unittest.TestCase):
         self.api._input_color_func = self.mock_input_func
 
         # Patch methods within the GeminiAPI instance or its module
-        self.patch_attempt_api_setup = patch.object(self.api, '_attempt_api_setup')
+        self.patch_attempt_api_setup = patch.object(self.api, "_attempt_api_setup")
         self.mock_attempt_api_setup = self.patch_attempt_api_setup.start()
 
-        self.patch_load_genai = patch.object(self.api, '_load_genai', return_value=True)
+        self.patch_load_genai = patch.object(self.api, "_load_genai", return_value=True)
         self.mock_load_genai = self.patch_load_genai.start()
 
-        self.patch_os_path_exists = patch('game_engine.gemini_interactions.os.path.exists')
+        self.patch_os_path_exists = patch(
+            "game_engine.gemini_interactions.os.path.exists"
+        )
         self.mock_os_path_exists = self.patch_os_path_exists.start()
 
-        self.patch_open = patch('game_engine.gemini_interactions.open', new_callable=unittest.mock.mock_open)
+        self.patch_open = patch(
+            "game_engine.gemini_interactions.open", new_callable=unittest.mock.mock_open
+        )
         self.mock_open_file = self.patch_open.start()
 
-        self.patch_os_getenv = patch('game_engine.gemini_interactions.os.getenv')
+        self.patch_os_getenv = patch("game_engine.gemini_interactions.os.getenv")
         self.mock_os_getenv = self.patch_os_getenv.start()
 
         # Default mock behaviors
-        self.mock_os_getenv.return_value = None # No ENV key by default
-        self.mock_os_path_exists.return_value = False # No config file by default
+        self.mock_os_getenv.return_value = None  # No ENV key by default
+        self.mock_os_path_exists.return_value = False  # No config file by default
         # self.mock_attempt_api_setup.return_value = False # API setup fails by default - will set per test
 
     def tearDown(self):
@@ -1245,14 +1814,15 @@ class TestGeminiAPIConfiguration(unittest.TestCase):
     def _configure_mock_attempt_api_setup_success(self):
         def mock_setup(api_key, source, model_id):
             self.api.chosen_model_name = model_id
-            self.api.model = MagicMock() # Simulate model instance being set
+            self.api.model = MagicMock()  # Simulate model instance being set
             return True
+
         self.mock_attempt_api_setup.side_effect = mock_setup
 
     def test_ask_for_model_selection_updated_options_and_default(self):
         # This test focuses on the behavior of _ask_for_model_selection,
         # which is called by configure. We'll trigger it via configure.
-        self.mock_os_getenv.return_value = None # No ENV key
+        self.mock_os_getenv.return_value = None  # No ENV key
         self._configure_mock_attempt_api_setup_success()
 
         # User provides key, presses Enter for default model, then 'n' for Low AI mode, then 'n' for saving ENV key combo
@@ -1261,16 +1831,34 @@ class TestGeminiAPIConfiguration(unittest.TestCase):
         self.api.configure(self.mock_print_func, self.mock_input_func)
 
         # Check that the correct model options were printed
-        model_prompt_calls = [args[0] for args, _ in self.mock_print_func.call_args_list if args and isinstance(args[0], str)]
+        model_prompt_calls = [
+            args[0]
+            for args, _ in self.mock_print_func.call_args_list
+            if args and isinstance(args[0], str)
+        ]
 
-        self.assertTrue(any("Gemini 3 Pro Preview (ID: gemini-3-pro-preview)" in call for call in model_prompt_calls))
-        self.assertTrue(any("Gemini 3 Flash Preview (Default) (ID: gemini-3-flash-preview)" in call for call in model_prompt_calls))
+        self.assertTrue(
+            any(
+                "Gemini 3 Pro Preview (ID: gemini-3-pro-preview)" in call
+                for call in model_prompt_calls
+            )
+        )
+        self.assertTrue(
+            any(
+                "Gemini 3 Flash Preview (Default) (ID: gemini-3-flash-preview)" in call
+                for call in model_prompt_calls
+            )
+        )
 
         # Check that the input prompt was for choices 1-2
         input_prompt_found = False
         for call_args in self.mock_input_func.call_args_list:
             args, _ = call_args
-            if args and isinstance(args[0], str) and "(1-2), or press Enter for default): " in args[0]:
+            if (
+                args
+                and isinstance(args[0], str)
+                and "(1-2), or press Enter for default): " in args[0]
+            ):
                 input_prompt_found = True
                 break
         self.assertTrue(input_prompt_found, "Input prompt for 1-2 choices not found.")
@@ -1278,19 +1866,21 @@ class TestGeminiAPIConfiguration(unittest.TestCase):
         self.assertEqual(self.api.chosen_model_name, DEFAULT_GEMINI_MODEL_NAME)
 
     def test_configure_select_first_model_successfully(self):
-        self.mock_os_getenv.return_value = None # No ENV key
+        self.mock_os_getenv.return_value = None  # No ENV key
         self._configure_mock_attempt_api_setup_success()
         # Input: "dummy_manual_key", "1" for model, "n" for Low AI, "n" for saving ENV key combo
         self.mock_input_func.side_effect = ["dummy_manual_key", "1", "n", "n"]
 
         self.api.configure(self.mock_print_func, self.mock_input_func)
-        self.assertEqual(self.api.chosen_model_name, 'gemini-3-pro-preview')
-        self.mock_attempt_api_setup.assert_called_with("dummy_manual_key", "user input", 'gemini-3-pro-preview')
+        self.assertEqual(self.api.chosen_model_name, "gemini-3-pro-preview")
+        self.mock_attempt_api_setup.assert_called_with(
+            "dummy_manual_key", "user input", "gemini-3-pro-preview"
+        )
 
     def test_configure_successful_api_setup_prompts_low_ai_mode_yes(self):
         # Simulate manual API key input path
         self.mock_os_getenv.return_value = None
-        self.mock_os_path_exists.return_value = False # No config file
+        self.mock_os_path_exists.return_value = False  # No config file
 
         # Inputs: "dummy_api_key", "" (for default model), "y" (for low AI), "n" (for save key)
         self.mock_input_func.side_effect = ["dummy_api_key", "", "y", "n"]
@@ -1302,18 +1892,30 @@ class TestGeminiAPIConfiguration(unittest.TestCase):
         low_ai_enabled_msg_found = False
         for call_args in self.mock_input_func.call_args_list:
             args, _ = call_args
-            if args and isinstance(args[0], str) and "Enable Low AI Data Mode?" in args[0]:
+            if (
+                args
+                and isinstance(args[0], str)
+                and "Enable Low AI Data Mode?" in args[0]
+            ):
                 low_ai_prompt_found = True
                 break
         for call_args in self.mock_print_func.call_args_list:
             args, _ = call_args
-            if args and isinstance(args[0], str) and "Low AI Data Mode will be ENABLED." in args[0]:
+            if (
+                args
+                and isinstance(args[0], str)
+                and "Low AI Data Mode will be ENABLED." in args[0]
+            ):
                 low_ai_enabled_msg_found = True
                 break
 
         self.assertTrue(low_ai_prompt_found, "Low AI mode prompt not found.")
-        self.assertTrue(low_ai_enabled_msg_found, "Low AI Mode ENABLED message not found.")
-        self.assertEqual(config_result, {"api_configured": True, "low_ai_preference": True})
+        self.assertTrue(
+            low_ai_enabled_msg_found, "Low AI Mode ENABLED message not found."
+        )
+        self.assertEqual(
+            config_result, {"api_configured": True, "low_ai_preference": True}
+        )
         self.assertIsNotNone(self.api.model)
 
     def test_configure_successful_api_setup_prompts_low_ai_mode_no(self):
@@ -1328,19 +1930,27 @@ class TestGeminiAPIConfiguration(unittest.TestCase):
         disabled_msg_found = False
         for call_args in self.mock_print_func.call_args_list:
             args, _ = call_args
-            if args and isinstance(args[0], str) and "Low AI Data Mode will be DISABLED (default)." in args[0]:
+            if (
+                args
+                and isinstance(args[0], str)
+                and "Low AI Data Mode will be DISABLED (default)." in args[0]
+            ):
                 disabled_msg_found = True
                 break
         self.assertTrue(disabled_msg_found, "Low AI Mode DISABLED message not found.")
-        self.assertEqual(config_result, {"api_configured": True, "low_ai_preference": False})
+        self.assertEqual(
+            config_result, {"api_configured": True, "low_ai_preference": False}
+        )
 
     def test_configure_skip_api_returns_low_ai_false(self):
         self.mock_os_getenv.return_value = None
         self.mock_os_path_exists.return_value = False
-        self.mock_input_func.return_value = "skip" # User types 'skip' for API key
+        self.mock_input_func.return_value = "skip"  # User types 'skip' for API key
 
         config_result = self.api.configure(self.mock_print_func, self.mock_input_func)
-        self.assertEqual(config_result, {"api_configured": False, "low_ai_preference": False})
+        self.assertEqual(
+            config_result, {"api_configured": False, "low_ai_preference": False}
+        )
         self.assertIsNone(self.api.model)
 
 
@@ -1349,5 +1959,5 @@ class TestGeminiAPIConfiguration(unittest.TestCase):
 # --- Tests for Game._initialize_game() within TestLowAIMode ---
 # The following methods are moved to TestLowAIMode class below
 
-if __name__ == '__main__':
-    unittest.main(argv=['first-arg-is-ignored'], exit=False)
+if __name__ == "__main__":
+    unittest.main(argv=["first-arg-is-ignored"], exit=False)

--- a/tests/test_game_state.py
+++ b/tests/test_game_state.py
@@ -1,21 +1,27 @@
 import unittest
-from unittest.mock import patch, MagicMock, mock_open
+from unittest.mock import patch, mock_open
 import os
-import json
 import sys
 
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from game_engine.game_state import Game
-from game_engine.character_module import Character
-from game_engine.game_config import Colors, TIME_UNITS_PER_PLAYER_ACTION
+from game_engine.game_state import Game  # noqa: E402
+from game_engine.character_module import Character  # noqa: E402
+from game_engine.game_config import Colors, TIME_UNITS_PER_PLAYER_ACTION  # noqa: E402
+
 
 class TestGameState(unittest.TestCase):
     def setUp(self):
         self.game = Game()
-        self.game.player_character = Character("Test Player", "A brave adventurer.", "Hello!", "start_location", ["start_location"])
+        self.game.player_character = Character(
+            "Test Player",
+            "A brave adventurer.",
+            "Hello!",
+            "start_location",
+            ["start_location"],
+        )
         self.game.current_location_name = "start_location"
         self.game.game_time = 100
         self.game.current_day = 1
@@ -43,7 +49,9 @@ class TestGameState(unittest.TestCase):
             "visited_locations": [],
             "game_time": 100,
             "current_day": 1,
-            "all_character_objects_state": {"Test Player": self.game.player_character.to_dict()},
+            "all_character_objects_state": {
+                "Test Player": self.game.player_character.to_dict()
+            },
             "dynamic_location_items": {"start_location": []},
             "triggered_events": ["event1"],
             "last_significant_event_summary": "Something happened.",
@@ -58,7 +66,6 @@ class TestGameState(unittest.TestCase):
             "verbosity_level": "brief",
             "turn_headers_enabled": True,
             "command_history": [],
-            "visited_locations": []
         }
 
         mock_json_dump.assert_called_once()
@@ -66,7 +73,7 @@ class TestGameState(unittest.TestCase):
         self.assertEqual(args[0], expected_save_data)
 
     @patch("os.path.exists", return_value=True)
-    @patch("builtins.open", new_callable=mock_open, read_data='{}')
+    @patch("builtins.open", new_callable=mock_open, read_data="{}")
     @patch("json.load")
     def test_load_game_success(self, mock_json_load, mock_open, mock_exists):
         mock_save_data = {
@@ -75,7 +82,9 @@ class TestGameState(unittest.TestCase):
             "visited_locations": [],
             "game_time": 100,
             "current_day": 1,
-            "all_character_objects_state": {"Test Player": self.game.player_character.to_dict()},
+            "all_character_objects_state": {
+                "Test Player": self.game.player_character.to_dict()
+            },
             "dynamic_location_items": {"start_location": []},
             "triggered_events": ["event1"],
             "last_significant_event_summary": "Something happened.",
@@ -89,11 +98,22 @@ class TestGameState(unittest.TestCase):
             "color_theme": "default",
             "verbosity_level": "standard",
             "turn_headers_enabled": True,
-            "command_history": []
+            "command_history": [],
         }
         mock_json_load.return_value = mock_save_data
 
-        with patch.dict('game_engine.character_module.CHARACTERS_DATA', {"Test Player": {"persona": "A brave adventurer.", "greeting": "Hello!", "default_location": "start_location", "accessible_locations": ["start_location"]}}, clear=True):
+        with patch.dict(
+            "game_engine.character_module.CHARACTERS_DATA",
+            {
+                "Test Player": {
+                    "persona": "A brave adventurer.",
+                    "greeting": "Hello!",
+                    "default_location": "start_location",
+                    "accessible_locations": ["start_location"],
+                }
+            },
+            clear=True,
+        ):
             result = self.game.load_game()
 
         self.assertTrue(result)
@@ -106,21 +126,30 @@ class TestGameState(unittest.TestCase):
         self.game.world_manager.advance_time(10)
         self.assertEqual(self.game.game_time, initial_time + 10)
 
-    @patch('random.random', return_value=0.1)
+    @patch("random.random", return_value=0.1)
     def test_update_npc_locations_by_schedule(self, mock_random):
-        npc = Character("Test NPC", "A scheduled NPC.", "Greetings.", "loc_A", ["loc_A", "loc_B"], schedule={"Morning": "loc_B"})
+        npc = Character(
+            "Test NPC",
+            "A scheduled NPC.",
+            "Greetings.",
+            "loc_A",
+            ["loc_A", "loc_B"],
+            schedule={"Morning": "loc_B"},
+        )
         self.game.all_character_objects["Test NPC"] = npc
-        self.game.game_time = 0 # Morning
-        with patch.dict('game_engine.location_module.LOCATIONS_DATA', {"loc_A": {}, "loc_B": {}}, clear=True):
+        self.game.game_time = 0  # Morning
+        with patch.dict(
+            "game_engine.location_module.LOCATIONS_DATA",
+            {"loc_A": {}, "loc_B": {}},
+            clear=True,
+        ):
             self.game.world_manager.update_npc_locations_by_schedule()
         self.assertEqual(npc.current_location, "loc_B")
 
-    @patch('game_engine.game_state.random.randint', return_value=5)
+    @patch("game_engine.game_state.random.randint", return_value=5)
     def test_handle_wait_command(self, mock_randint):
         time_advanced = self.game._handle_wait_command()
         self.assertEqual(time_advanced, TIME_UNITS_PER_PLAYER_ACTION * 5)
-
-
 
     @patch("builtins.open", new_callable=mock_open)
     @patch("json.dump")
@@ -129,7 +158,7 @@ class TestGameState(unittest.TestCase):
         mock_open_file.assert_called_once_with("savegame_slot1.json", "w")
 
     @patch("os.path.exists", return_value=True)
-    @patch("builtins.open", new_callable=mock_open, read_data='{}')
+    @patch("builtins.open", new_callable=mock_open, read_data="{}")
     @patch("json.load")
     def test_load_game_with_slot(self, mock_json_load, mock_open_file, mock_exists):
         mock_json_load.return_value = {
@@ -138,7 +167,9 @@ class TestGameState(unittest.TestCase):
             "visited_locations": [],
             "game_time": 100,
             "current_day": 1,
-            "all_character_objects_state": {"Test Player": self.game.player_character.to_dict()},
+            "all_character_objects_state": {
+                "Test Player": self.game.player_character.to_dict()
+            },
             "dynamic_location_items": {"start_location": []},
             "triggered_events": ["event1"],
             "last_significant_event_summary": "Something happened.",
@@ -152,9 +183,20 @@ class TestGameState(unittest.TestCase):
             "color_theme": "default",
             "verbosity_level": "standard",
             "turn_headers_enabled": True,
-            "command_history": []
+            "command_history": [],
         }
-        with patch.dict('game_engine.character_module.CHARACTERS_DATA', {"Test Player": {"persona": "A brave adventurer.", "greeting": "Hello!", "default_location": "start_location", "accessible_locations": ["start_location"]}}, clear=True):
+        with patch.dict(
+            "game_engine.character_module.CHARACTERS_DATA",
+            {
+                "Test Player": {
+                    "persona": "A brave adventurer.",
+                    "greeting": "Hello!",
+                    "default_location": "start_location",
+                    "accessible_locations": ["start_location"],
+                }
+            },
+            clear=True,
+        ):
             result = self.game.load_game("slot1")
 
         self.assertTrue(result)
@@ -163,36 +205,50 @@ class TestGameState(unittest.TestCase):
     def test_autosave_after_threshold_actions(self):
         self.game.autosave_interval_actions = 1
         self.game.actions_since_last_autosave = 0
-        with patch.object(self.game, 'save_game') as mock_save:
-            self.game.world_manager._update_world_state_after_action("look", True, TIME_UNITS_PER_PLAYER_ACTION)
+        with patch.object(self.game, "save_game") as mock_save:
+            self.game.world_manager._update_world_state_after_action(
+                "look", True, TIME_UNITS_PER_PLAYER_ACTION
+            )
         mock_save.assert_called_once_with("autosave", is_autosave=True)
 
     def test_get_contextual_command_examples_includes_context(self):
-        self.game.npcs_in_current_location = [Character("Sonya", "", "", "start_location", ["start_location"])]
+        self.game.npcs_in_current_location = [
+            Character("Sonya", "", "", "start_location", ["start_location"])
+        ]
         self.game.dynamic_location_items = {"start_location": [{"name": "coin"}]}
-        with patch.dict('game_engine.location_module.LOCATIONS_DATA', {"start_location": {"exits": {"street": "A street"}}}, clear=True):
+        with patch.dict(
+            "game_engine.location_module.LOCATIONS_DATA",
+            {"start_location": {"exits": {"street": "A street"}}},
+            clear=True,
+        ):
             examples = self.game.command_handler._get_contextual_command_examples()
         self.assertIn("look", examples)
         self.assertIn("talk to Sonya", examples)
 
     def test_display_help_with_category(self):
-        with patch.object(self.game, '_print_color') as mock_print:
+        with patch.object(self.game, "_print_color") as mock_print:
             self.game.display_help("movement")
-        printed = "\n".join(call.args[0] for call in mock_print.call_args_list if call.args)
+        printed = "\n".join(
+            call.args[0] for call in mock_print.call_args_list if call.args
+        )
         self.assertIn("Category: movement", printed)
         self.assertIn("move to", printed)
 
     @patch("os.path.exists", return_value=True)
-    @patch("builtins.open", new_callable=mock_open, read_data='{}')
+    @patch("builtins.open", new_callable=mock_open, read_data="{}")
     @patch("json.load")
-    def test_load_game_displays_recap(self, mock_json_load, mock_open_file, mock_exists):
+    def test_load_game_displays_recap(
+        self, mock_json_load, mock_open_file, mock_exists
+    ):
         mock_save_data = {
             "player_character_name": "Test Player",
             "current_location_name": "start_location",
             "visited_locations": [],
             "game_time": 100,
             "current_day": 1,
-            "all_character_objects_state": {"Test Player": self.game.player_character.to_dict()},
+            "all_character_objects_state": {
+                "Test Player": self.game.player_character.to_dict()
+            },
             "dynamic_location_items": {"start_location": []},
             "triggered_events": ["event1"],
             "last_significant_event_summary": "Something happened.",
@@ -206,33 +262,48 @@ class TestGameState(unittest.TestCase):
             "color_theme": "default",
             "verbosity_level": "standard",
             "turn_headers_enabled": True,
-            "command_history": []
+            "command_history": [],
         }
         mock_json_load.return_value = mock_save_data
 
-        with patch.dict('game_engine.character_module.CHARACTERS_DATA', {"Test Player": {"persona": "A brave adventurer.", "greeting": "Hello!", "default_location": "start_location", "accessible_locations": ["start_location"]}}, clear=True), \
-             patch.object(self.game, '_display_load_recap') as mock_recap:
+        with patch.dict(
+            "game_engine.character_module.CHARACTERS_DATA",
+            {
+                "Test Player": {
+                    "persona": "A brave adventurer.",
+                    "greeting": "Hello!",
+                    "default_location": "start_location",
+                    "accessible_locations": ["start_location"],
+                }
+            },
+            clear=True,
+        ), patch.object(self.game, "_display_load_recap") as mock_recap:
             result = self.game.load_game()
 
         self.assertTrue(result)
         mock_recap.assert_called_once()
+
     def test_handle_status_command(self):
-        with patch.object(self.game, '_print_color') as mock_print:
+        with patch.object(self.game, "_print_color") as mock_print:
             self.game._handle_status_command()
-            mock_print.assert_any_call(f"Name: {Colors.GREEN}Test Player{Colors.RESET}", Colors.WHITE)
+            mock_print.assert_any_call(
+                f"Name: {Colors.GREEN}Test Player{Colors.RESET}", Colors.WHITE
+            )
 
     def test_get_player_input_repeat_last_command(self):
         self.game.command_history = ["look"]
-        with patch.object(self.game, '_input_color', return_value="!!"), \
-             patch.object(self.game, '_print_color'):
+        with patch.object(self.game, "_input_color", return_value="!!"), patch.object(
+            self.game, "_print_color"
+        ):
             command, argument = self.game.command_handler._get_player_input()
         self.assertEqual(command, "look")
         self.assertIsNone(argument)
 
     def test_get_player_input_repeat_without_history(self):
         self.game.command_history = []
-        with patch.object(self.game, '_input_color', return_value="!!"), \
-             patch.object(self.game, '_print_color') as mock_print:
+        with patch.object(self.game, "_input_color", return_value="!!"), patch.object(
+            self.game, "_print_color"
+        ) as mock_print:
             command, argument = self.game.command_handler._get_player_input()
         self.assertIsNone(command)
         self.assertIsNone(argument)
@@ -240,11 +311,15 @@ class TestGameState(unittest.TestCase):
 
     def test_process_history_command(self):
         self.game.command_history = ["look", "inventory"]
-        with patch.object(self.game, '_print_color') as mock_print:
-            action_taken, show_atmospherics, _, _ = self.game.command_handler._process_command("history", None)
+        with patch.object(self.game, "_print_color") as mock_print:
+            action_taken, show_atmospherics, _, _ = (
+                self.game.command_handler._process_command("history", None)
+            )
         self.assertFalse(action_taken)
         self.assertFalse(show_atmospherics)
-        printed = "\n".join(call.args[0] for call in mock_print.call_args_list if call.args)
+        printed = "\n".join(
+            call.args[0] for call in mock_print.call_args_list if call.args
+        )
         self.assertIn("Recent Commands", printed)
 
     def test_theme_and_verbosity_commands(self):
@@ -255,5 +330,5 @@ class TestGameState(unittest.TestCase):
         self.game.command_handler._process_command("theme", "default")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gemini_interactions.py
+++ b/tests/test_gemini_interactions.py
@@ -1,36 +1,65 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 import os
 import sys
 
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from game_engine.gemini_interactions import GeminiAPI
-from game_engine.character_module import Character
+from game_engine.gemini_interactions import GeminiAPI  # noqa: E402
+from game_engine.character_module import Character  # noqa: E402
+
 
 class TestGeminiInteractions(unittest.TestCase):
     def setUp(self):
         self.api = GeminiAPI()
         self.api.model = MagicMock()
-        self.player = Character("Test Player", "A brave adventurer.", "Hello!", "start_location", ["start_location"])
+        self.player = Character(
+            "Test Player",
+            "A brave adventurer.",
+            "Hello!",
+            "start_location",
+            ["start_location"],
+        )
 
     def test_get_atmospheric_details(self):
-        self.api.model.generate_content.return_value.text = "The air is thick with mystery."
-        details = self.api.get_atmospheric_details(self.player, "a dark room", "night", "a strange noise", "find the key")
+        self.api.model.generate_content.return_value.text = (
+            "The air is thick with mystery."
+        )
+        details = self.api.get_atmospheric_details(
+            self.player, "a dark room", "night", "a strange noise", "find the key"
+        )
         self.assertEqual(details, "The air is thick with mystery.")
 
     def test_get_rumor_or_gossip(self):
         npc = Character("Test NPC", "A gossip.", "Psst!", "market", ["market"])
-        self.api.model.generate_content.return_value.text = "I heard the king is a frog."
-        rumor = self.api.get_rumor_or_gossip(npc, "market", "day", "The king is missing.", 2, "neutral", "get the latest scoop")
+        self.api.model.generate_content.return_value.text = (
+            "I heard the king is a frog."
+        )
+        rumor = self.api.get_rumor_or_gossip(
+            npc,
+            "market",
+            "day",
+            "The king is missing.",
+            2,
+            "neutral",
+            "get the latest scoop",
+        )
         self.assertEqual(rumor, "I heard the king is a frog.")
 
     def test_get_dream_sequence(self):
-        self.api.model.generate_content.return_value.text = "You dream of electric sheep."
-        dream = self.api.get_dream_sequence(self.player, "You saw a unicorn.", "Find the unicorn.", "You are friends with the unicorn.")
+        self.api.model.generate_content.return_value.text = (
+            "You dream of electric sheep."
+        )
+        dream = self.api.get_dream_sequence(
+            self.player,
+            "You saw a unicorn.",
+            "Find the unicorn.",
+            "You are friends with the unicorn.",
+        )
         self.assertEqual(dream, "You dream of electric sheep.")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- Eliminate the remaining Ruff linter errors and E402 import-order warnings introduced by the previous broad formatting pass so the codebase is clean and tests remain green.

### Description
- Move misplaced imports (e.g. `random`, game config imports) to module tops and replace the unused `google.genai` import in `main.py` with `importlib.util.find_spec(...)` to preserve behavior without F401 warnings.
- Remove unused local assignments flagged by Ruff (`F841`) and tidy small logic/formatting issues in `item_interaction_handler.py`, `world_manager.py`, and other modules.
- Add `# noqa: E402` to test imports that are intentionally performed after inserting the project root into `sys.path`, and fix a duplicated dictionary key and other test data issues so tests and test patching remain compatible.
- Re-export `STATIC_ATMOSPHERIC_DETAILS` and `STATIC_NEWSPAPER_SNIPPETS` from `game_state` to preserve existing test patch targets and apply minor formatting cleanups across several modules.

### Testing
- Ran the linter: `python -m ruff check .` and the check completed successfully with the previous issues resolved.
- Ran the unit test suite: `pytest -q` and all tests passed (`98 passed`).
- Formatted touched files with `python -m black` as part of the validation steps (completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ab26732c08325b9b7e2d27dc77373)