### PR TITLE
Add baseline lint config and annotate ItemInteractionHandler mixin

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203
+exclude = .git,__pycache__,.pytest_cache

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,17 @@
+[MASTER]
+ignore=.git,__pycache__,.pytest_cache
+
+[MESSAGES CONTROL]
+disable=
+    C0114,
+    C0115,
+    C0116,
+    R0902,
+    R0912,
+    R0913,
+    R0914,
+    R0915,
+    W0212
+
+[FORMAT]
+max-line-length=100

--- a/game_engine/item_interaction_handler.py
+++ b/game_engine/item_interaction_handler.py
@@ -1,4 +1,5 @@
 import random
+from typing import Any
 from .game_config import (
     Colors,
     DEFAULT_ITEMS,
@@ -14,6 +15,17 @@ from .location_module import LOCATIONS_DATA
 
 
 class ItemInteractionHandler:
+    """Handle item and scenery inspection interactions for the active game session."""
+
+    # Attributes provided by the composing Game class.
+    player_character: Any = None
+    current_location_name: str | None = None
+    gemini_api: Any = None
+    low_ai_data_mode: bool = False
+    command_handler: Any = None
+    npcs_in_current_location: list[Any] = []
+    game_time: int = 0
+
     def _inspect_item(
         self,
         item_name,


### PR DESCRIPTION
### Motivation
- Reduce the overwhelming lint noise (primarily line-length and docstring/design checks) so future lint work can focus on actionable issues. 
- Help static analyzers understand mixin composition to reduce false-positive missing-member warnings reported for `ItemInteractionHandler`. 
- Establish a practical, repo-level baseline for line length and common ignores to align local tooling.

### Description
- Add a repository-level Flake8 config in `.flake8` with `max-line-length = 100` and common exclusions to reduce `E501` noise. 
- Add a baseline Pylint config in `.pylintrc` that sets `max-line-length=100` and disables several high-volume checks (`C0114`, `C0115`, `C0116`, `R0902`, `R0912`, `R0913`, `R0914`, `R0915`, `W0212`). 
- Annotate `game_engine/item_interaction_handler.py` by importing `Any` and adding a class docstring plus typed attribute placeholders (e.g. `player_character: Any`, `gemini_api: Any`, `low_ai_data_mode: bool`) so the mixin's runtime-provided members are explicit for static analysis. 

### Testing
- Ran `pytest -q` which resulted in `98 passed` and returned success. 
- No lint tool runs are included in automated test output here; changes are focused on lint configuration and static annotations only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ab5155f5883258cb7e184481bf3a6)